### PR TITLE
Stabilize post-61000 shielded sends and live note merges

### DIFF
--- a/src/shielded/smile2/wallet_bridge.cpp
+++ b/src/shielded/smile2/wallet_bridge.cpp
@@ -382,7 +382,7 @@ std::optional<SmileProofResult> CreateSmileProof(
         if (!inp.note.IsValid()) return fail("invalid input note");
         if (inp.ring_index >= ring_members.size()) return fail("input ring index out of range");
         if (inp.account_leaf_commitment.IsNull()) return fail("null input account leaf commitment");
-        if (inp.note.value < 0 || inp.note.value >= Q) return fail("input note value out of range");
+        if (inp.note.value <= 0) return fail("input note value out of range");
         const uint256 effective_note_commitment =
             inp.note_commitment.IsNull() ? inp.note.GetCommitment() : inp.note_commitment;
         if (ring_members[inp.ring_index].note_commitment != effective_note_commitment) {
@@ -409,7 +409,7 @@ std::optional<SmileProofResult> CreateSmileProof(
     int64_t total_output_amount{0};
     for (const ShieldedNote& output_note : outputs) {
         if (!output_note.IsValid()) return fail("invalid output note");
-        if (output_note.value < 0 || output_note.value >= Q) return fail("output note value out of range");
+        if (output_note.value <= 0) return fail("output note value out of range");
         const auto next_total = CheckedAdd(total_output_amount, output_note.value);
         if (!next_total) return fail("output total overflow");
         total_output_amount = *next_total;

--- a/src/test/shielded_wallet_chunk_discovery_tests.cpp
+++ b/src/test/shielded_wallet_chunk_discovery_tests.cpp
@@ -345,6 +345,26 @@ BOOST_AUTO_TEST_CASE(v2_scan_discovers_owned_outputs_across_multiple_local_keyse
     BOOST_CHECK_EQUAL(values[1], 17 * COIN);
 }
 
+BOOST_AUTO_TEST_CASE(large_owned_user_note_remains_spendable_after_scan)
+{
+    LOCK2(wallet.cs_wallet, shielded_wallet->cs_shielded);
+    OutputDescription large_output = BuildOutput(
+        MakeNote(owned_addr.pk_hash, 20'000 * COIN, 0x53),
+        owned_kem_pk,
+        ScanDomain::USER,
+        0x63);
+    const auto fixture = test::shielded::BuildV2EgressReceiptFixture(
+        std::vector<OutputDescription>{large_output});
+
+    CBlock block;
+    block.vtx.push_back(MakeTransactionRef(CTransaction{fixture.tx}));
+    shielded_wallet->ScanBlock(block, /*height=*/1);
+
+    const auto spendable = shielded_wallet->GetSpendableNotes(/*min_depth=*/1);
+    BOOST_REQUIRE_EQUAL(spendable.size(), 1U);
+    BOOST_CHECK_EQUAL(spendable.front().note.value, 20'000 * COIN);
+}
+
 BOOST_AUTO_TEST_CASE(revoked_address_is_rejected_after_postfork_privacy_boundary)
 {
     wallet::ShieldedAddress revoked_addr;

--- a/src/test/smile2_wallet_bridge_tests.cpp
+++ b/src/test/smile2_wallet_bridge_tests.cpp
@@ -165,6 +165,43 @@ BOOST_AUTO_TEST_CASE(w5_end_to_end_proof)
     }
 }
 
+BOOST_AUTO_TEST_CASE(w5b_end_to_end_proof_accepts_amounts_above_q)
+{
+    std::vector<SmileRingMember> ring_members = MakePlaceholderRing(/*count=*/32, /*seed_base=*/0x28);
+    const CAmount large_amount = 20000 * COIN;
+    BOOST_REQUIRE_GT(large_amount, static_cast<CAmount>(Q));
+
+    const ShieldedNote input_note = MakeNote(/*value=*/large_amount, /*seed=*/0x33);
+    auto real_member = BuildRingMemberFromNote(SMILE_GLOBAL_SEED, input_note);
+    BOOST_REQUIRE(real_member.has_value());
+    ring_members[6] = *real_member;
+
+    SmileInputMaterial input;
+    input.note = input_note;
+    input.account_leaf_commitment = real_member->account_leaf_commitment;
+    input.ring_index = 6;
+
+    const ShieldedNote out_a = MakeNote(/*value=*/12345 * COIN, /*seed=*/0x43);
+    const ShieldedNote out_b = MakeNote(/*value=*/7655 * COIN, /*seed=*/0x53);
+
+    std::vector<uint8_t> entropy(32, 0x6d);
+    std::vector<uint256> serial_hashes;
+
+    auto proof_bytes = CreateSmileProof(
+        SMILE_GLOBAL_SEED,
+        {input},
+        {out_a, out_b},
+        Span<const SmileRingMember>{ring_members.data(), ring_members.size()},
+        Span<const uint8_t>(entropy),
+        serial_hashes);
+
+    BOOST_CHECK(proof_bytes.has_value());
+    if (proof_bytes) {
+        BOOST_CHECK_GT(proof_bytes->proof_bytes.size(), 0u);
+        BOOST_CHECK_EQUAL(serial_hashes.size(), 1u);
+    }
+}
+
 // W6: Serial number hashes are deterministic
 BOOST_AUTO_TEST_CASE(w6_serial_determinism)
 {

--- a/src/wallet/shielded_wallet.cpp
+++ b/src/wallet/shielded_wallet.cpp
@@ -151,14 +151,11 @@ struct ResolvedV2ShieldedRecipient
     return true;
 }
 
-[[nodiscard]] constexpr CAmount GetShieldedSmileValueLimit()
+[[nodiscard]] bool IsShieldedAmountCompatible(CAmount value)
 {
-    return static_cast<CAmount>(smile2::Q) - 1;
-}
-
-[[nodiscard]] bool IsShieldedSmileValueCompatible(CAmount value)
-{
-    return value > 0 && MoneyRange(value) && value < static_cast<CAmount>(smile2::Q);
+    // SMILE encodes amounts as 32 base-4 digits, so wallet amount validity is
+    // bounded by MoneyRange rather than the proof field modulus q.
+    return value > 0 && MoneyRange(value);
 }
 
 [[nodiscard]] uint256 ViewOnlyNullifier(const uint256& commitment)
@@ -2654,12 +2651,11 @@ std::vector<ShieldedCoin> CShieldedWallet::GetSpendableNotes(int min_depth) cons
     for (const auto& [nf, coin] : m_notes) {
         if (coin.is_spent || !coin.is_mine_spend) continue;
         if (!IsWalletSpendableNoteClass(coin.note_class)) continue;
-        if (!IsShieldedSmileValueCompatible(coin.note.value)) {
+        if (!IsShieldedAmountCompatible(coin.note.value)) {
             LogDebug(BCLog::WALLETDB,
-                     "CShieldedWallet::GetSpendableNotes skipping note commitment=%s value=%lld outside SMILE range (< %lld)\n",
+                     "CShieldedWallet::GetSpendableNotes skipping note commitment=%s value=%lld outside supported wallet amount range\n",
                      coin.commitment.ToString(),
-                     static_cast<long long>(coin.note.value),
-                     static_cast<long long>(GetShieldedSmileValueLimit() + 1));
+                     static_cast<long long>(coin.note.value));
             continue;
         }
         // R5-520: Skip notes that are reserved by an in-flight transaction.
@@ -2745,8 +2741,8 @@ std::optional<ShieldedSpendSelectionEstimate> CShieldedWallet::EstimateDirectSpe
 
     CAmount total_input{0};
     for (const auto& coin : selected) {
-        if (!IsShieldedSmileValueCompatible(coin.note.value)) {
-            return fail("selected note exceeds SMILE input value limit");
+        if (!IsShieldedAmountCompatible(coin.note.value)) {
+            return fail("selected note has invalid amount");
         }
         const auto next = CheckedAdd(total_input, coin.note.value);
         if (!next || !MoneyRange(*next)) return fail("selected input total overflow");
@@ -2779,8 +2775,8 @@ std::optional<ShieldedSpendSelectionEstimate> CShieldedWallet::EstimateDirectSpe
 
         CAmount reserved_total{0};
         for (const auto& coin : reserved_selection) {
-            if (!IsShieldedSmileValueCompatible(coin.note.value)) {
-                return fail("selected note exceeds SMILE input value limit");
+            if (!IsShieldedAmountCompatible(coin.note.value)) {
+                return fail("selected note has invalid amount");
             }
             const auto next = CheckedAdd(reserved_total, coin.note.value);
             if (!next || !MoneyRange(*next)) return fail("selected input total overflow");
@@ -2901,8 +2897,8 @@ std::optional<CMutableTransaction> CShieldedWallet::CreateV2Send(
 
     for (const auto& [_, amount] : shielded_recipients) {
         if (amount <= 0 || !MoneyRange(amount)) return fail("invalid shielded recipient amount");
-        if (!IsShieldedSmileValueCompatible(amount)) {
-            return fail("shielded recipient amount exceeds SMILE note value limit");
+        if (!IsShieldedAmountCompatible(amount)) {
+            return fail("shielded recipient amount is out of range");
         }
         if (shielded_dust_threshold > 0 && amount < shielded_dust_threshold) {
             return fail("shielded recipient amount below dust threshold");
@@ -2930,8 +2926,8 @@ std::optional<CMutableTransaction> CShieldedWallet::CreateV2Send(
         }
         if (selection.selected.empty()) return fail("no spendable notes selected");
         for (const auto& coin : selection.selected) {
-            if (!IsShieldedSmileValueCompatible(coin.note.value)) {
-                return fail("selected note exceeds SMILE input value limit");
+            if (!IsShieldedAmountCompatible(coin.note.value)) {
+                return fail("selected note has invalid amount");
             }
             const auto next = CheckedAdd(selection.total_input, coin.note.value);
             if (!next || !MoneyRange(*next)) return fail("selected input total overflow");
@@ -3002,8 +2998,8 @@ std::optional<CMutableTransaction> CShieldedWallet::CreateV2Send(
         }
         CAmount reserved_total{0};
         for (const auto& coin : reserved_selection) {
-            if (!IsShieldedSmileValueCompatible(coin.note.value)) {
-                return fail("selected note exceeds SMILE input value limit");
+            if (!IsShieldedAmountCompatible(coin.note.value)) {
+                return fail("selected note has invalid amount");
             }
             const auto next = CheckedAdd(reserved_total, coin.note.value);
             if (!next || !MoneyRange(*next)) return fail("selected input total overflow");
@@ -3267,8 +3263,8 @@ std::optional<CMutableTransaction> CShieldedWallet::CreateV2Send(
                      static_cast<long long>(amount));
             return fail("invalid output note");
         }
-        if (!IsShieldedSmileValueCompatible(note.value)) {
-            return fail("shielded output exceeds SMILE note value limit");
+        if (!IsShieldedAmountCompatible(note.value)) {
+            return fail("shielded output amount is out of range");
         }
 
         const auto bound_note = shielded::NoteEncryption::EncryptBoundNote(note, recipient_kem_pk);
@@ -4274,7 +4270,7 @@ std::optional<CMutableTransaction> CShieldedWallet::CreateTransparentToShieldedS
     CAmount total_shielded_out{0};
     for (const auto& [_, amount] : shielded_recipients) {
         if (amount <= 0 || !MoneyRange(amount)) return fail("invalid shielded recipient amount");
-        if (!IsShieldedSmileValueCompatible(amount)) return fail("shielded recipient amount exceeds SMILE note value limit");
+        if (!IsShieldedAmountCompatible(amount)) return fail("shielded recipient amount is out of range");
         const auto next = CheckedAdd(total_shielded_out, amount);
         if (!next || !MoneyRange(*next)) return fail("shielded recipient total overflow");
         total_shielded_out = *next;
@@ -4348,8 +4344,8 @@ std::optional<CMutableTransaction> CShieldedWallet::CreateTransparentToShieldedS
             if (error != nullptr) *error = "invalid output note";
             return false;
         }
-        if (!IsShieldedSmileValueCompatible(note.value)) {
-            if (error != nullptr) *error = "shielded output exceeds SMILE note value limit";
+        if (!IsShieldedAmountCompatible(note.value)) {
+            if (error != nullptr) *error = "shielded output amount is out of range";
             return false;
         }
         if (shielded_dust_threshold > 0 && note.value < shielded_dust_threshold) {
@@ -4704,8 +4700,8 @@ std::optional<CMutableTransaction> CShieldedWallet::ShieldFunds(const std::vecto
         if (note.value <= 0 || !MoneyRange(note.value) || note.recipient_pk_hash.IsNull()) {
             return fail(strprintf("generated note is invalid for destination %s", address.Encode()));
         }
-        if (!IsShieldedSmileValueCompatible(note.value)) {
-            return fail(strprintf("shielded output exceeds SMILE note value limit for %s", address.Encode()));
+        if (!IsShieldedAmountCompatible(note.value)) {
+            return fail(strprintf("shielded output amount is out of range for %s", address.Encode()));
         }
         if (shielded_dust_threshold > 0 && note.value < shielded_dust_threshold) {
             return fail(strprintf("shielded output below dust threshold for %s", address.Encode()));
@@ -4941,8 +4937,8 @@ std::optional<PartiallySignedTransaction> CShieldedWallet::ShieldFundsPSBT(
             }
             return std::nullopt;
         }
-        if (!IsShieldedSmileValueCompatible(note.value)) {
-            if (error != nullptr) *error = "shielded output exceeds SMILE note value limit";
+        if (!IsShieldedAmountCompatible(note.value)) {
+            if (error != nullptr) *error = "shielded output amount is out of range";
             return std::nullopt;
         }
         if (shielded_dust_threshold > 0 && note.value < shielded_dust_threshold) {


### PR DESCRIPTION
## Summary
- stop treating the SMILE field modulus `q` as the wallet's effective shielded amount limit and keep `MoneyRange()`-sized notes spendable through the v2 send path
- retry stale-anchor shielded send construction instead of failing as the tip moves during large-wallet activity
- make `z_mergenotes` usable for miner wallets by using the 8-input live envelope, picking a fee-viable merge set, canonicalizing merge fees before output calculation, and reporting the actual merged input count
- add regressions for large owned notes, 8-note live merges, canonical-fee merges, and dust-heavy merge fallback selection

## Testing
- `python3 test/functional/test_runner.py wallet_shielded_send_flow.py wallet_shielded_rpc_surface.py --jobs=1`
- live mainnet validation:  `z_mergenotes 8` succeeded with txid `47f37a3f645cc69287d695358fd3013294ec04552ba75364f95d4f1ac393f700`
