### PR TITLE
Add activation-gated spend-path recovery for stranded shielded notes

### DIFF
--- a/doc/design/post-fork-spend-path-recovery/01-problem-statement.md
+++ b/doc/design/post-fork-spend-path-recovery/01-problem-statement.md
@@ -1,0 +1,85 @@
+# Problem Statement: Post-Fork Spend-Path Loss For Owned Shielded Notes
+
+Date: 2026-04-23
+
+## Summary
+
+This document describes a class of failure where shielded notes remain fully
+ owned by a wallet but become non-spendable through the ordinary post-fork
+ transaction flow.
+
+The problem is not "funds disappeared."
+
+The problem is:
+
+> the spend path disappeared while custody remained intact
+
+## Symptoms
+
+An affected wallet typically shows all or most of the following:
+
+- the wallet still reports a shielded balance
+- the wallet still holds the spending keys
+- note decryption still works
+- the wallet can identify concrete note commitments and nullifiers
+- ordinary merge, sweep, or send RPCs fail
+- rescans may restore truthful visibility but not spendability
+
+## Root cause pattern
+
+The most likely root-cause pattern is:
+
+1. Notes were created under an earlier shielded transaction model.
+2. A later protocol transition moved ordinary spending to a newer spend model.
+3. The older notes never created the modern witness or registry state now
+   required by ordinary spend builders.
+4. The wallet still owns those notes, but ordinary spend selection excludes
+   them or cannot build a valid spend from them.
+
+This can happen even if:
+
+- the wallet is unlocked
+- the node is healthy
+- the notes are not watch-only
+- the balance is still visible
+
+## Why ordinary fixes are not enough
+
+The following are not sufficient:
+
+- wallet recreation
+- rescanning
+- local index rebuilding
+- unlocking again
+- retrying ordinary shielded sends
+- loosening wallet-side spend filters only
+
+These actions may improve visibility or diagnostics, but they do not create a
+ new accepted spend path.
+
+## Problem framing
+
+The right framing is:
+
+- custody: intact
+- visibility: intact
+- ordinary spend path: lost
+- network-accepted recovery path: not yet available
+
+## Recovery objective
+
+A correct solution must:
+
+1. prove ownership of stranded notes safely
+2. convert them into ordinary modern spendable outputs
+3. preserve amount accounting and auditability
+4. avoid weakening normal spend rules for unaffected notes
+
+## Non-goals
+
+This bundle does not attempt to:
+
+- redefine ordinary modern note spending for everyone
+- hide the problem with wallet-only tricks
+- invent fake witness material
+- justify operator shortcuts without consensus validity

--- a/doc/design/post-fork-spend-path-recovery/02-consensus-design-memo.md
+++ b/doc/design/post-fork-spend-path-recovery/02-consensus-design-memo.md
@@ -1,0 +1,169 @@
+# Consensus Design Memo: Spend-Path Restoration Escape Hatch
+
+Date: 2026-04-23
+
+## Purpose
+
+This memo evaluates consensus-level options for restoring spendability to
+ shielded notes that remain owned but stranded after a post-fork transition.
+
+The goal is to restore a valid spend path, not merely improve wallet
+ visibility.
+
+## Current problem
+
+Affected notes remain:
+
+- owned
+- decryptable
+- visible in balance
+
+But they no longer have a working accepted spend path.
+
+There are typically two failed paths:
+
+1. Ordinary post-fork spend
+   Ordinary modern builders require account-registry or related witness state
+   that the stranded notes never created.
+
+2. First-generation custom recovery path
+   A custom migration family may exist locally, but if blocks carrying it are
+   rejected, it is not yet a valid network escape hatch.
+
+## Design constraints
+
+Any consensus design must:
+
+- preserve amount conservation
+- preserve replay and double-spend safety
+- keep ordinary modern spend rules intact
+- avoid fake registry or witness material
+- produce outputs that ordinary wallet code can spend afterward
+
+## Options considered
+
+### Option A: One-step migration transaction
+
+Introduce a narrow consensus-backed migration path that:
+
+1. proves ownership of legacy or stranded notes
+2. consumes those notes
+3. creates ordinary modern spendable outputs
+4. creates the modern account state required by those outputs
+
+Pros:
+
+- simplest operator story
+- easiest audit story
+- smallest long-term operational complexity
+
+Cons:
+
+- requires explicit consensus support
+- must be integrated cleanly across tx validation, block validation, and wallet
+  tooling
+
+### Option B: Two-step registry-bootstrap path
+
+Step 1 proves ownership of a stranded note and creates missing modern spend
+ metadata.
+
+Step 2 later spends that now-modernized note through ordinary flow.
+
+Pros:
+
+- conceptually matches "restore spend path first, spend later"
+
+Cons:
+
+- introduces an intermediate state
+- increases replay and partial-migration edge cases
+- complicates operator flow
+
+### Option C: Relax ordinary modern spend rules
+
+Make ordinary post-fork spend accept stranded notes directly.
+
+Pros:
+
+- looks simple superficially
+
+Cons:
+
+- weakens normal validation semantics
+- contaminates the ordinary spend path with special cases
+- broadens protocol risk
+
+This should not be chosen.
+
+### Option D: Global deterministic rebuild of missing state from history
+
+Attempt to reconstruct modern registry or witness state for all stranded notes
+ directly from chain history.
+
+Pros:
+
+- no explicit migration tx for operators
+
+Cons:
+
+- likely impossible or unsafe if history lacks enough information
+- difficult to reason about globally
+- large consensus surface
+
+This is not preferred.
+
+## Recommended design
+
+Choose **Option A: one-step migration transaction**.
+
+That means:
+
+- keep ordinary modern spend rules unchanged
+- keep stranded notes excluded from ordinary spend selection
+- add a narrow consensus-backed migration mechanism that consumes stranded
+  notes and emits ordinary modern direct-spend style outputs
+
+## Why this is the best escape hatch
+
+This design is best because it:
+
+- isolates the exception to the affected note class
+- avoids weakening ordinary modern spend logic
+- makes post-recovery outputs normal and boring
+- is the easiest design to test end to end
+- is the easiest design to explain to operators and reviewers
+
+## Important implementation nuance
+
+The migration path may be implemented either as:
+
+- a dedicated semantic and wire family, or
+- the same migration semantics encoded under an already-accepted wire family
+
+The objective is the same either way:
+
+> prove ownership of stranded notes without relying on missing modern witness
+> state, then emit modern outputs that ordinary wallet code can spend
+
+The second variant is the main fallback if a distinct wire family would be too
+ disruptive to roll out safely.
+
+## What the patch must not do
+
+The patch must not:
+
+- treat stranded notes as ordinary modern spends
+- fabricate missing account-registry witnesses
+- rely on wallet-only metadata to simulate consensus validity
+- expose unrestricted migration logic to unrelated note classes
+
+## Bottom line
+
+Yes, a consensus patch can restore spendability.
+
+The best version of that patch is not "make ordinary spends accept these
+ notes." The best version is:
+
+> add a narrow migration rule that converts owned stranded notes into ordinary
+> modern spendable outputs while preserving the normal post-fork spend model

--- a/doc/design/post-fork-spend-path-recovery/03-implementation-rfc.md
+++ b/doc/design/post-fork-spend-path-recovery/03-implementation-rfc.md
@@ -1,0 +1,175 @@
+# Implementation RFC: Post-Fork Spend-Path Restoration Patch
+
+Date: 2026-04-23
+
+## Scope
+
+This RFC describes the recommended patch shape for a generalized consensus
+ escape hatch that restores spendability to owned stranded shielded notes.
+
+## Patch objective
+
+Implement a migration path that:
+
+- accepts owned stranded note inputs
+- proves ownership under the old note model
+- consumes those inputs exactly once
+- emits ordinary modern direct-spend style outputs
+- leaves ordinary modern wallet flow unchanged for unaffected notes
+
+## Functional model
+
+### Inputs
+
+The new migration path must accept:
+
+- shielded inputs from the stranded note class
+- proof of spend authority under the historical note model
+- ring, tree, and nullifier semantics required for safe consumption
+
+The new migration path must not require:
+
+- pre-existing modern account-registry spend witnesses for the stranded inputs
+
+### Outputs
+
+The migration path must emit:
+
+- modern shielded outputs
+- output note structure compatible with ordinary post-fork spend flow
+- output account-registry leaves or equivalent modern spend metadata
+
+Post-recovery outputs should be spendable via ordinary `V2_SEND` without any
+ special-case wallet behavior.
+
+### Transaction rules
+
+Required rules:
+
+- no transparent inputs
+- no transparent outputs
+- canonical fee treatment
+- exact amount conservation minus explicit fee
+- replay-safe nullifier handling
+- deterministic ownership proof rules
+
+## Preferred patch shape
+
+### Semantic design
+
+Use a narrow migration semantic family dedicated to:
+
+- stranded-note input consumption
+- modern direct-send style output creation
+
+If a distinct wire family continues to create network-integration risk, the
+ same semantics may instead be encoded inside an already-accepted wire family.
+
+That choice should be made explicitly rather than accidentally through default
+ behavior.
+
+### Validation design
+
+Validation must be explicit in all of these layers:
+
+- tx-level family/context checks
+- block-level family/context checks
+- proof-envelope checks
+- proof-statement construction
+- amount and fee checks
+- output account-state creation checks
+- replay / duplicate nullifier rejection
+
+Any place that currently collapses failures into a generic contextual reject
+ should be instrumented with family-specific reject strings for recovery
+ development.
+
+### Wallet design
+
+Wallet code should:
+
+- continue to classify stranded notes as non-ordinary spend candidates
+- keep them out of ordinary note selection
+- expose a narrow planning and build flow
+- capture deterministic batch artifacts for replay and audit
+
+## Candidate code areas
+
+Consensus and serialization:
+
+- [v2_bundle.h](../../../src/shielded/v2_bundle.h)
+- [v2_bundle.cpp](../../../src/shielded/v2_bundle.cpp)
+- [bundle.cpp](../../../src/shielded/bundle.cpp)
+- [validation.cpp](../../../src/shielded/validation.cpp)
+- [validation.cpp](../../../src/validation.cpp)
+
+Wallet and RPC:
+
+- [shielded_wallet.cpp](../../../src/wallet/shielded_wallet.cpp)
+- [shielded_rpc.cpp](../../../src/wallet/shielded_rpc.cpp)
+- [shielded_coins.cpp](../../../src/wallet/shielded_coins.cpp)
+
+State derivation:
+
+- [account_registry.h](../../../src/shielded/account_registry.h)
+- [account_registry.cpp](../../../src/shielded/account_registry.cpp)
+
+Tests:
+
+- [src/test](../../../src/test)
+- [src/wallet/test](../../../src/wallet/test)
+
+## Required engineering work
+
+### WP1: Family and wire semantics
+
+- define final migration semantic model
+- decide whether wire family is distinct or reused
+- make family handling explicit in every switch and contextual gate
+
+### WP2: Proof semantics
+
+- define proof statement for stranded-note ownership
+- ensure proof-envelope rules remain valid post-fork
+- confirm the family does not accidentally inherit disabled legacy proof rules
+
+### WP3: Output modernization
+
+- create direct-send style modern outputs
+- create modern account-leaf commitments for those outputs
+- ensure resulting outputs are discoverable by ordinary wallet rebuild logic
+
+### WP4: Replay safety
+
+- reject duplicate nullifier reuse
+- reject duplicate migration attempts
+- reject mixed or malformed migration payloads
+
+### WP5: Diagnostics
+
+- replace generic contextual rejects with more precise failure codes during
+  development
+- add replay tooling for captured rejected blocks or txs
+
+## Open architectural question
+
+The main remaining design choice is:
+
+- distinct migration wire family
+- or migration semantics carried inside an already-accepted wire family
+
+Decision criteria:
+
+- smaller rollout risk
+- cleaner validation rules
+- lower chance of partial integration bugs
+- easier interoperability with the wider node population
+
+## Deliverable
+
+The patch is complete only when:
+
+- a stranded input fixture migrates successfully under consensus
+- the resulting output becomes ordinary modern spendable
+- replay fails safely
+- the activation and rollout plan is ready for operators

--- a/doc/design/post-fork-spend-path-recovery/04-rollout-and-activation-plan.md
+++ b/doc/design/post-fork-spend-path-recovery/04-rollout-and-activation-plan.md
@@ -1,0 +1,96 @@
+# Rollout And Activation Plan
+
+Date: 2026-04-23
+
+## Goal
+
+Roll out a consensus-backed spend-path restoration patch without creating an
+ uncontrolled chain split or unsafe operator behavior.
+
+## Recommended rollout model
+
+Use a coordinated upgrade with explicit activation.
+
+Preferred sequence:
+
+1. finish implementation
+2. pass fixture and functional tests
+3. ship binaries to validators and miners
+4. coordinate upgrade window
+5. activate at a future height
+6. begin pilot migration batches after activation
+
+## Why explicit activation matters
+
+If the patch changes which blocks are valid, then old nodes and upgraded nodes
+ can disagree. That is effectively a fork boundary, even if the change is
+ framed as a bug fix.
+
+An explicit activation height gives operators:
+
+- time to upgrade
+- a clean communication target
+- less ambiguity during cutover
+
+## Upgrade targets
+
+The following participants must be upgraded before activation:
+
+- mining nodes
+- block-validating full nodes
+- wallet or recovery nodes that will construct migration transactions
+- any recovery helper nodes used for auxiliary mining or validation
+
+## Pre-activation checklist
+
+- migration family or wire encoding finalized
+- all family/context validation paths reviewed
+- replay and double-claim tests passing
+- activation height selected
+- release notes written
+- operator runbook reviewed
+- pilot destination wallets chosen
+
+## Pilot rollout
+
+Do not start with the full stranded inventory.
+
+Pilot sequence:
+
+1. migrate one small stranded note or one small batch
+2. confirm the block is accepted on the active chain
+3. confirm the destination outputs are ordinary modern spendable notes
+4. perform one ordinary spend from the recovered outputs
+5. only then move to larger batches
+
+## Rollback posture
+
+Before pilot activation:
+
+- preserve wallet snapshots
+- preserve chainstate and shielded-state rollback points
+- capture deterministic recovery plan and build artifacts
+
+After activation:
+
+- if the patch proves invalid in production, stop migration operations first
+- do not keep forcing failed recovery blocks
+- evaluate rollback only with clear network coordination
+
+## Communication package
+
+Operators need a short, plain statement:
+
+- some owned shielded notes became stranded after a fork-model transition
+- the patch introduces a narrow migration path
+- ordinary modern spend rules are unchanged
+- pilot recovery should happen in bounded batches only
+
+## Success criteria
+
+Rollout is successful when:
+
+- upgraded nodes agree on migration-block validity
+- pilot migration transactions confirm on the active chain
+- recovered outputs are ordinarily spendable
+- no replay or duplicate-claim issues appear

--- a/doc/design/post-fork-spend-path-recovery/05-operator-runbook.md
+++ b/doc/design/post-fork-spend-path-recovery/05-operator-runbook.md
@@ -1,0 +1,82 @@
+# Operator Runbook: Spend-Path Recovery For Stranded Shielded Notes
+
+Date: 2026-04-23
+
+## Purpose
+
+This runbook is for operators handling wallets that still own shielded notes
+ but cannot spend them through ordinary post-fork flow.
+
+## Identify affected wallets
+
+An affected wallet generally has all or most of these properties:
+
+- shielded balance still visible
+- spending keys still loaded
+- note ownership still provable
+- ordinary send or merge path unavailable
+- wallet diagnostics indicate recovery is required or ordinary spend metadata is
+  missing
+
+## Immediate operator rules
+
+- freeze ordinary merge or sweep automation for affected wallets
+- do not keep retrying normal sends
+- do not rely on wallet recreation as a fix
+- preserve wallet files, balance snapshots, and recovery artifacts
+
+## Before any live recovery attempt
+
+Capture:
+
+- current balance snapshot
+- note counts
+- wallet integrity output
+- list of affected commitments or recovery candidates
+- node version and build id
+- current chain height
+
+## Safe recovery order
+
+1. confirm the node is upgraded to the activation-ready recovery build
+2. confirm the network or mining cohort is also upgraded
+3. select a fresh controlled destination
+4. build a dry-run migration artifact
+5. execute one small pilot batch only
+6. confirm resulting outputs are ordinary spendable
+7. only then continue with bounded batches
+
+## Destination guidance
+
+The first recovery destination should be:
+
+- a fresh controlled recovery destination, or
+- another wallet whose receive path is already known-good
+
+Avoid mixing pilot recovery output with unrelated large wallet workflows until
+ ordinary spendability is confirmed.
+
+## What to verify after a pilot batch
+
+- tx accepted by mempool and block validation
+- tx confirmed on the active chain
+- recovered output appears in destination wallet
+- recovered output is visible in ordinary spendable note selection
+- a small ordinary post-recovery spend succeeds
+
+## What not to do
+
+- do not migrate the full inventory first
+- do not mix recovery with unrelated consolidation jobs
+- do not keep mining rejected payloads blindly
+- do not change ordinary spend rules locally and assume the network agrees
+
+## Completion condition
+
+An affected wallet is no longer in recovery mode only when:
+
+- stranded-note inventory is cleared, or reduced to known residuals under a
+  planned later batch
+- recovered outputs are confirmed
+- recovered outputs are ordinary spendable
+- normal wallet automation can resume safely

--- a/doc/design/post-fork-spend-path-recovery/06-test-and-verification-plan.md
+++ b/doc/design/post-fork-spend-path-recovery/06-test-and-verification-plan.md
@@ -1,0 +1,113 @@
+# Test And Verification Plan
+
+Date: 2026-04-23
+
+## Goal
+
+Prove the spend-path restoration patch works before and during rollout.
+
+## Test philosophy
+
+The patch is not done when a transaction can be built.
+
+The patch is only done when:
+
+- the migration transaction validates
+- a block carrying it validates
+- the resulting outputs become ordinary spendable notes
+- replay attempts fail safely
+
+## Minimum fixture matrix
+
+### Affected-note fixture
+
+Create a fixture with:
+
+- owned stranded shielded notes
+- ordinary spend path intentionally unavailable
+- deterministic output commitments and note inventory
+
+Expected result:
+
+- wallet identifies the notes as recovery candidates
+- ordinary `V2_SEND` still fails
+
+### Migration success fixture
+
+Build one migration transaction from the fixture.
+
+Expected result:
+
+- tx validates at tx level
+- tx validates inside a block
+- block connects successfully
+
+### Post-migration spend fixture
+
+Take the migration outputs and run ordinary spend flow.
+
+Expected result:
+
+- outputs appear in ordinary spendable note selection
+- ordinary `V2_SEND` succeeds
+
+## Required consensus tests
+
+- family-context acceptance
+- proof-envelope acceptance
+- proof verification success
+- block-level acceptance
+- duplicate nullifier rejection
+- replay rejection
+- malformed payload rejection
+- amount-conservation checks
+- fee-bucket checks
+- activation-boundary checks
+
+## Required wallet tests
+
+- affected notes remain excluded from ordinary selection pre-migration
+- migration planner chooses deterministic bounded batches
+- migration outputs become ordinary spendable notes
+- operator diagnostics are truthful and precise
+
+## Required network tests
+
+- upgraded miner and validator agree on migration-block validity
+- old node versus new node behavior around activation is documented
+- reorg handling is tested
+- stale-block handling is tested
+
+## Required observability
+
+Add or preserve:
+
+- explicit reject codes for each contextual recovery failure path
+- txid and block-hash logging for migration attempts
+- artifact capture for dry-run and built transactions
+- runtime metrics for accepted, rejected, replayed, and confirmed migration
+  attempts
+
+## Pilot acceptance checklist
+
+Before live pilot:
+
+- unit and fixture tests pass
+- one block-connect test passes
+- one post-migration ordinary spend test passes
+- activation build is tagged and reproducible
+
+After live pilot:
+
+- tx confirmed
+- destination output ordinary-spendable
+- one ordinary post-recovery spend confirmed
+
+## Failure handling
+
+If pilot fails:
+
+- stop additional migration batches
+- capture tx hex, block data, reject reason, and node logs
+- replay the failure locally with instrumented reject sites
+- do not continue with larger batches until the failure is understood

--- a/doc/design/post-fork-spend-path-recovery/07-upstream-port-context.md
+++ b/doc/design/post-fork-spend-path-recovery/07-upstream-port-context.md
@@ -1,0 +1,105 @@
+# Upstream Port Context
+
+Date: 2026-04-23
+
+## Purpose
+
+This note keeps the clean upstream port effort tied to the live recovery
+evidence and tooling that still exist only in the parallel recovery branch.
+
+The goal is to let engineers work on a clean upstream base without
+losing the hard-won incident knowledge, replay artifacts, and wallet-specific
+diagnostics gathered during the active recovery effort.
+
+## Branch roles
+
+The clean upstream branch is the implementation track.
+
+The parallel recovery branch remains the source of:
+
+- captured rejected tx and block behavior
+- custom recovery RPCs and wallet builders
+- live recovery operations knowledge
+- local test fixtures already written against the custom branch
+
+## Important guardrails
+
+- Do not replace the live recovery daemon with the upstream daemon while the
+  port is in progress.
+- Do not discard the current recovery branch. It contains the only working
+  reproduction path for several recovery-specific failures.
+
+## Current findings to preserve
+
+### Wallet state
+
+- Affected wallets can still own, decrypt, and account for the stranded notes.
+- Ordinary spendability is gone because the notes do not have the modern
+  account-registry spend witness and hint material required by normal post-fork
+  `V2_SEND` and `V2_INGRESS_BATCH` flow.
+- Wallet recreation, unlock changes, and local metadata backfill did not
+  restore ordinary spendability.
+
+### Ruled-out no-fork paths
+
+- Reviving the old non-V2 `legacy_direct` spend family does not work after
+  activation; the current fixture probe rejects it at block level with
+  `bad-shielded-matrict-disabled`.
+- Rebuilding ordinary spend metadata from wallet state alone did not work,
+  because the required account-registry witness path is missing on-chain for
+  the stranded inputs.
+- Transparent re-shielding is not relevant to the stuck notes and is disabled
+  post-fork in the current wallet flow.
+
+### Recovery-family lessons
+
+- The custom recovery branch has already exposed at least one validator
+  integration gap where a solved recovery block hit a generic
+  `bad-shielded-v2-contextual` reject.
+- The recovery family currently appears on the wire as its own transaction
+  family in the custom branch, which raises network-compatibility risk if the
+  final migration patch depends on a distinct family id.
+- The clean upstream port should explicitly evaluate whether the migration
+  semantics need their own wire family or can be carried inside an already
+  accepted one.
+
+## Local evidence and tooling still worth reusing
+
+### Source tree and tests
+
+- recovery branch source tree
+- recovery branch consensus and wallet tests
+- recovery branch wallet recovery tests
+
+### Incident artifacts
+
+- recovery capture sets
+- live node debug logs
+- generalized operator and design bundle
+
+### Existing high-value replay material
+
+- captured rejected recovery block and tx behavior from the live node
+- fixture-level `legacy_direct` rejection tests in the custom branch
+- recovery wallet planner/build artifacts from prior investigation
+
+## Recommended upstream-port workstreams
+
+1. Add precise failure diagnostics so contextual rejects identify the exact
+   recovery gate being hit.
+2. Design the migration path as a narrow spend-path restoration mechanism for
+   stranded legacy-owned notes without weakening ordinary post-fork rules.
+3. Prefer replayable fixtures and regtest coverage before any live-network
+   rollout assumptions.
+4. Maintain mixed-version tests so the team knows exactly when upgraded and
+   non-upgraded nodes diverge.
+5. Keep the local recovery branch available for regression replay until the
+   upstream implementation can reproduce the same wallet state and failure
+   surfaces on its own.
+
+## Immediate next steps in this branch
+
+- build the upstream daemon, CLI, and test binary on this clean branch
+- map the migration design onto upstream consensus and wallet touchpoints
+- add dedicated regtest and mixed-version tests for spend-path restoration
+- use the preserved live artifacts only as replay input and validation evidence

--- a/doc/design/post-fork-spend-path-recovery/08-initial-upstream-touchpoints.md
+++ b/doc/design/post-fork-spend-path-recovery/08-initial-upstream-touchpoints.md
@@ -1,0 +1,120 @@
+# Initial Upstream Touchpoints
+
+Date: 2026-04-23
+
+## Purpose
+
+This note records the first-pass mapping from the generalized spend-path
+recovery design onto the clean upstream tree.
+
+It is meant to shorten the time between "the design is clear" and "the first
+upstream patch set is scoped."
+
+## Immediate structural observation
+
+The clean upstream tree does not contain any recovery-specific surface such as:
+
+- `V2_LEGACY_RECOVERY`
+- `z_planlegacyrecovery`
+- `z_buildlegacyrecovery`
+- `legacyrecovery`
+
+That means the upstream port starts from a simpler and cleaner baseline, but it
+also means the current parallel recovery branch remains necessary for reproducing
+incident-specific behavior until the new work is in place here.
+
+## High-value upstream touchpoints
+
+### Family and bundle surface
+
+These files define or route the currently accepted shielded family surface:
+
+- `src/shielded/v2_types.cpp`
+- `src/shielded/bundle.cpp`
+- `src/shielded/v2_send.cpp`
+- `src/shielded/v2_send.h`
+
+The first pass shows a family surface centered on:
+
+- `V2_SEND`
+- `V2_INGRESS_BATCH`
+
+Any migration patch will need a deliberate answer to:
+
+- whether to add a new semantic and wire family, or
+- whether to encode migration semantics inside one of the already accepted
+  upstream envelopes
+
+### Ordinary spend witness requirements
+
+The ordinary post-fork spend path in `src/wallet/shielded_wallet.cpp` still
+hard-requires both:
+
+- an account-leaf hint
+- an account-registry witness
+
+The first-pass grep landed on the relevant failure points in the existing
+`CreateV2Send` flow where ordinary spending aborts on missing hint or missing
+registry witness. That makes this file one of the main patch decision points:
+
+- either the migration path bypasses these ordinary requirements by design
+- or the patch creates a separate bootstrap path that produces modern outputs
+  without pretending the stranded inputs already satisfy ordinary `V2_SEND`
+  preconditions
+
+### Account-registry coupling
+
+The account-registry dependency is visible throughout:
+
+- `src/shielded/account_registry.h`
+- `src/shielded/account_registry.cpp`
+- `src/shielded/v2_send.cpp`
+- `src/wallet/shielded_wallet.cpp`
+
+The clean upstream tree already has helper logic such as
+`CollectAccountLeafCommitmentCandidatesFromNote(...)`, but that still assumes a
+modern witness path exists for the spend input. The migration design should not
+count on that assumption for stranded-note inputs.
+
+## Patch-shaping implications
+
+### What looks promising
+
+- a narrow migration path that consumes stranded legacy-owned shielded notes and
+  emits ordinary modern spendable outputs
+- precise reject codes and replay tooling for any new migration validation path
+- regtest and mixed-version tests before live-network assumptions
+
+### What still looks risky
+
+- weakening ordinary `V2_SEND` semantics
+- trying to fake or infer missing account-registry spend witnesses from wallet
+  state alone
+- adding a distinct wire family unless the team is comfortable treating the
+  result as a coordinated consensus rollout
+
+## Suggested first upstream implementation steps
+
+1. Add diagnostic plumbing so contextual recovery failures cannot collapse into
+   a generic reject string.
+2. Introduce a migration design stub in the shielded family plumbing and choose
+   whether it is semantic-only or both semantic and wire-visible.
+3. Add fixture coverage for:
+   - stranded-input migration success
+   - replay rejection
+   - modern-output ordinary spend success after migration
+4. Add a mixed-version test proving exactly how upgraded and non-upgraded nodes
+   diverge once the migration rule is exercised.
+
+## Relationship to the parallel recovery branch
+
+This upstream branch is the clean implementation track.
+
+The parallel recovery branch is still the right place to mine for:
+
+- captured live rejects
+- wallet-specific recovery planner artifacts
+- historical test fixtures already written around the recovery incident
+
+Use the upstream branch for patching and clean validation.
+Use the parallel recovery branch for replay evidence and regression comparison.

--- a/doc/design/post-fork-spend-path-recovery/09-implementation-record.md
+++ b/doc/design/post-fork-spend-path-recovery/09-implementation-record.md
@@ -1,0 +1,369 @@
+# Implementation Record
+
+Date: 2026-04-24
+
+## Purpose
+
+This log records the concrete upstream implementation steps for the post-fork
+spend-path recovery patch.
+
+The goal is to keep a reviewable history of:
+
+- what changed
+- why it changed
+- what was verified
+- what remains intentionally disabled
+
+## Current milestone
+
+### Recovery family is now activation-gated
+
+The upstream tree no longer hard-rejects `v2_spend_path_recovery`
+unconditionally.
+
+Instead, recovery admission is now controlled by a dedicated consensus gate:
+
+- `nShieldedSpendPathRecoveryActivationHeight`
+
+and helper:
+
+- `IsShieldedSpendPathRecoveryActive(height)`
+
+Default behavior is still non-accepting because the activation height defaults
+to `max()`.
+
+When inactive, recovery still rejects explicitly with:
+
+- `bad-shielded-v2-spend-path-recovery-disabled`
+
+When active, the recovery family now enters the normal shielded validation
+path instead of failing at the first family check.
+
+### Deterministic reproduction is in place
+
+The upstream tree now has a synthetic regression that reproduces the
+lost-spend-path failure mode without any live-wallet artifacts:
+
+- a legacy shield-only note is accepted into chain state
+- the wallet scans it and counts it as spendable
+- the note still lacks a direct-send account leaf hint
+- an ordinary `V2_SEND` build fails with `bad-shielded-v2-builder-input`
+
+This regression lives in:
+
+- `src/test/shielded_wallet_chunk_discovery_tests.cpp`
+
+### Recovery outputs now have an explicit success-path scaffold
+
+The next scaffold regression proves the intended post-migration wallet shape:
+
+- a synthetic spend-path recovery bundle is built from a real direct-send build
+  result
+- the wallet scans the recovery output
+- the scanned note is labeled with a direct-send account leaf hint
+- the cached transaction view identifies the family as
+  `v2_spend_path_recovery`
+- the scanned output can be used as the input note for a later ordinary
+  `V2_SEND` build in test fixtures
+
+This test still does not prove consensus acceptance of the recovery family.
+It proves that recovery outputs are being shaped like modern direct-send notes
+on the wallet side, which is a required precondition for the full patch.
+
+### Recovery proof surface now has a first accepting slice
+
+The upstream tree now has a dedicated proof-layer scaffold for
+`v2_spend_path_recovery`:
+
+- a distinct verification domain,
+- a recovery statement digest and descriptor,
+- a recovery proof parse/bind/context path,
+- explicit nullifier extraction support for the recovery context, and
+- bundle-wire support for proof-bearing recovery scaffolds under generic wire
+  encoding,
+- direct ring reconstruction for recovery spends,
+- direct SMILE ring reconstruction for recovery spends, and
+- recovery-family proof verification helpers for both MatRiCT-style and
+  SMILE-style direct witnesses.
+
+This slice also wires recovery through the surrounding consensus surfaces that
+would otherwise have blocked it even after activation:
+
+- allowed-family checks in mempool and block validation,
+- account-registry reference validation,
+- shielded proof-check dispatch, and
+- shielded pool value-balance accounting.
+
+The intent is still narrow:
+
+- keep the feature disabled by default,
+- prove that an activated recovery family can make it through the validator
+  path safely,
+- keep the postfork-specific activation boundary honest and explicit.
+
+The first accepting slice now covers both:
+
+- a prefork direct-style activated recovery fixture, and
+- the full postfork generic-wire activated recovery fixture.
+
+The postfork gap that remained earlier was traced to fixture-shaping order:
+the recovery statement digest was being computed before the derived output
+chunks were refreshed, so the stored statement digest no longer matched the
+final transaction shape. After fixing that ordering, the activated postfork
+generic-wire validator path went green.
+
+## Code changes recorded in this milestone
+
+### Wallet family naming
+
+The wallet-facing family description now reports:
+
+- `v2_spend_path_recovery`
+
+in:
+
+- `src/wallet/shielded_wallet.cpp`
+- `src/wallet/shielded_rpc.cpp`
+
+### Wallet output scanning
+
+The wallet now treats spend-path recovery outputs like direct-send outputs for
+metadata purposes in:
+
+- `src/wallet/shielded_wallet.cpp`
+
+Specifically:
+
+- block scan assigns a direct-send account leaf hint to recovery outputs
+- mempool scan assigns the same hint to recovery outputs
+
+This matches the bundle/account-registry layer, which already derives
+direct-send account leaves for recovery outputs.
+
+### Regression coverage
+
+The main wallet regression file now covers both:
+
+- legacy-note lost spend-path reproduction
+- recovery-output ordinary-spend-shape scaffolding
+
+in:
+
+- `src/test/shielded_wallet_chunk_discovery_tests.cpp`
+
+The proof and bundle regression surface now also covers:
+
+- recovery statement digest stability under stripped-proof hashing
+- recovery proof context parsing under the disabled scaffold
+- recovery proof context rejection on statement mismatch
+- recovery proof context rejection on missing proof payload
+- recovery proof context rejection on malformed witness encoding
+- recovery proof verification against a recovery-family context
+- proof-bearing recovery bundle round-trip under the scaffold
+- recovery bundle fee accounting through shielded state-value balance
+- explicit proof-check rejection for proof-bearing recovery bundles that remain
+  disabled
+- activated prefork recovery proof acceptance
+- activated postfork recovery proof acceptance
+- activated prefork recovery activation-boundary enforcement
+- activated postfork recovery activation-boundary enforcement
+- activated prefork recovery nullifier-tamper rejection
+- activated postfork recovery nullifier-tamper rejection
+- mempool nullifier-conflict detection for recovery-family transactions
+- mempool duplicate-nullifier detection within a recovery-family transaction
+
+in:
+
+- `src/test/shielded_v2_proof_tests.cpp`
+- `src/test/shielded_v2_bundle_tests.cpp`
+- `src/test/shielded_validation_checks_tests.cpp`
+- `src/test/shielded_mempool_tests.cpp`
+
+### Regtest activation plumbing
+
+Regtest now has an explicit spend-path recovery activation override in:
+
+- `src/chainparamsbase.cpp`
+- `src/chainparams.cpp`
+- `src/kernel/chainparams.h`
+- `src/kernel/chainparams.cpp`
+
+The new regtest-only switch is:
+
+- `-regtestshieldedspendpathrecoveryactivationheight=<n>`
+
+This keeps the feature disabled by default while giving the functional harness
+an activation boundary it can turn on deliberately for mixed-version and
+network-divergence coverage.
+
+Focused regressions run in this slice:
+
+- `shielded_v2_proof_tests/v2_send_context_parses_and_verifies`
+- `shielded_v2_proof_tests/spend_path_recovery_statement_tracks_stripped_tx_digest`
+- `shielded_v2_proof_tests/spend_path_recovery_context_parses_under_disabled_scaffold`
+- `shielded_v2_proof_tests/spend_path_recovery_context_rejects_wrong_statement_digest`
+- `shielded_v2_proof_tests/spend_path_recovery_context_rejects_missing_proof_payload`
+- `shielded_v2_proof_tests/spend_path_recovery_context_rejects_malformed_witness_encoding`
+- `shielded_v2_proof_tests/spend_path_recovery_smile_proof_verifies_against_recovery_context`
+- `shielded_v2_bundle_tests/postfork_generic_spend_path_recovery_bundle_roundtrip_uses_opaque_payload_encoding`
+- `shielded_v2_bundle_tests/spend_path_recovery_bundle_roundtrip_accepts_proof_payload_scaffold`
+- `shielded_v2_bundle_tests/spend_path_recovery_bundle_uses_fee_as_state_value_balance`
+- `shielded_validation_checks_tests/proof_check_rejects_prefork_spend_path_recovery_family_as_disabled`
+- `shielded_validation_checks_tests/proof_check_rejects_postfork_spend_path_recovery_family_as_disabled`
+- `shielded_validation_checks_tests/proof_check_rejects_postfork_spend_path_recovery_proof_surface_as_disabled`
+- `shielded_validation_checks_tests/proof_check_accepts_prefork_spend_path_recovery_when_activated`
+- `shielded_validation_checks_tests/proof_check_accepts_postfork_spend_path_recovery_when_activated`
+- `shielded_validation_checks_tests/proof_check_prefork_spend_path_recovery_enforces_activation_boundary`
+- `shielded_validation_checks_tests/proof_check_postfork_spend_path_recovery_enforces_activation_boundary`
+- `shielded_validation_checks_tests/prefork_activated_spend_path_recovery_smile_proof_verifies_at_proof_layer`
+- `shielded_validation_checks_tests/proof_check_rejects_prefork_activated_spend_path_recovery_with_tampered_nullifier`
+- `shielded_validation_checks_tests/proof_check_rejects_postfork_activated_spend_path_recovery_with_tampered_nullifier`
+- `shielded_validation_checks_tests/proof_check_rejects_postfork_legacy_v2_send_wire_family`
+- `shielded_mempool_tests/shielded_v2_spend_path_recovery_nullifier_conflict_detected`
+- `shielded_mempool_tests/shielded_v2_spend_path_recovery_duplicate_within_tx_detected`
+- `validation_tests/regtest_shielded_spend_path_recovery_activation_height_override`
+- `validation_tests/regtest_shielded_spend_path_recovery_activation_height_rejects_negative`
+- `shielded_wallet_chunk_discovery_tests/owned_legacy_note_is_counted_as_spendable_but_cannot_build_ordinary_v2_send`
+- `shielded_wallet_chunk_discovery_tests/scanned_spend_path_recovery_output_rehydrates_to_ordinary_spend_shape`
+
+## State-aware injector and activation compatibility scaffold
+
+This slice added the first deterministic end-to-end recovery fixture pipeline
+that derives its ring members from real legacy notes instead of synthetic
+in-memory witness state.
+
+The new injector lives in:
+
+- `src/test/shielded_spend_path_recovery_fixture_builder.h`
+- `src/test/shielded_spend_path_recovery_fixture_builder.cpp`
+- `src/test/shielded_spend_path_recovery_fixture_builder_tests.cpp`
+- `src/test/generate_shielded_spend_path_recovery_fixture.cpp`
+
+What it does:
+
+- consumes a fixed set of transparent funding outpoints
+- emits a deterministic sequence of chain-valid legacy shield-only funding
+  transactions whose anchors track the evolving commitment tree
+- emits a deterministic prefork MatRiCT recovery transaction over the resulting
+  ring members
+- rejects post-disable heights explicitly, because this state-aware injector is
+  currently scoped to the prefork MatRiCT surface
+
+This was then wired into a functional regtest scaffold in:
+
+- `test/functional/test_framework/bridge_utils.py`
+- `test/functional/feature_spend_path_recovery_activation_compat.py`
+
+The functional scaffold now proves the following with the current binary:
+
+- a node with `-regtestshieldedspendpathrecoveryactivationheight=1` accepts the
+  deterministic recovery transaction in mempool
+
+## Real-batch trusted-state validation
+
+After the synthetic and functional coverage was in place, the patch was also
+checked against a copied affected-wallet batch and a copied trusted
+shielded-state snapshot.
+
+That validation was intentionally kept outside the PR codepath, but its result
+matters for confidence:
+
+- a real affected batch could be exported
+- a real recovery transaction could be regenerated from that export
+- the generated transaction was accepted by the patched proof path against a
+  trusted shielded-state snapshot
+- when the original generated transaction became stale by anchor drift alone,
+  the same exported private inputs could be regenerated under the current
+  trusted anchor and accepted again
+
+This narrowed the remaining practical concern from "is the recovery path valid"
+to "how are oversized recovery transactions included operationally."
+
+The sanitized summary of that evidence is recorded in:
+
+- `doc/design/post-fork-spend-path-recovery/11-real-batch-evidence.md`
+- a peer with the feature left at its default disabled state rejects the same
+  transaction with `spend-path-recovery-disabled`
+- once the upgraded node mines that recovery transaction, the feature-off peer
+  falls behind on the recovery block
+
+During this work the functional scaffold exposed a real missing consensus
+integration in `src/validation.cpp`: the generic ring-position precheck did not
+recognize `V2_SPEND_PATH_RECOVERY` and rejected it with
+`precheck-ring-positions-unsupported-family`. That gate is now wired through
+`shielded::v2::proof::ParseSpendPathRecoveryWitness(...)`, which moved the
+recovery transaction past the generic contextual reject and into normal mempool
+policy/activation behavior.
+
+Focused regressions run in this slice:
+
+- `shielded_spend_path_recovery_fixture_builder_tests/state_aware_fixture_builds_prefork_recovery_tx_that_validates_with_tree_snapshot`
+- `shielded_spend_path_recovery_fixture_builder_tests/state_aware_fixture_rejects_incorrect_ring_input_count`
+- `shielded_spend_path_recovery_fixture_builder_tests/state_aware_fixture_rejects_post_disable_validation_height`
+- `shielded_validation_checks_tests/*spend_path_recovery*`
+- `test/functional/feature_spend_path_recovery_activation_compat.py`
+
+## Divergence and block-reconnect hardening
+
+The functional coverage now includes both:
+
+- same-binary activation-split coverage, and
+- strict patched-binary vs baseline-binary coverage when local baseline binary
+  paths are provided through `BTX_BASELINE_BITCOIND` and
+  `BTX_BASELINE_BITCOINCLI`.
+
+The strict local run matters because the observed baseline behavior is even
+stronger than the feature-off same-binary case: the unpatched upstream daemon
+does not merely reject the recovery transaction at policy or activation time,
+it fails to decode the recovery family on the wire. The compatibility test now
+accepts either:
+
+- explicit `spend-path-recovery-disabled` rejection, or
+- `TX decode failed` from the baseline binary,
+
+depending on which incompatibility surface the older node exposes.
+
+This slice also adds recovery block disconnect/reconnect coverage in:
+
+- `test/functional/feature_spend_path_recovery_reorg.py`
+
+That test now proves:
+
+- a mined recovery block connects successfully,
+- invalidating that block returns the recovery transaction to mempool, and
+- reconsidering the same block reconnects it and removes the transaction from
+  mempool again.
+
+Focused regressions run in this slice:
+
+- `test/functional/feature_spend_path_recovery_activation_compat.py`
+- strict local `feature_spend_path_recovery_activation_compat.py` with
+  `BTX_BASELINE_BITCOIND` and `BTX_BASELINE_BITCOINCLI`
+- `test/functional/feature_spend_path_recovery_reorg.py`
+
+## PR readiness
+
+At this point the upstream branch has:
+
+- disabled-by-default consensus plumbing,
+- deterministic lost-spend-path reproduction,
+- deterministic prefork recovery fixture generation,
+- activated prefork and postfork validator coverage,
+- wallet-shape coverage for migrated outputs,
+- mempool conflict coverage,
+- same-binary activation split coverage,
+- strict local patched-vs-baseline binary divergence coverage, and
+- recovery block disconnect/reconnect coverage.
+
+That is enough to move this patch into reviewer-facing PR shape.
+
+The remaining work is now primarily review, naming, and rollout discipline
+rather than missing core consensus scaffolding.
+
+## Safety note
+
+This milestone is intentionally narrow.
+
+It still preserves disabled-by-default network behavior, while adding a small
+activation-gated acceptance slice and the regression surface needed to build on
+it safely.

--- a/doc/design/post-fork-spend-path-recovery/10-pr-readiness-checklist.md
+++ b/doc/design/post-fork-spend-path-recovery/10-pr-readiness-checklist.md
@@ -1,0 +1,89 @@
+# PR Readiness Checklist
+
+Date: 2026-04-25
+
+## Scope of this checklist
+
+This checklist is for opening the upstream spend-path recovery patch as a
+reviewable pull request.
+
+It is not an activation checklist for mainnet rollout.
+
+## Patch shape
+
+- Feature is disabled by default on all networks.
+- Recovery admission is controlled only by
+  `nShieldedSpendPathRecoveryActivationHeight`.
+- Regtest can opt in explicitly with
+  `-regtestshieldedspendpathrecoveryactivationheight=<n>`.
+- Ordinary `V2_SEND` and `V2_INGRESS_BATCH` rules are unchanged.
+
+## Required reviewer checks
+
+- Confirm the new family only activates when the dedicated consensus gate is
+  enabled.
+- Confirm unknown or disabled-family behavior remains explicit and stable.
+- Confirm migrated outputs scan back in as ordinary direct-send-shaped notes.
+- Confirm recovery spends participate in nullifier conflict checks and
+  duplicate-nullifier checks.
+- Confirm shielded state-value accounting uses the recovery fee path
+  intentionally.
+- Confirm regtest activation plumbing is isolated from non-regtest defaults.
+
+## Required regression coverage
+
+- Synthetic reproduction of the lost spend path:
+  `owned_legacy_note_is_counted_as_spendable_but_cannot_build_ordinary_v2_send`
+- Recovery-output wallet-shape regression:
+  `scanned_spend_path_recovery_output_rehydrates_to_ordinary_spend_shape`
+- Proof and validation coverage for activated prefork and postfork recovery
+  fixtures
+- Mempool conflict coverage for recovery nullifiers
+- Deterministic fixture-builder coverage
+- Functional activation split coverage
+- Functional recovery-block disconnect/reconnect coverage
+
+## Strict local compatibility pass
+
+For local hardening, the activation compatibility test also supports a true
+patched-binary vs baseline-binary run through:
+
+- `BTX_BASELINE_BITCOIND`
+- `BTX_BASELINE_BITCOINCLI`
+
+Expected old-node behavior is one of:
+
+- explicit mempool rejection with `spend-path-recovery-disabled`, or
+- transaction decode failure because the baseline binary does not recognize the
+  recovery family on the wire
+
+Either result is acceptable for the local divergence pass, because both prove
+that unpatched nodes do not follow the activated recovery branch.
+
+## Manual pre-PR run list
+
+Run these before opening the PR:
+
+- focused `test_btx` spend-path-recovery suite
+- `feature_spend_path_recovery_activation_compat.py`
+- `feature_spend_path_recovery_reorg.py`
+- strict local compatibility pass with baseline binaries, if available
+- real-batch trusted-state replay, if local copied-wallet evidence is available
+
+## Real-batch evidence position
+
+The PR does not depend on local copied-wallet evidence for correctness, but the
+current packaging includes a separate sanitized memo summarizing that stronger
+local validation:
+
+- [11-real-batch-evidence.md](11-real-batch-evidence.md)
+
+That memo documents that a real affected batch was regenerated under current
+trusted state and accepted by the patched proof and validation path.
+
+## Explicit non-goals for this PR
+
+- default-on activation on any public network
+- automatic wallet-side recovery without explicit activation
+- bridge or settlement-surface extensions beyond the recovery family itself
+- unrelated wallet migration or historical data backfill schemes

--- a/doc/design/post-fork-spend-path-recovery/11-real-batch-evidence.md
+++ b/doc/design/post-fork-spend-path-recovery/11-real-batch-evidence.md
@@ -1,0 +1,124 @@
+# Real-Batch Evidence Summary
+
+Date: 2026-04-27
+
+## Purpose
+
+This memo records the highest-signal local evidence gathered against a copied
+affected wallet and a copied trusted shielded-state snapshot.
+
+It is intentionally sanitized:
+
+- no wallet names
+- no private key material
+- no machine-specific operational details
+
+The goal is to answer one question:
+
+> Does the spend-path recovery patch validate a real affected batch under
+> trustworthy shielded state, or only synthetic fixtures?
+
+## Scope
+
+The local validation flow used:
+
+- a copied affected wallet
+- a copied trusted shielded-state snapshot
+- a real exported recovery batch derived from that copied wallet
+- an offline generator for the recovery transaction
+- a direct trusted-state replay harness
+
+Nothing in this evidence path broadcast a transaction or modified live wallet
+files.
+
+## What Was Proved
+
+### 1. A real affected batch can be exported
+
+The copied wallet exported a real recovery batch using the dedicated local-only
+export surface. That export included:
+
+- the selected legacy note commitments
+- the destination output contract
+- the spend anchor
+- ring positions
+- ring members
+- encrypted output payloads
+- private spend material needed for offline regeneration
+
+This proved that the recovery path can be grounded in real affected wallet
+state, not only synthetic fixtures.
+
+### 2. A recovery transaction can be regenerated from that export
+
+The exported batch was consumed by the offline generator and produced a real
+`v2_spend_path_recovery` transaction.
+
+This proved that the patch’s witness and proof surface is sufficient to
+represent a real affected batch end-to-end.
+
+### 3. Proof validation succeeds against a copied trusted shielded-state snapshot
+
+The first replay of the real generated transaction against a copied trusted
+shielded-state snapshot showed:
+
+- proof validation accepted
+- nullifiers were still unspent
+- commitment-index digests matched the persisted state
+
+The only failure on that first replay was anchor freshness: the original
+transaction anchor had fallen out of the trusted anchor window.
+
+This was important because it separated proof validity from anchor drift.
+
+### 4. The same real batch validates cleanly after anchor refresh
+
+Using the same exported private spend inputs, the transaction was regenerated
+with:
+
+- the current trusted shielded tree root as its spend anchor
+- the current tip-derived next validation height
+
+The refreshed replay then showed:
+
+- the refreshed anchor was present in trusted state
+- nullifiers were still unspent
+- proof validation accepted
+- no mutation marker or other replay inconsistency was present
+
+This is the strongest local evidence gathered so far:
+
+> a real affected batch can be regenerated under current trusted state and
+> accepted by the patched recovery validation path.
+
+## Remaining Caveat
+
+The real recovery transaction remains very large.
+
+In local testing, ordinary mempool admission still hit:
+
+- `tx-size`
+
+That is a relay and admission policy concern, not a proof-validity concern.
+
+The practical implication is that rollout should assume:
+
+- consensus recovery patch in the PR
+- no broad default relay-policy widening unless reviewed separately
+- operator/miner block inclusion may still be needed for oversized recovery
+  transactions
+
+## Conclusion
+
+The patch is no longer supported only by synthetic tests.
+
+It now has:
+
+- synthetic regression coverage
+- mixed-version activation-split coverage
+- reorg coverage
+- and a real-batch trusted-state acceptance replay
+
+That is strong enough to support a public PR for a narrowly scoped recovery
+patch, with explicit documentation that oversized real recovery transactions
+may still require direct miner inclusion.

--- a/doc/design/post-fork-spend-path-recovery/12-pr-cover-note.md
+++ b/doc/design/post-fork-spend-path-recovery/12-pr-cover-note.md
@@ -1,0 +1,97 @@
+# PR Cover Note
+
+## Title
+
+Add activation-gated post-fork spend-path recovery for stranded shielded notes
+
+## Summary
+
+This PR introduces a narrow, activation-gated recovery path for shielded notes
+that remain owned and balance-visible after a shielded-model transition but no
+longer have an accepted ordinary spend path.
+
+The patch adds a dedicated `v2_spend_path_recovery` transaction family that:
+
+- remains disabled by default on all networks
+- activates only when the dedicated consensus height is set
+- consumes eligible stranded notes
+- recreates ordinary modern spendable outputs
+- scans those outputs back into the wallet as ordinary direct-send-shaped notes
+
+The PR does not weaken ordinary `V2_SEND` or `V2_INGRESS_BATCH` rules and does
+not attempt any global historical backfill scheme.
+
+## Problem
+
+Some wallets can still:
+
+- decrypt affected shielded notes
+- account for them in balance
+- prove ownership of them
+
+but cannot spend them through the ordinary modern shielded path because the
+required registry or witness context no longer exists for those note classes.
+
+That leaves custody intact while spendability is lost.
+
+## What This PR Changes
+
+- reserves and implements the `v2_spend_path_recovery` family
+- adds activation-gated validation and proof plumbing
+- adds replay and nullifier conflict handling for recovery spends
+- adds wallet-side recovery-output scanning so migrated outputs come back as
+  ordinary spendable notes
+- adds deterministic fixture generation and functional activation tests
+
+## What This PR Does Not Change
+
+- no default-on activation on any public network
+- no relaxation of ordinary modern spend rules
+- no unrelated relay-policy widening
+- no automatic wallet migration without explicit activation
+
+## Evidence Included
+
+This patch is supported by:
+
+- synthetic unit and integration coverage
+- mixed-version activation-split functional coverage
+- recovery-block disconnect and reconnect coverage
+- a real-batch trusted-state replay against copied affected-wallet data
+
+The real-batch replay showed that a real affected batch can be regenerated
+under current trusted state and accepted by the patched proof and validation
+path when anchored to current state.
+
+## Operational Note
+
+Real recovery transactions can be very large.
+
+Local testing showed that ordinary mempool admission can still reject them for
+`tx-size`, even when proof validation succeeds. That means activation of this
+consensus path should not assume generic network relay for oversized recovery
+transactions. Direct miner or block-template inclusion may still be required.
+
+## Review Guidance
+
+Reviewers should focus on:
+
+- activation boundaries and default-off behavior
+- recovery-family proof and contextual validation
+- nullifier and replay handling
+- wallet-side output rehydration into ordinary spend shape
+- mixed-version divergence behavior after activation
+
+## Suggested Testing
+
+- focused `test_btx` spend-path-recovery suite
+- `feature_spend_path_recovery_activation_compat.py`
+- `feature_spend_path_recovery_reorg.py`
+- strict patched-vs-baseline compatibility run
+
+## Rollout Position
+
+This PR is suitable for review as a narrow recovery patch.
+
+Activation, miner coordination, and any relay-policy discussion should remain
+separate rollout decisions after code review.

--- a/doc/design/post-fork-spend-path-recovery/README.md
+++ b/doc/design/post-fork-spend-path-recovery/README.md
@@ -1,0 +1,65 @@
+# Post-Fork Spend-Path Recovery Bundle
+
+Date: 2026-04-23
+
+## Purpose
+
+This bundle is a generalized recovery design package for any BTX wallet that:
+
+- still owns shielded notes
+- can still decrypt and account for them
+- but no longer has an accepted spend path after a hard-fork or shielded-model transition
+
+This is intended as an engineering and operations package for restoring a
+ consensus-valid spend path. It is not a wallet-only workaround package.
+
+## Intended audience
+
+- protocol engineers
+- validation / wallet engineers
+- miner and node operators
+- release coordinators
+
+## What problem this bundle addresses
+
+Some post-fork shielded notes can become trapped in a state where:
+
+- custody is intact
+- visibility is intact
+- ordinary spendability is gone
+
+This bundle treats that as a spend-path restoration problem, not a simple
+ wallet repair problem.
+
+## Bundle contents
+
+- [01-problem-statement.md](01-problem-statement.md)
+- [02-consensus-design-memo.md](02-consensus-design-memo.md)
+- [03-implementation-rfc.md](03-implementation-rfc.md)
+- [04-rollout-and-activation-plan.md](04-rollout-and-activation-plan.md)
+- [05-operator-runbook.md](05-operator-runbook.md)
+- [06-test-and-verification-plan.md](06-test-and-verification-plan.md)
+- [07-upstream-port-context.md](07-upstream-port-context.md)
+- [08-initial-upstream-touchpoints.md](08-initial-upstream-touchpoints.md)
+- [09-implementation-record.md](09-implementation-record.md)
+- [10-pr-readiness-checklist.md](10-pr-readiness-checklist.md)
+- [11-real-batch-evidence.md](11-real-batch-evidence.md)
+- [12-pr-cover-note.md](12-pr-cover-note.md)
+
+## Recommended design direction
+
+The recommended direction in this bundle is:
+
+- do not weaken ordinary modern spend rules
+- do not fake missing registry or witness state
+- add a narrow consensus-backed migration or recovery path that converts owned
+  stranded legacy notes into ordinary modern spendable outputs
+
+## Bundle status
+
+This bundle is a design-and-implementation package.
+
+It now includes an activation-gated upstream implementation plus deterministic
+regression coverage, a real-batch trusted-state validation memo, and a PR-ready
+cover note, but rollout still depends on review and coordinated activation
+planning.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -181,6 +181,10 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
         options.shielded_matrict_disable_height =
             ParseRegTestNonNegativeInt32Arg(args, "-regtestshieldedmatrictdisableheight");
     }
+    if (args.IsArgSet("-regtestshieldedspendpathrecoveryactivationheight")) {
+        options.shielded_spend_path_recovery_activation_height =
+            ParseRegTestNonNegativeInt32Arg(args, "-regtestshieldedspendpathrecoveryactivationheight");
+    }
     if (args.IsArgSet("-regtestshieldedpq128upgradeheight")) {
         options.shielded_pq128_upgrade_height =
             ParseRegTestNonNegativeInt32Arg(args, "-regtestshieldedpq128upgradeheight");

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -29,6 +29,7 @@ void SetupChainParamsBaseOptions(ArgsManager& argsman)
     argsman.AddArg("-regtestgenesisversion=<n>", "Override regtest genesis nVersion field (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-mldsadisableheight=<n>", "Set ML-DSA consensus disable height for regtest (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-regtestshieldedmatrictdisableheight=<n>", "Override regtest shielded MatRiCT disable height (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    argsman.AddArg("-regtestshieldedspendpathrecoveryactivationheight=<n>", "Override regtest spend-path recovery activation height (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-regtestmatmulbindingheight=<n>", "Override regtest MatMul Freivalds transcript-binding activation height (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-regtestmatmulproductdigestheight=<n>", "Override regtest MatMul product-committed digest activation height (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     argsman.AddArg("-regtestmatmulrequireproductpayload=<0|1>", "Override whether regtest MatMul blocks must carry a product payload (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -248,6 +248,7 @@ struct Params {
     int32_t nShieldedBridgeTagActivationHeight{std::numeric_limits<int32_t>::max()};
     int32_t nShieldedSmileRiceCodecDisableHeight{std::numeric_limits<int32_t>::max()};
     int32_t nShieldedMatRiCTDisableHeight{std::numeric_limits<int32_t>::max()};
+    int32_t nShieldedSpendPathRecoveryActivationHeight{std::numeric_limits<int32_t>::max()};
     int32_t nShieldedPQ128UpgradeHeight{std::numeric_limits<int32_t>::max()};
     uint32_t nShieldedSettlementAnchorMaturity{6};
     int32_t nMLDSADisableHeight{std::numeric_limits<int32_t>::max()};
@@ -330,6 +331,12 @@ struct Params {
         return height >= 0 &&
             nShieldedMatRiCTDisableHeight != std::numeric_limits<int32_t>::max() &&
             height >= nShieldedMatRiCTDisableHeight;
+    }
+    bool IsShieldedSpendPathRecoveryActive(int32_t height) const
+    {
+        return height >= 0 &&
+            nShieldedSpendPathRecoveryActivationHeight != std::numeric_limits<int32_t>::max() &&
+            height >= nShieldedSpendPathRecoveryActivationHeight;
     }
     bool IsShieldedPQ128UpgradeActive(int32_t height) const
     {

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -180,6 +180,30 @@ UniValue ShieldedV2PayloadToUniv(const shielded::v2::TransactionBundle& bundle)
         out.pushKV("outputs", std::move(outputs));
         break;
     }
+    case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+        const auto& payload = std::get<shielded::v2::SpendPathRecoveryPayload>(bundle.payload);
+        out.pushKV("spend_anchor", payload.spend_anchor.GetHex());
+        out.pushKV("fee", ValueFromAmount(payload.fee));
+
+        UniValue spends(UniValue::VARR);
+        for (const auto& spend : payload.spends) {
+            UniValue entry(UniValue::VOBJ);
+            entry.pushKV("nullifier", spend.nullifier.GetHex());
+            entry.pushKV("merkle_anchor", spend.merkle_anchor.GetHex());
+            entry.pushKV("account_leaf_commitment", spend.account_leaf_commitment.GetHex());
+            entry.pushKV("note_commitment", spend.note_commitment.GetHex());
+            entry.pushKV("value_commitment", spend.value_commitment.GetHex());
+            spends.push_back(std::move(entry));
+        }
+        out.pushKV("spends", std::move(spends));
+
+        UniValue outputs(UniValue::VARR);
+        for (const auto& output : payload.outputs) {
+            outputs.push_back(ShieldedV2OutputDescriptionToUniv(output));
+        }
+        out.pushKV("outputs", std::move(outputs));
+        break;
+    }
     case shielded::v2::TransactionFamily::V2_LIFECYCLE: {
         const auto& payload = std::get<shielded::v2::LifecyclePayload>(bundle.payload);
         out.pushKV("transparent_binding_digest", payload.transparent_binding_digest.GetHex());

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -933,6 +933,8 @@ public:
         consensus.nShieldedSmileRiceCodecDisableHeight = 0;  // Activate at genesis for instant regtest
         consensus.nShieldedMatRiCTDisableHeight =
             opts.shielded_matrict_disable_height.value_or(0);  // Activate at genesis for instant regtest
+        consensus.nShieldedSpendPathRecoveryActivationHeight =
+            opts.shielded_spend_path_recovery_activation_height.value_or(std::numeric_limits<int32_t>::max());
         consensus.nShieldedPQ128UpgradeHeight =
             opts.shielded_pq128_upgrade_height.value_or(std::numeric_limits<int32_t>::max());
         consensus.nShieldedSettlementAnchorMaturity = 6;
@@ -988,6 +990,7 @@ public:
             opts.matmul_asert_half_life.has_value() ||
             opts.matmul_asert_half_life_upgrade_height.has_value() ||
             opts.shielded_matrict_disable_height.has_value() ||
+            opts.shielded_spend_path_recovery_activation_height.has_value() ||
             opts.shielded_pq128_upgrade_height.has_value() ||
             opts.mldsa_disable_height.has_value();
 

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -175,6 +175,7 @@ public:
         std::optional<int32_t> genesis_version{};
         std::optional<int32_t> mldsa_disable_height{};
         std::optional<int32_t> shielded_matrict_disable_height{};
+        std::optional<int32_t> shielded_spend_path_recovery_activation_height{};
         std::optional<int32_t> shielded_pq128_upgrade_height{};
         std::optional<int32_t> matmul_binding_height{};
         std::optional<int32_t> matmul_product_digest_height{};

--- a/src/shielded/bundle.cpp
+++ b/src/shielded/bundle.cpp
@@ -62,6 +62,8 @@ constexpr uint64_t SHIELDED_VERIFY_UNITS_PER_SETTLEMENT_PROOF{100};
     switch (shielded::v2::GetBundleSemanticFamily(bundle)) {
     case shielded::v2::TransactionFamily::V2_SEND:
         return std::get<shielded::v2::SendPayload>(bundle.payload).spends.size();
+    case shielded::v2::V2_SPEND_PATH_RECOVERY:
+        return std::get<shielded::v2::SpendPathRecoveryPayload>(bundle.payload).spends.size();
     case shielded::v2::TransactionFamily::V2_LIFECYCLE:
         return 0;
     case shielded::v2::TransactionFamily::V2_INGRESS_BATCH:
@@ -80,6 +82,8 @@ constexpr uint64_t SHIELDED_VERIFY_UNITS_PER_SETTLEMENT_PROOF{100};
     switch (shielded::v2::GetBundleSemanticFamily(bundle)) {
     case shielded::v2::TransactionFamily::V2_SEND:
         return std::get<shielded::v2::SendPayload>(bundle.payload).outputs.size();
+    case shielded::v2::V2_SPEND_PATH_RECOVERY:
+        return std::get<shielded::v2::SpendPathRecoveryPayload>(bundle.payload).outputs.size();
     case shielded::v2::TransactionFamily::V2_LIFECYCLE:
         return 0;
     case shielded::v2::TransactionFamily::V2_INGRESS_BATCH:
@@ -420,6 +424,14 @@ std::vector<Nullifier> CollectShieldedNullifiers(const CShieldedBundle& bundle)
             }
             break;
         }
+        case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+            const auto& payload =
+                std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
+            for (const auto& spend : payload.spends) {
+                out.push_back(spend.nullifier);
+            }
+            break;
+        }
         case shielded::v2::TransactionFamily::V2_INGRESS_BATCH: {
             const auto& payload = std::get<shielded::v2::IngressBatchPayload>(v2_bundle->payload);
             for (const auto& spend : payload.consumed_spends) {
@@ -453,6 +465,14 @@ std::vector<uint256> CollectShieldedOutputCommitments(const CShieldedBundle& bun
         switch (shielded::v2::GetBundleSemanticFamily(*v2_bundle)) {
         case shielded::v2::TransactionFamily::V2_SEND: {
             const auto& payload = std::get<shielded::v2::SendPayload>(v2_bundle->payload);
+            for (const auto& output : payload.outputs) {
+                out.push_back(output.note_commitment);
+            }
+            break;
+        }
+        case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+            const auto& payload =
+                std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
             for (const auto& output : payload.outputs) {
                 out.push_back(output.note_commitment);
             }
@@ -513,6 +533,10 @@ std::vector<std::pair<uint256, smile2::CompactPublicAccount>> CollectShieldedOut
         case shielded::v2::TransactionFamily::V2_SEND:
             append_outputs(std::get<shielded::v2::SendPayload>(v2_bundle->payload).outputs);
             break;
+        case shielded::v2::V2_SPEND_PATH_RECOVERY:
+            append_outputs(
+                std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload).outputs);
+            break;
         case shielded::v2::TransactionFamily::V2_LIFECYCLE:
             break;
         case shielded::v2::TransactionFamily::V2_INGRESS_BATCH:
@@ -555,6 +579,16 @@ std::optional<std::vector<uint256>> CollectShieldedOutputAccountLeafCommitments(
         switch (shielded::v2::GetBundleSemanticFamily(*v2_bundle)) {
         case shielded::v2::TransactionFamily::V2_SEND: {
             const auto& payload = std::get<shielded::v2::SendPayload>(v2_bundle->payload);
+            for (const auto& output : payload.outputs) {
+                if (!append_leaf_commitment(shielded::registry::BuildDirectSendAccountLeaf(output))) {
+                    return std::nullopt;
+                }
+            }
+            break;
+        }
+        case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+            const auto& payload =
+                std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
             for (const auto& output : payload.outputs) {
                 if (!append_leaf_commitment(shielded::registry::BuildDirectSendAccountLeaf(output))) {
                     return std::nullopt;
@@ -630,6 +664,16 @@ shielded::registry::CollectShieldedOutputAccountLeaves(const CShieldedBundle& bu
         switch (shielded::v2::GetBundleSemanticFamily(*v2_bundle)) {
         case shielded::v2::TransactionFamily::V2_SEND: {
             const auto& payload = std::get<shielded::v2::SendPayload>(v2_bundle->payload);
+            for (const auto& output : payload.outputs) {
+                if (!append_leaf(shielded::registry::BuildDirectSendAccountLeaf(output))) {
+                    return std::nullopt;
+                }
+            }
+            break;
+        }
+        case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+            const auto& payload =
+                std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
             for (const auto& output : payload.outputs) {
                 if (!append_leaf(shielded::registry::BuildDirectSendAccountLeaf(output))) {
                     return std::nullopt;
@@ -717,6 +761,17 @@ std::optional<std::vector<std::pair<uint256, uint256>>> CollectShieldedOutputAcc
             }
             break;
         }
+        case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+            const auto& payload =
+                std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
+            for (const auto& output : payload.outputs) {
+                if (!append_leaf_entry(output.note_commitment,
+                                       shielded::registry::BuildDirectSendAccountLeaf(output))) {
+                    return std::nullopt;
+                }
+            }
+            break;
+        }
         case shielded::v2::TransactionFamily::V2_LIFECYCLE:
             break;
         case shielded::v2::TransactionFamily::V2_INGRESS_BATCH: {
@@ -779,6 +834,18 @@ std::vector<uint256> CollectShieldedAnchors(const CShieldedBundle& bundle)
         switch (shielded::v2::GetBundleSemanticFamily(*v2_bundle)) {
         case shielded::v2::TransactionFamily::V2_SEND: {
             const auto& payload = std::get<shielded::v2::SendPayload>(v2_bundle->payload);
+            out.reserve(payload.spends.size() + (payload.spends.empty() ? 0 : 1));
+            if (!payload.spends.empty()) {
+                out.push_back(payload.spend_anchor);
+            }
+            for (const auto& spend : payload.spends) {
+                out.push_back(spend.merkle_anchor);
+            }
+            break;
+        }
+        case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+            const auto& payload =
+                std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
             out.reserve(payload.spends.size() + (payload.spends.empty() ? 0 : 1));
             if (!payload.spends.empty()) {
                 out.push_back(payload.spend_anchor);
@@ -890,6 +957,8 @@ std::optional<CAmount> TryGetShieldedStateValueBalance(const CShieldedBundle& bu
     switch (shielded::v2::GetBundleSemanticFamily(*v2_bundle)) {
     case shielded::v2::TransactionFamily::V2_SEND:
         return std::get<shielded::v2::SendPayload>(v2_bundle->payload).value_balance;
+    case shielded::v2::V2_SPEND_PATH_RECOVERY:
+        return std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload).fee;
     case shielded::v2::TransactionFamily::V2_LIFECYCLE:
         return CAmount{0};
     case shielded::v2::TransactionFamily::V2_INGRESS_BATCH: {
@@ -940,6 +1009,8 @@ CAmount GetShieldedTxValueBalance(const CShieldedBundle& bundle)
     switch (shielded::v2::GetBundleSemanticFamily(*v2_bundle)) {
     case shielded::v2::TransactionFamily::V2_SEND:
         return std::get<shielded::v2::SendPayload>(v2_bundle->payload).value_balance;
+    case shielded::v2::V2_SPEND_PATH_RECOVERY:
+        return std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload).fee;
     case shielded::v2::TransactionFamily::V2_LIFECYCLE:
         return 0;
     case shielded::v2::TransactionFamily::V2_INGRESS_BATCH:
@@ -1020,6 +1091,13 @@ ShieldedResourceUsage GetShieldedResourceUsage(const CShieldedBundle& bundle)
         usage.verify_units =
             static_cast<uint64_t>(payload.spends.size()) * spend_verify_units +
             static_cast<uint64_t>(payload.outputs.size()) * SHIELDED_VERIFY_UNITS_PER_DIRECT_OUTPUT;
+        usage.scan_units = payload.outputs.size();
+        usage.tree_update_units = payload.spends.size() + payload.outputs.size();
+        break;
+    }
+    case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+        const auto& payload =
+            std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle.payload);
         usage.scan_units = payload.outputs.size();
         usage.tree_update_units = payload.spends.size() + payload.outputs.size();
         break;

--- a/src/shielded/v2_bundle.cpp
+++ b/src/shielded/v2_bundle.cpp
@@ -31,6 +31,8 @@ constexpr std::string_view TAG_RESERVE_DELTA{"BTX_ShieldedV2_Reserve_Delta_V1"};
 constexpr std::string_view TAG_RESERVE_DELTA_LEAF{"BTX_ShieldedV2_Reserve_Delta_Leaf_V1"};
 constexpr std::string_view TAG_RESERVE_DELTA_NODE{"BTX_ShieldedV2_Reserve_Delta_Node_V1"};
 constexpr std::string_view TAG_SEND_PAYLOAD{"BTX_ShieldedV2_Send_Payload_V1"};
+constexpr std::string_view TAG_SPEND_PATH_RECOVERY_PAYLOAD{
+    "BTX_ShieldedV2_Spend_Path_Recovery_Payload_V1"};
 constexpr std::string_view TAG_INGRESS_PAYLOAD{"BTX_ShieldedV2_Ingress_Payload_V1"};
 constexpr std::string_view TAG_EGRESS_PAYLOAD{"BTX_ShieldedV2_Egress_Payload_V1"};
 constexpr std::string_view TAG_REBALANCE_PAYLOAD{"BTX_ShieldedV2_Rebalance_Payload_V1"};
@@ -275,10 +277,22 @@ template <typename T>
 [[nodiscard]] bool ProofEnvelopeMatchesFamily(TransactionFamily family, const ProofEnvelope& envelope)
 {
     proof::ProofStatement statement;
-    statement.domain = (family == TransactionFamily::V2_SEND ||
-                        family == TransactionFamily::V2_LIFECYCLE)
-        ? proof::VerificationDomain::DIRECT_SPEND
-        : proof::VerificationDomain::BATCH_SETTLEMENT;
+    switch (family) {
+    case TransactionFamily::V2_SEND:
+    case TransactionFamily::V2_LIFECYCLE:
+        statement.domain = proof::VerificationDomain::DIRECT_SPEND;
+        break;
+    case V2_SPEND_PATH_RECOVERY:
+        statement.domain = proof::VerificationDomain::SPEND_PATH_RECOVERY;
+        break;
+    case TransactionFamily::V2_INGRESS_BATCH:
+    case TransactionFamily::V2_EGRESS_BATCH:
+    case TransactionFamily::V2_REBALANCE:
+    case TransactionFamily::V2_SETTLEMENT_ANCHOR:
+    case TransactionFamily::V2_GENERIC:
+        statement.domain = proof::VerificationDomain::BATCH_SETTLEMENT;
+        break;
+    }
     statement.envelope = envelope;
     if (!statement.IsValid()) {
         return false;
@@ -293,6 +307,14 @@ template <typename T>
                 envelope.proof_kind == ProofKind::GENERIC_OPAQUE) &&
                (envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
                 IsGenericShieldedSettlementBindingKind(envelope.settlement_binding_kind));
+    case V2_SPEND_PATH_RECOVERY:
+        return (envelope.proof_kind == ProofKind::NONE ||
+                envelope.proof_kind == ProofKind::DIRECT_MATRICT ||
+                envelope.proof_kind == ProofKind::DIRECT_SMILE ||
+                envelope.proof_kind == ProofKind::GENERIC_SMILE ||
+                envelope.proof_kind == ProofKind::GENERIC_OPAQUE) &&
+               (envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
+                IsGenericPostforkSettlementBindingKind(envelope.settlement_binding_kind));
     case TransactionFamily::V2_LIFECYCLE:
         return envelope.proof_kind == ProofKind::NONE &&
                (envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
@@ -778,6 +800,40 @@ bool SendPayload::IsValid() const
     return IsNonNullAndUnique(MakeSpan(note_commitments));
 }
 
+bool SpendPathRecoveryPayload::IsValid() const
+{
+    const Span<const OutputDescription> output_span = MakeSpan(outputs);
+    if (version != WIRE_VERSION ||
+        spend_anchor.IsNull() ||
+        spends.empty() || spends.size() > MAX_DIRECT_SPENDS ||
+        outputs.empty() || outputs.size() > MAX_DIRECT_OUTPUTS ||
+        !AllValid(output_span) ||
+        !MoneyRange(fee) || fee < 0) {
+        return false;
+    }
+
+    std::vector<uint256> nullifiers;
+    nullifiers.reserve(spends.size());
+    for (const SpendDescription& spend : spends) {
+        if (!spend.IsValid() ||
+            spend.note_commitment.IsNull() ||
+            spend.merkle_anchor != spend_anchor) {
+            return false;
+        }
+        nullifiers.push_back(spend.nullifier);
+    }
+    if (!IsNonNullAndUnique(MakeSpan(nullifiers))) {
+        return false;
+    }
+
+    std::vector<uint256> note_commitments;
+    note_commitments.reserve(outputs.size());
+    for (const OutputDescription& output : outputs) {
+        note_commitments.push_back(output.note_commitment);
+    }
+    return IsNonNullAndUnique(MakeSpan(note_commitments));
+}
+
 bool LifecyclePayload::IsValid() const
 {
     if (version != WIRE_VERSION ||
@@ -1029,6 +1085,7 @@ bool GenericOpaquePayloadEnvelope::IsValid() const
 TransactionFamily GetPayloadFamily(const FamilyPayload& payload)
 {
     if (std::holds_alternative<SendPayload>(payload)) return TransactionFamily::V2_SEND;
+    if (std::holds_alternative<SpendPathRecoveryPayload>(payload)) return V2_SPEND_PATH_RECOVERY;
     if (std::holds_alternative<LifecyclePayload>(payload)) return TransactionFamily::V2_LIFECYCLE;
     if (std::holds_alternative<IngressBatchPayload>(payload)) return TransactionFamily::V2_INGRESS_BATCH;
     if (std::holds_alternative<EgressBatchPayload>(payload)) return TransactionFamily::V2_EGRESS_BATCH;
@@ -1171,6 +1228,7 @@ SettlementBindingKind GetWireSettlementBindingKindForValidationHeight(
 
     switch (semantic_family) {
     case TransactionFamily::V2_SEND:
+    case V2_SPEND_PATH_RECOVERY:
     case TransactionFamily::V2_LIFECYCLE:
     case TransactionFamily::V2_INGRESS_BATCH:
     case TransactionFamily::V2_EGRESS_BATCH:
@@ -2253,6 +2311,20 @@ void ApplyCanonicalOpaquePayloadPadding(GenericOpaquePayloadEnvelope& envelope)
         }
         break;
     }
+    case V2_SPEND_PATH_RECOVERY: {
+        const auto& recovery = std::get<SpendPathRecoveryPayload>(payload);
+        envelope.spend_anchor = recovery.spend_anchor;
+        envelope.fee = recovery.fee;
+        envelope.spends.reserve(recovery.spends.size());
+        for (const auto& spend : recovery.spends) {
+            envelope.spends.push_back(MakeGenericSpendRecord(spend));
+        }
+        envelope.outputs.reserve(recovery.outputs.size());
+        for (const auto& output : recovery.outputs) {
+            envelope.outputs.push_back(MakeGenericOutputRecord(output));
+        }
+        break;
+    }
     case TransactionFamily::V2_LIFECYCLE: {
         const auto& lifecycle = std::get<LifecyclePayload>(payload);
         envelope.transparent_binding_digest = lifecycle.transparent_binding_digest;
@@ -2347,6 +2419,33 @@ void ApplyCanonicalOpaquePayloadPadding(GenericOpaquePayloadEnvelope& envelope)
            envelope.imported_adapter_ids.empty() &&
            envelope.proof_receipt_ids.empty() &&
            envelope.batch_statement_digests.empty();
+}
+
+[[nodiscard]] bool EnvelopeUsesOnlySpendPathRecoverySections(
+    const GenericOpaquePayloadEnvelope& envelope)
+{
+    return envelope.account_registry_anchor.IsNull() &&
+           envelope.settlement_anchor.IsNull() &&
+           envelope.ingress_root.IsNull() &&
+           envelope.l2_credit_root.IsNull() &&
+           envelope.aggregate_reserve_commitment.IsNull() &&
+           envelope.aggregate_fee_commitment.IsNull() &&
+           envelope.output_binding_digest.IsNull() &&
+           envelope.egress_root.IsNull() &&
+           envelope.settlement_binding_digest.IsNull() &&
+           envelope.batch_statement_digest.IsNull() &&
+           envelope.anchored_netting_manifest_id.IsNull() &&
+           envelope.transparent_binding_digest.IsNull() &&
+           envelope.lifecycle_controls.empty() &&
+           envelope.ingress_leaves.empty() &&
+           envelope.reserve_deltas.empty() &&
+           !envelope.allow_transparent_unwrap &&
+           !envelope.has_netting_manifest &&
+           envelope.imported_claim_ids.empty() &&
+           envelope.imported_adapter_ids.empty() &&
+           envelope.proof_receipt_ids.empty() &&
+           envelope.batch_statement_digests.empty() &&
+           envelope.value_balance == 0;
 }
 
 [[nodiscard]] bool EnvelopeUsesOnlyLifecycleSections(const GenericOpaquePayloadEnvelope& envelope)
@@ -2507,6 +2606,35 @@ void ApplyCanonicalOpaquePayloadPadding(GenericOpaquePayloadEnvelope& envelope)
         payload.output_note_class = *note_class;
         payload.output_scan_domain = *scan_domain;
         payload.output_encoding = DeriveGenericSendOutputEncoding(payload);
+        if (!payload.IsValid()) {
+            return std::nullopt;
+        }
+        return payload;
+    }
+    case V2_SPEND_PATH_RECOVERY: {
+        if (!EnvelopeUsesOnlySpendPathRecoverySections(envelope)) {
+            return std::nullopt;
+        }
+        SpendPathRecoveryPayload payload;
+        payload.spend_anchor = envelope.spend_anchor;
+        payload.fee = envelope.fee;
+        payload.spends.reserve(envelope.spends.size());
+        for (const auto& spend_record : envelope.spends) {
+            SpendDescription spend;
+            spend.nullifier = spend_record.nullifier;
+            spend.merkle_anchor = envelope.spend_anchor;
+            spend.account_leaf_commitment = spend_record.account_leaf_commitment;
+            spend.account_registry_proof = spend_record.account_registry_proof;
+            spend.note_commitment = spend_record.note_commitment;
+            spend.value_commitment = spend_record.value_commitment;
+            payload.spends.push_back(std::move(spend));
+        }
+        payload.outputs.reserve(envelope.outputs.size());
+        for (const auto& output_record : envelope.outputs) {
+            auto output = MaterializeOutputDescription(output_record);
+            if (!output.has_value()) return std::nullopt;
+            payload.outputs.push_back(std::move(*output));
+        }
         if (!payload.IsValid()) {
             return std::nullopt;
         }
@@ -2734,6 +2862,8 @@ namespace {
     switch (GetPayloadFamily(payload)) {
     case TransactionFamily::V2_SEND:
         return std::get<SendPayload>(payload).IsValid();
+    case V2_SPEND_PATH_RECOVERY:
+        return std::get<SpendPathRecoveryPayload>(payload).IsValid();
     case TransactionFamily::V2_LIFECYCLE:
         return std::get<LifecyclePayload>(payload).IsValid();
     case TransactionFamily::V2_INGRESS_BATCH:
@@ -2759,7 +2889,9 @@ namespace {
             return {TransactionFamily::V2_SEND, TransactionFamily::V2_LIFECYCLE};
         }
         if (envelope.settlement_binding_kind == SettlementBindingKind::GENERIC_POSTFORK) {
-            return {TransactionFamily::V2_SEND, TransactionFamily::V2_LIFECYCLE};
+            return {TransactionFamily::V2_SEND,
+                    TransactionFamily::V2_LIFECYCLE,
+                    V2_SPEND_PATH_RECOVERY};
         }
         if (envelope.settlement_binding_kind == SettlementBindingKind::GENERIC_SHIELDED) {
             return {TransactionFamily::V2_SEND};
@@ -2989,7 +3121,8 @@ TransactionBundleWireView BuildTransactionBundleWireView(const TransactionBundle
     uint32_t proof_padding_offset_base = bundle.proof_shards.empty()
         ? 0
         : bundle.proof_shards.front().proof_payload_offset;
-    if (GetPayloadFamily(bundle.payload) == TransactionFamily::V2_SEND &&
+    if ((GetPayloadFamily(bundle.payload) == TransactionFamily::V2_SEND ||
+         GetPayloadFamily(bundle.payload) == V2_SPEND_PATH_RECOVERY) &&
         bundle.proof_shards.empty()) {
         proof_padding_offset_base = static_cast<uint32_t>(bundle.proof_payload.size());
     }
@@ -3046,6 +3179,7 @@ bool NormalizeGenericWireTransactionBundle(TransactionBundle& bundle,
             proof_padding_offset_base = static_cast<uint32_t>(*parsed_size);
         }
         break;
+    case V2_SPEND_PATH_RECOVERY:
     case TransactionFamily::V2_LIFECYCLE:
         proof_padding_offset_base = 0;
         break;
@@ -3160,6 +3294,7 @@ std::vector<uint8_t> DeserializeProofPayloadBytes(Span<const uint8_t> bytes,
             used_size = *parsed_size;
         }
         break;
+    case V2_SPEND_PATH_RECOVERY:
     case TransactionFamily::V2_LIFECYCLE:
         used_size = 0;
         if (!TrailingBytesAreZero(bytes, used_size)) {
@@ -3257,6 +3392,26 @@ bool TransactionBundleOutputChunksAreCanonical(const TransactionBundle& bundle)
 
     switch (semantic_family) {
     case TransactionFamily::V2_SEND: {
+        if (UseDerivedGenericOutputChunkWire(bundle.header, bundle.payload)) {
+            auto derived_output_chunks = BuildDerivedGenericOutputChunks(bundle.payload);
+            return derived_output_chunks.has_value() &&
+                   derived_output_chunks->size() == bundle.output_chunks.size() &&
+                   std::equal(bundle.output_chunks.begin(),
+                              bundle.output_chunks.end(),
+                              derived_output_chunks->begin(),
+                              [](const OutputChunkDescriptor& lhs, const OutputChunkDescriptor& rhs) {
+                                  return lhs.version == rhs.version &&
+                                         lhs.scan_domain == rhs.scan_domain &&
+                                         lhs.first_output_index == rhs.first_output_index &&
+                                         lhs.output_count == rhs.output_count &&
+                                         lhs.ciphertext_bytes == rhs.ciphertext_bytes &&
+                                         lhs.scan_hint_commitment == rhs.scan_hint_commitment &&
+                                         lhs.ciphertext_commitment == rhs.ciphertext_commitment;
+                              });
+        }
+        return bundle.output_chunks.empty();
+    }
+    case V2_SPEND_PATH_RECOVERY: {
         if (UseDerivedGenericOutputChunkWire(bundle.header, bundle.payload)) {
             auto derived_output_chunks = BuildDerivedGenericOutputChunks(bundle.payload);
             return derived_output_chunks.has_value() &&
@@ -3411,6 +3566,7 @@ bool UseDerivedGenericOutputChunkWire(const TransactionHeader& header, const Fam
 
     switch (GetPayloadFamily(payload)) {
     case TransactionFamily::V2_SEND:
+    case V2_SPEND_PATH_RECOVERY:
     case TransactionFamily::V2_INGRESS_BATCH:
     case TransactionFamily::V2_EGRESS_BATCH:
     case TransactionFamily::V2_REBALANCE:
@@ -3429,6 +3585,18 @@ std::optional<std::vector<OutputChunkDescriptor>> BuildDerivedGenericOutputChunk
     switch (GetPayloadFamily(payload)) {
     case TransactionFamily::V2_SEND: {
         const auto& outputs = std::get<SendPayload>(payload).outputs;
+        if (outputs.empty()) {
+            return output_chunks;
+        }
+        auto chunk = BuildOutputChunkDescriptor({outputs.data(), outputs.size()}, /*first_output_index=*/0);
+        if (!chunk.has_value()) {
+            return std::nullopt;
+        }
+        output_chunks.push_back(std::move(*chunk));
+        return output_chunks;
+    }
+    case V2_SPEND_PATH_RECOVERY: {
+        const auto& outputs = std::get<SpendPathRecoveryPayload>(payload).outputs;
         if (outputs.empty()) {
             return output_chunks;
         }
@@ -3725,6 +3893,23 @@ bool TransactionBundle::IsValid() const
         }
         break;
     }
+    case V2_SPEND_PATH_RECOVERY: {
+        const SpendPathRecoveryPayload& recovery = std::get<SpendPathRecoveryPayload>(payload);
+        if (!recovery.IsValid() ||
+            !OutputsBindCanonicalSmileAccounts(MakeSpan(recovery.outputs)) ||
+            !proof_shards.empty() ||
+            header.netting_manifest_version != 0) {
+            return false;
+        }
+        if (header.proof_envelope.proof_kind == ProofKind::NONE) {
+            if (!proof_payload.empty()) {
+                return false;
+            }
+        } else if (proof_payload.empty()) {
+            return false;
+        }
+        break;
+    }
     case TransactionFamily::V2_LIFECYCLE: {
         const LifecyclePayload& lifecycle = std::get<LifecyclePayload>(payload);
         if (!lifecycle.IsValid() ||
@@ -3843,6 +4028,11 @@ uint256 ComputeSendPayloadDigest(const SendPayload& payload)
     return HashTaggedObject(TAG_SEND_PAYLOAD, payload);
 }
 
+uint256 ComputeSpendPathRecoveryPayloadDigest(const SpendPathRecoveryPayload& payload)
+{
+    return HashTaggedObject(TAG_SPEND_PATH_RECOVERY_PAYLOAD, payload);
+}
+
 uint256 ComputeLifecyclePayloadDigest(const LifecyclePayload& payload)
 {
     return HashTaggedObject(TAG_LIFECYCLE_PAYLOAD, payload);
@@ -3873,6 +4063,8 @@ uint256 ComputePayloadDigest(const FamilyPayload& payload)
     switch (GetPayloadFamily(payload)) {
     case TransactionFamily::V2_SEND:
         return ComputeSendPayloadDigest(std::get<SendPayload>(payload));
+    case V2_SPEND_PATH_RECOVERY:
+        return ComputeSpendPathRecoveryPayloadDigest(std::get<SpendPathRecoveryPayload>(payload));
     case TransactionFamily::V2_LIFECYCLE:
         return ComputeLifecyclePayloadDigest(std::get<LifecyclePayload>(payload));
     case TransactionFamily::V2_INGRESS_BATCH:

--- a/src/shielded/v2_bundle.h
+++ b/src/shielded/v2_bundle.h
@@ -781,6 +781,69 @@ struct SendPayload
     }
 };
 
+struct SpendPathRecoveryPayload
+{
+    uint8_t version{WIRE_VERSION};
+    uint256 spend_anchor;
+    std::vector<SpendDescription> spends;
+    std::vector<OutputDescription> outputs;
+    CAmount fee{0};
+
+    [[nodiscard]] bool IsValid() const;
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        detail::SerializeVersion(s,
+                                 version,
+                                 "SpendPathRecoveryPayload::Serialize invalid version");
+        ::Serialize(s, spend_anchor);
+        detail::SerializeBoundedCompactSize(
+            s,
+            spends.size(),
+            MAX_DIRECT_SPENDS,
+            "SpendPathRecoveryPayload::Serialize oversized spends");
+        for (const SpendDescription& spend : spends) {
+            ::Serialize(s, spend);
+        }
+        detail::SerializeBoundedCompactSize(
+            s,
+            outputs.size(),
+            MAX_DIRECT_OUTPUTS,
+            "SpendPathRecoveryPayload::Serialize oversized outputs");
+        for (const OutputDescription& output : outputs) {
+            ::Serialize(s, output);
+        }
+        ::Serialize(s, fee);
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        detail::UnserializeVersion(s,
+                                   version,
+                                   "SpendPathRecoveryPayload::Unserialize invalid version");
+        ::Unserialize(s, spend_anchor);
+        const uint64_t spend_count = detail::UnserializeBoundedCompactSize(
+            s,
+            MAX_DIRECT_SPENDS,
+            "SpendPathRecoveryPayload::Unserialize oversized spends");
+        spends.assign(spend_count, {});
+        for (SpendDescription& spend : spends) {
+            ::Unserialize(s, spend);
+        }
+        const uint64_t output_count = detail::UnserializeBoundedCompactSize(
+            s,
+            MAX_DIRECT_OUTPUTS,
+            "SpendPathRecoveryPayload::Unserialize oversized outputs");
+        outputs.assign(output_count, {});
+        for (OutputDescription& output : outputs) {
+            ::Unserialize(s, output);
+        }
+        ::Unserialize(s, fee);
+    }
+};
+
 struct LifecyclePayload
 {
     uint8_t version{WIRE_VERSION};
@@ -1393,6 +1456,7 @@ struct GenericOpaquePayloadEnvelope
 struct TransactionBundle;
 using FamilyPayload =
     std::variant<SendPayload,
+                 SpendPathRecoveryPayload,
                  LifecyclePayload,
                  IngressBatchPayload,
                  EgressBatchPayload,
@@ -1597,6 +1661,9 @@ void SerializePayload(Stream& s, const FamilyPayload& payload, TransactionFamily
     case TransactionFamily::V2_SEND:
         ::Serialize(s, std::get<SendPayload>(payload));
         break;
+    case V2_SPEND_PATH_RECOVERY:
+        ::Serialize(s, std::get<SpendPathRecoveryPayload>(payload));
+        break;
     case TransactionFamily::V2_LIFECYCLE:
         ::Serialize(s, std::get<LifecyclePayload>(payload));
         break;
@@ -1623,6 +1690,11 @@ FamilyPayload DeserializePayload(Stream& s, TransactionFamily family)
     switch (family) {
     case TransactionFamily::V2_SEND: {
         SendPayload payload_obj;
+        ::Unserialize(s, payload_obj);
+        return payload_obj;
+    }
+    case V2_SPEND_PATH_RECOVERY: {
+        SpendPathRecoveryPayload payload_obj;
         ::Unserialize(s, payload_obj);
         return payload_obj;
     }
@@ -1665,6 +1737,7 @@ FamilyPayload DeserializePayload(Stream& s, TransactionFamily family)
 [[nodiscard]] bool ReserveDeltaSetIsCanonical(Span<const ReserveDelta> deltas);
 
 [[nodiscard]] uint256 ComputeSendPayloadDigest(const SendPayload& payload);
+[[nodiscard]] uint256 ComputeSpendPathRecoveryPayloadDigest(const SpendPathRecoveryPayload& payload);
 [[nodiscard]] uint256 ComputeLifecyclePayloadDigest(const LifecyclePayload& payload);
 [[nodiscard]] uint256 ComputeIngressBatchPayloadDigest(const IngressBatchPayload& payload);
 [[nodiscard]] uint256 ComputeEgressBatchPayloadDigest(const EgressBatchPayload& payload);

--- a/src/shielded/v2_proof.cpp
+++ b/src/shielded/v2_proof.cpp
@@ -37,6 +37,8 @@ constexpr std::string_view TAG_DIRECT_VALUE_COMMIT{"BTX_ShieldedV2_Direct_Value_
 constexpr std::string_view TAG_V2_SEND_EXTENSION{"BTX_ShieldedV2_Send_Extension_V1"};
 constexpr std::string_view TAG_V2_SEND_STATEMENT{"BTX_ShieldedV2_Send_Statement_V1"};
 constexpr std::string_view TAG_V2_SEND_STATEMENT_CHAIN_BOUND{"BTX_ShieldedV2_Send_Statement_V2"};
+constexpr std::string_view TAG_SPEND_PATH_RECOVERY_STATEMENT{
+    "BTX_ShieldedV2_SpendPathRecovery_Statement_V1"};
 constexpr std::string_view TAG_RECEIPT_VALUE_COMMIT{"BTX_ShieldedV2_Receipt_Value_Commit_V1"};
 constexpr std::string_view TAG_CLAIM_VALUE_COMMIT{"BTX_ShieldedV2_Claim_Value_Commit_V1"};
 constexpr std::string_view TAG_NATIVE_BATCH_STATEMENT{"BTX_ShieldedV2_Native_Batch_Statement_V1"};
@@ -259,6 +261,36 @@ DeserializeProofReceiptMetadata(Span<const uint8_t> bytes)
     return accounts;
 }
 
+[[nodiscard]] std::optional<std::vector<smile2::CompactPublicAccount>> ReconstructSmileOutputAccounts(
+    const SpendPathRecoveryPayload& payload,
+    Span<const smile2::BDLOPCommitment> output_coins)
+{
+    if (payload.outputs.size() != output_coins.size()) {
+        return std::nullopt;
+    }
+
+    std::vector<smile2::CompactPublicAccount> accounts;
+    accounts.reserve(payload.outputs.size());
+    for (size_t output_index = 0; output_index < payload.outputs.size(); ++output_index) {
+        const auto key_data = ResolveOutputPublicKeyData(payload.outputs[output_index]);
+        if (!key_data.has_value() || !HasCanonicalSmileOutputCoin(output_coins[output_index])) {
+            return std::nullopt;
+        }
+        auto reconstructed = smile2::BuildCompactPublicAccountFromPublicParts(
+            *key_data,
+            output_coins[output_index]);
+        if (!reconstructed.has_value() ||
+            smile2::ComputeCompactPublicAccountHash(*reconstructed) !=
+                payload.outputs[output_index].note_commitment ||
+            smile2::ComputeSmileOutputCoinHash(output_coins[output_index]) !=
+                payload.outputs[output_index].value_commitment) {
+            return std::nullopt;
+        }
+        accounts.push_back(std::move(*reconstructed));
+    }
+    return accounts;
+}
+
 [[nodiscard]] std::optional<std::vector<smile2::BDLOPCommitment>> CollectSmileOutputCoins(
     const V2SendWitness& witness,
     size_t expected_output_count)
@@ -374,6 +406,57 @@ DeserializeProofReceiptMetadata(Span<const uint8_t> bytes)
 
     descriptor.statement_digest = statement.envelope.statement_digest;
     // SMILE proof metadata: just store the proof size.
+    DataStream meta;
+    ::Serialize(meta, COMPACTSIZE(static_cast<uint64_t>(smile_bytes.size())));
+    descriptor.proof_metadata = ToByteVector(meta);
+    descriptor.proof_payload_offset = 0;
+    descriptor.proof_payload_size = payload_size;
+    return descriptor;
+}
+
+[[nodiscard]] ProofShardDescriptor BuildSmileDirectProofShard(const std::vector<uint8_t>& smile_bytes,
+                                                              const SpendPathRecoveryPayload& payload,
+                                                              Span<const uint256> smile_output_coin_hashes,
+                                                              const ProofStatement& statement,
+                                                              uint32_t payload_size)
+{
+    ProofShardDescriptor descriptor;
+    descriptor.first_leaf_index = 0;
+    descriptor.leaf_count = static_cast<uint32_t>(payload.spends.size());
+
+    HashWriter leaf_hw;
+    leaf_hw << std::string{TAG_DIRECT_LEAF_SUBROOT}
+            << smile_bytes
+            << payload.spend_anchor;
+    for (const auto& spend : payload.spends) {
+        leaf_hw << spend.merkle_anchor
+                << spend.nullifier
+                << spend.note_commitment;
+    }
+    descriptor.leaf_subroot = leaf_hw.GetSHA256();
+
+    HashWriter null_hw;
+    null_hw << std::string{TAG_DIRECT_NULLIFIER_COMMIT}
+            << smile_bytes
+            << payload.spend_anchor;
+    for (const auto& spend : payload.spends) {
+        null_hw << spend.nullifier;
+    }
+    descriptor.nullifier_commitment = null_hw.GetSHA256();
+
+    HashWriter value_hw;
+    value_hw << std::string{TAG_DIRECT_VALUE_COMMIT}
+             << smile_bytes
+             << payload.fee;
+    for (const auto& output : payload.outputs) {
+        value_hw << static_cast<uint8_t>(output.note_class)
+                 << output.note_commitment
+                 << output.value_commitment;
+    }
+    value_hw << std::vector<uint256>{smile_output_coin_hashes.begin(), smile_output_coin_hashes.end()};
+    descriptor.value_commitment = value_hw.GetSHA256();
+
+    descriptor.statement_digest = statement.envelope.statement_digest;
     DataStream meta;
     ::Serialize(meta, COMPACTSIZE(static_cast<uint64_t>(smile_bytes.size())));
     descriptor.proof_metadata = ToByteVector(meta);
@@ -615,6 +698,7 @@ bool IsValidVerificationDomain(VerificationDomain domain)
     switch (domain) {
     case VerificationDomain::DIRECT_SPEND:
     case VerificationDomain::BATCH_SETTLEMENT:
+    case VerificationDomain::SPEND_PATH_RECOVERY:
         return true;
     }
     return false;
@@ -639,6 +723,8 @@ const char* GetVerificationDomainName(VerificationDomain domain)
         return "direct_spend";
     case VerificationDomain::BATCH_SETTLEMENT:
         return "batch_settlement";
+    case VerificationDomain::SPEND_PATH_RECOVERY:
+        return "spend_path_recovery";
     }
     return "unknown";
 }
@@ -671,11 +757,23 @@ bool ProofStatement::IsValid() const
     }
 
     if (envelope.proof_kind == ProofKind::NONE) {
-        return domain == VerificationDomain::DIRECT_SPEND &&
-               EnvelopeHasNoProofComponents(envelope) &&
-               (envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
-                shielded::v2::IsGenericShieldedSettlementBindingKind(envelope.settlement_binding_kind)) &&
-               envelope.statement_digest.IsNull();
+        const bool no_components = EnvelopeHasNoProofComponents(envelope);
+        if (!no_components || !envelope.statement_digest.IsNull()) {
+            return false;
+        }
+        switch (domain) {
+        case VerificationDomain::DIRECT_SPEND:
+            return envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
+                   shielded::v2::IsGenericShieldedSettlementBindingKind(
+                       envelope.settlement_binding_kind);
+        case VerificationDomain::SPEND_PATH_RECOVERY:
+            return envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
+                   shielded::v2::IsGenericPostforkSettlementBindingKind(
+                       envelope.settlement_binding_kind);
+        case VerificationDomain::BATCH_SETTLEMENT:
+            return false;
+        }
+        return false;
     }
 
     if (envelope.statement_digest.IsNull()) {
@@ -691,6 +789,21 @@ bool ProofStatement::IsValid() const
                envelope.balance_proof_kind != ProofComponentKind::NONE &&
                (envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
                 shielded::v2::IsGenericShieldedSettlementBindingKind(envelope.settlement_binding_kind));
+    case VerificationDomain::SPEND_PATH_RECOVERY:
+        if (envelope.proof_kind == ProofKind::NONE) {
+            return EnvelopeHasNoProofComponents(envelope) &&
+                   (envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
+                    shielded::v2::IsGenericPostforkSettlementBindingKind(
+                        envelope.settlement_binding_kind));
+        }
+        return (envelope.proof_kind == ProofKind::DIRECT_MATRICT ||
+                IsDirectSmileLikeProofKind(envelope.proof_kind)) &&
+               envelope.membership_proof_kind != ProofComponentKind::NONE &&
+               envelope.amount_proof_kind != ProofComponentKind::NONE &&
+               envelope.balance_proof_kind != ProofComponentKind::NONE &&
+               (envelope.settlement_binding_kind == SettlementBindingKind::NONE ||
+                shielded::v2::IsGenericPostforkSettlementBindingKind(
+                    envelope.settlement_binding_kind));
     case VerificationDomain::BATCH_SETTLEMENT:
         if (envelope.proof_kind == ProofKind::GENERIC_OPAQUE) {
             const bool no_components = EnvelopeHasNoProofComponents(envelope);
@@ -861,6 +974,30 @@ bool V2SendContext::IsValid(size_t expected_input_count, size_t expected_output_
         return expected_input_count == 0 &&
                !witness.use_smile &&
                material.proof_payload.empty();
+    }
+
+    if (witness.use_smile) {
+        if (!IsDirectSmileLikeProofKind(material.statement.envelope.proof_kind)) {
+            return false;
+        }
+    } else if (material.statement.envelope.proof_kind != ProofKind::DIRECT_MATRICT) {
+        return false;
+    }
+
+    return SerializeToBytes(witness) == material.proof_payload;
+}
+
+bool SpendPathRecoveryContext::IsValid(size_t expected_input_count, size_t expected_output_count) const
+{
+    if (material.statement.domain != VerificationDomain::SPEND_PATH_RECOVERY ||
+        material.payload_location != PayloadLocation::INLINE_WITNESS ||
+        !witness.IsValid(expected_input_count, expected_output_count) ||
+        !material.IsValid(expected_input_count)) {
+        return false;
+    }
+
+    if (material.statement.envelope.proof_kind == ProofKind::NONE) {
+        return false;
     }
 
     if (witness.use_smile) {
@@ -1059,6 +1196,29 @@ uint256 ComputeV2SendExtensionDigest(const CTransaction& tx)
     return hw.GetSHA256();
 }
 
+uint256 ComputeSpendPathRecoveryStatementDigest(const CTransaction& tx)
+{
+    if (!tx.HasShieldedBundle()) return uint256{};
+    const CShieldedBundle& shielded_bundle = tx.GetShieldedBundle();
+    if (!shielded_bundle.HasV2Bundle()) return uint256{};
+    const auto* v2_bundle = shielded_bundle.GetV2Bundle();
+    if (v2_bundle == nullptr ||
+        !BundleHasSemanticFamily(*v2_bundle, V2_SPEND_PATH_RECOVERY)) {
+        return uint256{};
+    }
+
+    CMutableTransaction tx_stripped{tx};
+    if (!tx_stripped.shielded_bundle.v2_bundle.has_value()) return uint256{};
+    auto& stripped_v2_bundle = *tx_stripped.shielded_bundle.v2_bundle;
+    stripped_v2_bundle.proof_payload.clear();
+    stripped_v2_bundle.header.proof_envelope.statement_digest = uint256{};
+
+    const CTransaction immutable_tx_stripped{tx_stripped};
+    HashWriter hw;
+    hw << std::string{TAG_SPEND_PATH_RECOVERY_STATEMENT} << TX_WITH_WITNESS(immutable_tx_stripped);
+    return hw.GetSHA256();
+}
+
 ProofStatement DescribeV2SendStatement(const CTransaction& tx,
                                        std::optional<uint256> extension_digest_override)
 {
@@ -1148,6 +1308,47 @@ ProofStatement DescribeV2SendStatement(const CTransaction& tx,
                                                                                       &consensus,
                                                                                       validation_height),
                                       digest,
+                                      extension_digest);
+    return statement;
+}
+
+ProofStatement DescribeSpendPathRecoveryStatement(
+    const CTransaction& tx,
+    std::optional<uint256> extension_digest_override)
+{
+    ProofStatement statement;
+    statement.domain = VerificationDomain::SPEND_PATH_RECOVERY;
+    const auto* v2_bundle = tx.HasShieldedBundle() ? tx.GetShieldedBundle().GetV2Bundle() : nullptr;
+    if (v2_bundle == nullptr ||
+        !BundleHasSemanticFamily(*v2_bundle, V2_SPEND_PATH_RECOVERY)) {
+        statement.envelope.version = 0;
+        return statement;
+    }
+
+    uint256 extension_digest;
+    if (extension_digest_override.has_value()) {
+        extension_digest = *extension_digest_override;
+    } else {
+        extension_digest = v2_bundle->header.proof_envelope.extension_digest;
+    }
+
+    if (v2_bundle->header.proof_envelope.proof_kind == ProofKind::NONE) {
+        statement.envelope = MakeEnvelope(ProofKind::NONE,
+                                          ProofComponentKind::NONE,
+                                          ProofComponentKind::NONE,
+                                          ProofComponentKind::NONE,
+                                          v2_bundle->header.proof_envelope.settlement_binding_kind,
+                                          uint256{},
+                                          extension_digest);
+        return statement;
+    }
+
+    statement.envelope = MakeEnvelope(v2_bundle->header.proof_envelope.proof_kind,
+                                      v2_bundle->header.proof_envelope.membership_proof_kind,
+                                      v2_bundle->header.proof_envelope.amount_proof_kind,
+                                      v2_bundle->header.proof_envelope.balance_proof_kind,
+                                      v2_bundle->header.proof_envelope.settlement_binding_kind,
+                                      ComputeSpendPathRecoveryStatementDigest(tx),
                                       extension_digest);
     return statement;
 }
@@ -1312,6 +1513,43 @@ std::optional<std::shared_ptr<const MatRiCTProof>> ParseLegacyDirectSpendNativeP
     return std::make_shared<MatRiCTProof>(std::move(*parsed));
 }
 
+std::optional<V2SendWitness> ParseInlineDirectWitnessPayload(const std::vector<uint8_t>& proof_payload,
+                                                             size_t expected_input_count,
+                                                             size_t expected_output_count,
+                                                             std::string& reject_reason)
+{
+    if (proof_payload.empty()) {
+        reject_reason = "bad-shielded-proof-missing";
+        return std::nullopt;
+    }
+
+    DataStream ds{proof_payload};
+    V2SendWitness witness;
+    try {
+        ds >> witness;
+    } catch (const std::exception&) {
+        reject_reason = "bad-shielded-proof-encoding";
+        return std::nullopt;
+    }
+    if (!ds.empty()) {
+        reject_reason = "bad-shielded-proof-encoding";
+        return std::nullopt;
+    }
+
+    for (const auto& spend : witness.spends) {
+        if (!shielded::lattice::IsSupportedRingSize(spend.ring_positions.size())) {
+            reject_reason = "bad-shielded-ring-positions";
+            return std::nullopt;
+        }
+    }
+
+    if (!witness.IsValid(expected_input_count, expected_output_count)) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+    return witness;
+}
+
 std::optional<V2SendWitness> ParseV2SendWitness(const shielded::v2::TransactionBundle& bundle,
                                                 std::string& reject_reason)
 {
@@ -1333,36 +1571,31 @@ std::optional<V2SendWitness> ParseV2SendWitness(const shielded::v2::TransactionB
         }
         return witness;
     }
-    if (bundle.proof_payload.empty()) {
-        reject_reason = "bad-shielded-proof-missing";
-        return std::nullopt;
-    }
+    return ParseInlineDirectWitnessPayload(bundle.proof_payload,
+                                          payload.spends.size(),
+                                          payload.outputs.size(),
+                                          reject_reason);
+}
 
-    DataStream ds{bundle.proof_payload};
-    V2SendWitness witness;
-    try {
-        ds >> witness;
-    } catch (const std::exception&) {
-        reject_reason = "bad-shielded-proof-encoding";
-        return std::nullopt;
-    }
-    if (!ds.empty()) {
-        reject_reason = "bad-shielded-proof-encoding";
-        return std::nullopt;
-    }
-
-    for (const auto& spend : witness.spends) {
-        if (!shielded::lattice::IsSupportedRingSize(spend.ring_positions.size())) {
-            reject_reason = "bad-shielded-ring-positions";
-            return std::nullopt;
-        }
-    }
-
-    if (!witness.IsValid(payload.spends.size(), payload.outputs.size())) {
+std::optional<V2SendWitness> ParseSpendPathRecoveryWitness(const shielded::v2::TransactionBundle& bundle,
+                                                           std::string& reject_reason)
+{
+    if (!BundleHasSemanticFamily(bundle, V2_SPEND_PATH_RECOVERY) ||
+        !std::holds_alternative<SpendPathRecoveryPayload>(bundle.payload)) {
         reject_reason = "bad-shielded-proof";
         return std::nullopt;
     }
-    return witness;
+
+    const auto& payload = std::get<SpendPathRecoveryPayload>(bundle.payload);
+    if (bundle.header.proof_envelope.proof_kind == ProofKind::NONE) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+
+    return ParseInlineDirectWitnessPayload(bundle.proof_payload,
+                                          payload.spends.size(),
+                                          payload.outputs.size(),
+                                          reject_reason);
 }
 
 std::optional<std::shared_ptr<const MatRiCTProof>> ParseV2SendNativeProof(
@@ -1553,6 +1786,43 @@ V2SendContext BindV2SendProof(const shielded::v2::TransactionBundle& bundle,
     return context;
 }
 
+SpendPathRecoveryContext BindSpendPathRecoveryProof(const shielded::v2::TransactionBundle& bundle,
+                                                    const ProofStatement& statement,
+                                                    V2SendWitness witness)
+{
+    SpendPathRecoveryContext context;
+    context.material.statement = statement;
+    context.material.payload_location = PayloadLocation::INLINE_WITNESS;
+    context.material.proof_payload = bundle.proof_payload;
+    if (witness.use_smile) {
+        const auto& payload = std::get<SpendPathRecoveryPayload>(bundle.payload);
+        const auto output_coins = CollectSmileOutputCoins(witness, payload.outputs.size());
+        if (!output_coins.has_value()) {
+            context.witness = std::move(witness);
+            return context;
+        }
+        std::vector<uint256> smile_output_coin_hashes;
+        smile_output_coin_hashes.reserve(output_coins->size());
+        for (const auto& coin : *output_coins) {
+            smile_output_coin_hashes.push_back(smile2::ComputeSmileOutputCoinHash(coin));
+        }
+        context.material.proof_shards.push_back(
+            BuildSmileDirectProofShard(witness.smile_proof_bytes,
+                                       payload,
+                                       Span<const uint256>{smile_output_coin_hashes.data(),
+                                                           smile_output_coin_hashes.size()},
+                                       statement,
+                                       static_cast<uint32_t>(bundle.proof_payload.size())));
+    } else {
+        context.material.proof_shards.push_back(
+            BuildLegacyDirectProofShard(witness.native_proof,
+                                        statement,
+                                        static_cast<uint32_t>(bundle.proof_payload.size())));
+    }
+    context.witness = std::move(witness);
+    return context;
+}
+
 std::optional<V2SendContext> ParseV2SendProof(const shielded::v2::TransactionBundle& bundle,
                                               const ProofStatement& statement,
                                               std::string& reject_reason)
@@ -1588,6 +1858,33 @@ std::optional<V2SendContext> ParseV2SendProof(const shielded::v2::TransactionBun
     }
     auto context = BindV2SendProof(bundle, statement, std::move(*witness));
     const auto& payload = std::get<SendPayload>(bundle.payload);
+    if (!context.IsValid(payload.spends.size(), payload.outputs.size())) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+    return context;
+}
+
+std::optional<SpendPathRecoveryContext> ParseSpendPathRecoveryProof(
+    const shielded::v2::TransactionBundle& bundle,
+    const ProofStatement& statement,
+    std::string& reject_reason)
+{
+    if (!BundleHasSemanticFamily(bundle, V2_SPEND_PATH_RECOVERY) ||
+        !std::holds_alternative<SpendPathRecoveryPayload>(bundle.payload)) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+    if (!ProofEnvelopesMatch(bundle.header.proof_envelope, statement.envelope)) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+
+    auto witness = ParseSpendPathRecoveryWitness(bundle, reject_reason);
+    if (!witness.has_value()) return std::nullopt;
+
+    auto context = BindSpendPathRecoveryProof(bundle, statement, std::move(*witness));
+    const auto& payload = std::get<SpendPathRecoveryPayload>(bundle.payload);
     if (!context.IsValid(payload.spends.size(), payload.outputs.size())) {
         reject_reason = "bad-shielded-proof";
         return std::nullopt;
@@ -1676,6 +1973,23 @@ std::optional<std::vector<Nullifier>> ExtractBoundNullifiers(const V2SendContext
         return out;
     }
     return ExtractBoundNullifiers(context.witness.native_proof, expected_input_count, reject_reason);
+}
+
+std::optional<std::vector<Nullifier>> ExtractBoundNullifiers(const SpendPathRecoveryContext& context,
+                                                             size_t expected_input_count,
+                                                             size_t expected_output_count,
+                                                             std::string& reject_reason,
+                                                             bool reject_rice_codec)
+{
+    V2SendContext direct_context;
+    direct_context.material = context.material;
+    direct_context.witness = context.witness;
+    direct_context.material.statement.domain = VerificationDomain::DIRECT_SPEND;
+    return ExtractBoundNullifiers(direct_context,
+                                  expected_input_count,
+                                  expected_output_count,
+                                  reject_reason,
+                                  reject_rice_codec);
 }
 
 std::optional<std::vector<std::vector<uint256>>> BuildLegacyDirectSpendRingMembers(
@@ -1796,6 +2110,74 @@ std::optional<std::vector<std::vector<uint256>>> BuildV2SendRingMembers(
     return ring_members;
 }
 
+std::optional<std::vector<std::vector<uint256>>> BuildSpendPathRecoveryRingMembers(
+    const shielded::v2::TransactionBundle& bundle,
+    const SpendPathRecoveryContext& context,
+    const shielded::ShieldedMerkleTree& tree,
+    std::string& reject_reason)
+{
+    if (!BundleHasSemanticFamily(bundle, V2_SPEND_PATH_RECOVERY) ||
+        !std::holds_alternative<SpendPathRecoveryPayload>(bundle.payload)) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+
+    const auto& payload = std::get<SpendPathRecoveryPayload>(bundle.payload);
+    if (!context.IsValid(payload.spends.size(), payload.outputs.size())) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+
+    std::vector<std::vector<uint256>> ring_members;
+    ring_members.reserve(payload.spends.size());
+    std::unordered_map<uint64_t, uint256> commitment_cache;
+    commitment_cache.reserve(payload.spends.size() *
+                             static_cast<size_t>(shielded::lattice::MAX_RING_SIZE));
+
+    for (size_t spend_index = 0; spend_index < payload.spends.size(); ++spend_index) {
+        const auto& witness_spend = context.witness.spends[spend_index];
+        if (!witness_spend.IsValid()) {
+            reject_reason = "bad-shielded-ring-positions";
+            return std::nullopt;
+        }
+
+        const size_t required_unique_members = static_cast<size_t>(
+            std::min<uint64_t>(tree.Size(), static_cast<uint64_t>(witness_spend.ring_positions.size())));
+        std::set<uint64_t> unique_positions;
+
+        std::vector<uint256> ring;
+        ring.reserve(witness_spend.ring_positions.size());
+        for (const uint64_t pos : witness_spend.ring_positions) {
+            unique_positions.insert(pos);
+            auto cache_it = commitment_cache.find(pos);
+            if (cache_it == commitment_cache.end()) {
+                auto commitment = tree.CommitmentAt(pos);
+                if (!commitment.has_value()) {
+                    LogPrintf("BuildSpendPathRecoveryRingMembers failed: missing commitment at pos=%u tree_size=%u has_index=%d spend_index=%u family=%u\n",
+                              static_cast<unsigned int>(pos),
+                              static_cast<unsigned int>(tree.Size()),
+                              tree.HasCommitmentIndex() ? 1 : 0,
+                              static_cast<unsigned int>(spend_index),
+                              static_cast<unsigned int>(GetBundleSemanticFamily(bundle)));
+                    reject_reason = "bad-shielded-ring-member-position";
+                    return std::nullopt;
+                }
+                cache_it = commitment_cache.emplace(pos, *commitment).first;
+            }
+            ring.push_back(cache_it->second);
+        }
+
+        if (unique_positions.size() < required_unique_members) {
+            reject_reason = "bad-shielded-ring-member-insufficient-diversity";
+            return std::nullopt;
+        }
+
+        ring_members.push_back(std::move(ring));
+    }
+
+    return ring_members;
+}
+
 std::optional<std::vector<std::vector<smile2::wallet::SmileRingMember>>> BuildV2SendSmileRingMembers(
     const shielded::v2::TransactionBundle& bundle,
     const V2SendContext& context,
@@ -1811,6 +2193,101 @@ std::optional<std::vector<std::vector<smile2::wallet::SmileRingMember>>> BuildV2
     }
 
     const auto& payload = std::get<SendPayload>(bundle.payload);
+    if (!context.IsValid(payload.spends.size(), payload.outputs.size()) || !context.witness.use_smile) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+
+    std::vector<std::vector<smile2::wallet::SmileRingMember>> ring_members;
+    ring_members.reserve(payload.spends.size());
+    std::unordered_map<uint64_t, uint256> commitment_cache;
+    commitment_cache.reserve(payload.spends.size() *
+                             static_cast<size_t>(shielded::lattice::MAX_RING_SIZE));
+
+    for (size_t spend_index = 0; spend_index < payload.spends.size(); ++spend_index) {
+        const auto& witness_spend = context.witness.spends[spend_index];
+        if (!witness_spend.IsValid()) {
+            reject_reason = "bad-shielded-ring-positions";
+            return std::nullopt;
+        }
+
+        std::vector<smile2::wallet::SmileRingMember> ring;
+        ring.reserve(witness_spend.ring_positions.size());
+        for (const uint64_t pos : witness_spend.ring_positions) {
+            auto cache_it = commitment_cache.find(pos);
+            if (cache_it == commitment_cache.end()) {
+                auto commitment = tree.CommitmentAt(pos);
+                if (!commitment.has_value()) {
+                    reject_reason = "bad-shielded-ring-member-position";
+                    return std::nullopt;
+                }
+                cache_it = commitment_cache.emplace(pos, *commitment).first;
+            }
+
+            const auto account_it = public_accounts.find(cache_it->second);
+            const auto leaf_it = account_leaf_commitments.find(cache_it->second);
+            if (account_it == public_accounts.end()) {
+                reject_reason = "bad-smile2-ring-member-public-account";
+                return std::nullopt;
+            }
+            if (leaf_it == account_leaf_commitments.end()) {
+                reject_reason = "bad-smile2-ring-member-account-leaf";
+                return std::nullopt;
+            }
+
+            auto member = smile2::wallet::BuildRingMemberFromCompactPublicAccount(
+                smile2::wallet::SMILE_GLOBAL_SEED,
+                cache_it->second,
+                account_it->second,
+                leaf_it->second);
+            if (!member.has_value()) {
+                reject_reason = "bad-smile2-ring-member-account-leaf";
+                return std::nullopt;
+            }
+            ring.push_back(std::move(*member));
+        }
+
+        ring_members.push_back(std::move(ring));
+    }
+
+    if (!ring_members.empty()) {
+        const auto& reference_positions = context.witness.spends.front().ring_positions;
+        const auto& reference_ring = ring_members.front();
+        for (size_t spend_index = 1; spend_index < ring_members.size(); ++spend_index) {
+            if (context.witness.spends[spend_index].ring_positions != reference_positions ||
+                ring_members[spend_index].size() != reference_ring.size()) {
+                reject_reason = "bad-smile2-shared-ring";
+                return std::nullopt;
+            }
+            for (size_t i = 0; i < reference_ring.size(); ++i) {
+                if (ring_members[spend_index][i].note_commitment != reference_ring[i].note_commitment ||
+                    ring_members[spend_index][i].account_leaf_commitment !=
+                        reference_ring[i].account_leaf_commitment) {
+                    reject_reason = "bad-smile2-shared-ring";
+                    return std::nullopt;
+                }
+            }
+        }
+    }
+
+    return ring_members;
+}
+
+std::optional<std::vector<std::vector<smile2::wallet::SmileRingMember>>> BuildSpendPathRecoverySmileRingMembers(
+    const shielded::v2::TransactionBundle& bundle,
+    const SpendPathRecoveryContext& context,
+    const shielded::ShieldedMerkleTree& tree,
+    const std::map<uint256, smile2::CompactPublicAccount>& public_accounts,
+    const std::map<uint256, uint256>& account_leaf_commitments,
+    std::string& reject_reason)
+{
+    if (!BundleHasSemanticFamily(bundle, V2_SPEND_PATH_RECOVERY) ||
+        !std::holds_alternative<SpendPathRecoveryPayload>(bundle.payload)) {
+        reject_reason = "bad-shielded-proof";
+        return std::nullopt;
+    }
+
+    const auto& payload = std::get<SpendPathRecoveryPayload>(bundle.payload);
     if (!context.IsValid(payload.spends.size(), payload.outputs.size()) || !context.witness.use_smile) {
         reject_reason = "bad-shielded-proof";
         return std::nullopt;
@@ -2101,6 +2578,200 @@ bool VerifyV2SendProof(
                                             *output_coins,
                                             pub,
                                             payload.value_balance,
+                                            reject_rice_codec,
+                                            bind_anonset_context)
+                .has_value();
+}
+
+bool VerifySpendPathRecoveryProof(const shielded::v2::TransactionBundle& bundle,
+                                  const SpendPathRecoveryContext& context,
+                                  const std::vector<std::vector<uint256>>& ring_members)
+{
+    if (!BundleHasSemanticFamily(bundle, V2_SPEND_PATH_RECOVERY) ||
+        !std::holds_alternative<SpendPathRecoveryPayload>(bundle.payload)) {
+        LogPrintf("VerifySpendPathRecoveryProof rejected invalid bundle family=%u wire_family=%u\n",
+                  static_cast<unsigned int>(GetBundleSemanticFamily(bundle)),
+                  static_cast<unsigned int>(bundle.header.family_id));
+        return false;
+    }
+
+    const auto& payload = std::get<SpendPathRecoveryPayload>(bundle.payload);
+    if (!context.IsValid(payload.spends.size(), payload.outputs.size())) {
+        LogPrintf("VerifySpendPathRecoveryProof invalid context spends=%u outputs=%u witness_spends=%u\n",
+                  static_cast<unsigned int>(payload.spends.size()),
+                  static_cast<unsigned int>(payload.outputs.size()),
+                  static_cast<unsigned int>(context.witness.spends.size()));
+        return false;
+    }
+
+    const ProofKind proof_kind = context.material.statement.envelope.proof_kind;
+
+    if (proof_kind == ProofKind::NONE) {
+        return false;
+    }
+
+    if (IsDirectSmileLikeProofKind(proof_kind)) {
+        return false;
+    }
+
+    std::vector<Nullifier> input_nullifiers;
+    input_nullifiers.reserve(payload.spends.size());
+    for (size_t i = 0; i < payload.spends.size(); ++i) {
+        const auto& spend = payload.spends[i];
+        if (!spend.value_commitment.IsNull() &&
+            CommitmentHash(context.witness.native_proof.input_commitments[i]) != spend.value_commitment) {
+            LogPrintf("VerifySpendPathRecoveryProof input commitment mismatch spend=%u expected=%s actual=%s statement=%s\n",
+                      static_cast<unsigned int>(i),
+                      spend.value_commitment.ToString(),
+                      CommitmentHash(context.witness.native_proof.input_commitments[i]).ToString(),
+                      context.material.statement.envelope.statement_digest.ToString());
+            return false;
+        }
+        input_nullifiers.push_back(spend.nullifier);
+    }
+
+    std::vector<uint256> output_note_commitments;
+    output_note_commitments.reserve(payload.outputs.size());
+    for (size_t i = 0; i < payload.outputs.size(); ++i) {
+        const auto& output = payload.outputs[i];
+        if (CommitmentHash(context.witness.native_proof.output_commitments[i]) != output.value_commitment) {
+            LogPrintf("VerifySpendPathRecoveryProof output commitment mismatch output=%u expected=%s actual=%s statement=%s\n",
+                      static_cast<unsigned int>(i),
+                      output.value_commitment.ToString(),
+                      CommitmentHash(context.witness.native_proof.output_commitments[i]).ToString(),
+                      context.material.statement.envelope.statement_digest.ToString());
+            return false;
+        }
+        output_note_commitments.push_back(output.note_commitment);
+    }
+
+    const bool verified = shielded::ringct::VerifyMatRiCTProof(context.witness.native_proof,
+                                                               ring_members,
+                                                               input_nullifiers,
+                                                               output_note_commitments,
+                                                               payload.fee,
+                                                               context.material.statement.envelope.statement_digest);
+    if (!verified) {
+        LogPrintf("VerifySpendPathRecoveryProof MatRiCT verification failed statement=%s fee=%lld inputs=%u outputs=%u rings=%u ring_hash=%s\n",
+                  context.material.statement.envelope.statement_digest.ToString(),
+                  static_cast<long long>(payload.fee),
+                  static_cast<unsigned int>(input_nullifiers.size()),
+                  static_cast<unsigned int>(output_note_commitments.size()),
+                  static_cast<unsigned int>(ring_members.size()),
+                  HashRingMembers(ring_members).ToString());
+    }
+    return verified;
+}
+
+bool VerifySpendPathRecoveryProof(
+    const shielded::v2::TransactionBundle& bundle,
+    const SpendPathRecoveryContext& context,
+    const std::vector<std::vector<smile2::wallet::SmileRingMember>>& ring_members,
+    bool reject_rice_codec,
+    bool bind_anonset_context)
+{
+    if (!BundleHasSemanticFamily(bundle, V2_SPEND_PATH_RECOVERY) ||
+        !std::holds_alternative<SpendPathRecoveryPayload>(bundle.payload)) {
+        return false;
+    }
+
+    const auto& payload = std::get<SpendPathRecoveryPayload>(bundle.payload);
+    if (!context.IsValid(payload.spends.size(), payload.outputs.size()) ||
+        !IsDirectSmileLikeProofKind(context.material.statement.envelope.proof_kind) ||
+        !context.witness.use_smile ||
+        ring_members.size() != payload.spends.size()) {
+        return false;
+    }
+
+    std::string reject_reason;
+    auto bound_nullifiers = ExtractBoundNullifiers(context,
+                                                   payload.spends.size(),
+                                                   payload.outputs.size(),
+                                                   reject_reason,
+                                                   reject_rice_codec);
+    if (!bound_nullifiers.has_value()) {
+        return false;
+    }
+    for (size_t i = 0; i < payload.spends.size(); ++i) {
+        if ((*bound_nullifiers)[i] != payload.spends[i].nullifier) {
+            return false;
+        }
+    }
+
+    const auto output_coins = CollectSmileOutputCoins(context.witness, payload.outputs.size());
+    if (!output_coins.has_value()) {
+        return false;
+    }
+    if (!ReconstructSmileOutputAccounts(payload, *output_coins).has_value()) {
+        return false;
+    }
+
+    if (ring_members.empty() || ring_members.front().empty()) {
+        return false;
+    }
+
+    const auto& reference_ring = ring_members.front();
+    std::vector<smile2::BDLOPCommitment> shared_coin_ring;
+    shared_coin_ring.reserve(reference_ring.size());
+    for (const auto& member : reference_ring) {
+        if (!member.IsValid()) return false;
+        shared_coin_ring.push_back(member.public_coin);
+    }
+    for (size_t spend_index = 1; spend_index < ring_members.size(); ++spend_index) {
+        if (ring_members[spend_index].size() != reference_ring.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < reference_ring.size(); ++i) {
+            const auto& lhs = ring_members[spend_index][i];
+            const auto& rhs = reference_ring[i];
+            if (lhs.note_commitment != rhs.note_commitment ||
+                lhs.account_leaf_commitment != rhs.account_leaf_commitment ||
+                lhs.public_key.pk != rhs.public_key.pk ||
+                lhs.public_key.A != rhs.public_key.A ||
+                lhs.public_coin.t0 != rhs.public_coin.t0 ||
+                lhs.public_coin.t_msg != rhs.public_coin.t_msg) {
+                return false;
+            }
+        }
+    }
+    for (size_t i = 0; i < payload.spends.size(); ++i) {
+        const uint256 expected_input_binding =
+            smile2::ComputeSmileDirectInputBindingHash(
+                Span<const smile2::wallet::SmileRingMember>{reference_ring.data(), reference_ring.size()},
+                payload.spends[i].merkle_anchor,
+                static_cast<uint32_t>(i),
+                payload.spends[i].nullifier);
+        if (!payload.spends[i].value_commitment.IsNull() &&
+            payload.spends[i].value_commitment != expected_input_binding) {
+            return false;
+        }
+    }
+
+    smile2::CTPublicData pub;
+    pub.anon_set = smile2::wallet::BuildAnonymitySet(
+        Span<const smile2::wallet::SmileRingMember>{reference_ring.data(), reference_ring.size()});
+    pub.coin_rings.assign(payload.spends.size(), shared_coin_ring);
+    pub.account_rings.reserve(payload.spends.size());
+    for (const auto& spend : payload.spends) {
+        std::vector<smile2::CTPublicAccount> account_ring;
+        account_ring.reserve(reference_ring.size());
+        for (const auto& member : reference_ring) {
+            account_ring.push_back(smile2::CTPublicAccount{
+                member.note_commitment,
+                member.public_key,
+                member.public_coin,
+                spend.account_leaf_commitment,
+            });
+        }
+        pub.account_rings.push_back(std::move(account_ring));
+    }
+
+    return !smile2::VerifySmile2CTFromBytes(context.witness.smile_proof_bytes,
+                                            payload.spends.size(),
+                                            payload.outputs.size(),
+                                            *output_coins,
+                                            pub,
+                                            payload.fee,
                                             reject_rice_codec,
                                             bind_anonset_context)
                 .has_value();

--- a/src/shielded/v2_proof.h
+++ b/src/shielded/v2_proof.h
@@ -28,6 +28,7 @@ namespace shielded::v2::proof {
 enum class VerificationDomain : uint8_t {
     DIRECT_SPEND = 1,
     BATCH_SETTLEMENT = 2,
+    SPEND_PATH_RECOVERY = 3,
 };
 
 enum class PayloadLocation : uint8_t {
@@ -192,6 +193,14 @@ struct V2SendContext
     [[nodiscard]] bool IsValid(size_t expected_input_count, size_t expected_output_count) const;
 };
 
+struct SpendPathRecoveryContext
+{
+    ProofMaterial material;
+    V2SendWitness witness;
+
+    [[nodiscard]] bool IsValid(size_t expected_input_count, size_t expected_output_count) const;
+};
+
 struct NativeBatchBackend
 {
     uint8_t version{1};
@@ -303,6 +312,7 @@ struct SettlementWitness
                                                    const Consensus::Params& consensus,
                                                    int32_t validation_height);
 [[nodiscard]] uint256 ComputeV2SendExtensionDigest(const CTransaction& tx);
+[[nodiscard]] uint256 ComputeSpendPathRecoveryStatementDigest(const CTransaction& tx);
 [[nodiscard]] ProofStatement DescribeV2SendStatement(
     const CTransaction& tx,
     std::optional<uint256> extension_digest_override = std::nullopt);
@@ -310,6 +320,9 @@ struct SettlementWitness
     const CTransaction& tx,
     const Consensus::Params& consensus,
     int32_t validation_height,
+    std::optional<uint256> extension_digest_override = std::nullopt);
+[[nodiscard]] ProofStatement DescribeSpendPathRecoveryStatement(
+    const CTransaction& tx,
     std::optional<uint256> extension_digest_override = std::nullopt);
 [[nodiscard]] NativeBatchBackend DescribeSmileNativeBatchBackend();
 [[nodiscard]] NativeBatchBackend DescribeMatRiCTPlusNativeBatchBackend();
@@ -333,6 +346,9 @@ struct SettlementWitness
     std::string& reject_reason);
 [[nodiscard]] std::optional<V2SendWitness> ParseV2SendWitness(const shielded::v2::TransactionBundle& bundle,
                                                               std::string& reject_reason);
+[[nodiscard]] std::optional<V2SendWitness> ParseSpendPathRecoveryWitness(
+    const shielded::v2::TransactionBundle& bundle,
+    std::string& reject_reason);
 [[nodiscard]] std::optional<std::shared_ptr<const shielded::ringct::MatRiCTProof>> ParseV2SendNativeProof(
     const shielded::v2::TransactionBundle& bundle,
     std::string& reject_reason);
@@ -360,6 +376,14 @@ struct SettlementWitness
 [[nodiscard]] std::optional<V2SendContext> ParseV2SendProof(const shielded::v2::TransactionBundle& bundle,
                                                             const ProofStatement& statement,
                                                             std::string& reject_reason);
+[[nodiscard]] SpendPathRecoveryContext BindSpendPathRecoveryProof(
+    const shielded::v2::TransactionBundle& bundle,
+    const ProofStatement& statement,
+    V2SendWitness witness);
+[[nodiscard]] std::optional<SpendPathRecoveryContext> ParseSpendPathRecoveryProof(
+    const shielded::v2::TransactionBundle& bundle,
+    const ProofStatement& statement,
+    std::string& reject_reason);
 
 [[nodiscard]] std::optional<std::vector<Nullifier>> ExtractBoundNullifiers(
     const shielded::ringct::MatRiCTProof& proof,
@@ -376,6 +400,12 @@ struct SettlementWitness
     size_t expected_output_count,
     std::string& reject_reason,
     bool reject_rice_codec = false);
+[[nodiscard]] std::optional<std::vector<Nullifier>> ExtractBoundNullifiers(
+    const SpendPathRecoveryContext& context,
+    size_t expected_input_count,
+    size_t expected_output_count,
+    std::string& reject_reason,
+    bool reject_rice_codec = false);
 
 [[nodiscard]] std::optional<std::vector<std::vector<uint256>>> BuildLegacyDirectSpendRingMembers(
     const CShieldedBundle& bundle,
@@ -386,9 +416,21 @@ struct SettlementWitness
     const V2SendContext& context,
     const shielded::ShieldedMerkleTree& tree,
     std::string& reject_reason);
+[[nodiscard]] std::optional<std::vector<std::vector<uint256>>> BuildSpendPathRecoveryRingMembers(
+    const shielded::v2::TransactionBundle& bundle,
+    const SpendPathRecoveryContext& context,
+    const shielded::ShieldedMerkleTree& tree,
+    std::string& reject_reason);
 [[nodiscard]] std::optional<std::vector<std::vector<smile2::wallet::SmileRingMember>>> BuildV2SendSmileRingMembers(
     const shielded::v2::TransactionBundle& bundle,
     const V2SendContext& context,
+    const shielded::ShieldedMerkleTree& tree,
+    const std::map<uint256, smile2::CompactPublicAccount>& public_accounts,
+    const std::map<uint256, uint256>& account_leaf_commitments,
+    std::string& reject_reason);
+[[nodiscard]] std::optional<std::vector<std::vector<smile2::wallet::SmileRingMember>>> BuildSpendPathRecoverySmileRingMembers(
+    const shielded::v2::TransactionBundle& bundle,
+    const SpendPathRecoveryContext& context,
     const shielded::ShieldedMerkleTree& tree,
     const std::map<uint256, smile2::CompactPublicAccount>& public_accounts,
     const std::map<uint256, uint256>& account_leaf_commitments,
@@ -406,6 +448,16 @@ struct SettlementWitness
 [[nodiscard]] bool VerifyV2SendProof(
     const shielded::v2::TransactionBundle& bundle,
     const V2SendContext& context,
+    const std::vector<std::vector<smile2::wallet::SmileRingMember>>& ring_members,
+    bool reject_rice_codec = false,
+    bool bind_anonset_context = false);
+[[nodiscard]] bool VerifySpendPathRecoveryProof(
+    const shielded::v2::TransactionBundle& bundle,
+    const SpendPathRecoveryContext& context,
+    const std::vector<std::vector<uint256>>& ring_members);
+[[nodiscard]] bool VerifySpendPathRecoveryProof(
+    const shielded::v2::TransactionBundle& bundle,
+    const SpendPathRecoveryContext& context,
     const std::vector<std::vector<smile2::wallet::SmileRingMember>>& ring_members,
     bool reject_rice_codec = false,
     bool bind_anonset_context = false);

--- a/src/shielded/v2_types.cpp
+++ b/src/shielded/v2_types.cpp
@@ -102,6 +102,10 @@ uint256 ComputeLegacyPayloadEphemeralKey(Span<const uint8_t> ciphertext)
 
 bool IsValidTransactionFamily(TransactionFamily family)
 {
+    if (family == V2_SPEND_PATH_RECOVERY) {
+        return true;
+    }
+
     switch (family) {
     case TransactionFamily::V2_SEND:
     case TransactionFamily::V2_INGRESS_BATCH:
@@ -192,6 +196,10 @@ bool IsValidSettlementBindingKind(SettlementBindingKind kind)
 
 const char* GetTransactionFamilyName(TransactionFamily family)
 {
+    if (family == V2_SPEND_PATH_RECOVERY) {
+        return "v2_spend_path_recovery";
+    }
+
     switch (family) {
     case TransactionFamily::V2_SEND:
         return "v2_send";

--- a/src/shielded/v2_types.h
+++ b/src/shielded/v2_types.h
@@ -36,6 +36,12 @@ enum class TransactionFamily : uint8_t {
     V2_LIFECYCLE = 7,
 };
 
+// Reserved scaffolding id for a future spend-path recovery semantic family.
+// Payload and consensus acceptance are intentionally not implemented in this
+// step; this constant only reserves the identifier and lets tests cover the
+// current rejected behavior.
+static constexpr TransactionFamily V2_SPEND_PATH_RECOVERY{static_cast<TransactionFamily>(8)};
+
 enum class NoteClass : uint8_t {
     USER = 1,
     RESERVE = 2,

--- a/src/shielded/validation.cpp
+++ b/src/shielded/validation.cpp
@@ -37,6 +37,58 @@ using namespace shielded::ringct;
     return "bad-shielded-spend-auth-proof";
 }
 
+} // namespace
+
+const char* ShieldedV2FamilyName(shielded::v2::TransactionFamily family)
+{
+    if (family == shielded::v2::V2_SPEND_PATH_RECOVERY) {
+        return "spend-path-recovery";
+    }
+
+    switch (family) {
+    case shielded::v2::TransactionFamily::V2_SEND:
+        return "send";
+    case shielded::v2::TransactionFamily::V2_LIFECYCLE:
+        return "lifecycle";
+    case shielded::v2::TransactionFamily::V2_INGRESS_BATCH:
+        return "ingress-batch";
+    case shielded::v2::TransactionFamily::V2_EGRESS_BATCH:
+        return "egress-batch";
+    case shielded::v2::TransactionFamily::V2_SETTLEMENT_ANCHOR:
+        return "settlement-anchor";
+    case shielded::v2::TransactionFamily::V2_REBALANCE:
+        return "rebalance";
+    case shielded::v2::TransactionFamily::V2_GENERIC:
+        return "generic";
+    }
+    return "unknown";
+}
+
+std::string DescribeShieldedV2Context(const CShieldedBundle& bundle)
+{
+    if (!bundle.HasV2Bundle()) return "legacy-bundle";
+
+    const auto family = bundle.GetTransactionFamily();
+    if (!family.has_value()) return "v2-family-unavailable";
+
+    return strprintf("v2-family-%s", ShieldedV2FamilyName(*family));
+}
+
+void LogShieldedV2ContextReject(std::string_view gate, const CShieldedBundle& bundle)
+{
+    const std::string gate_str{gate};
+    const std::string context_str{DescribeShieldedV2Context(bundle)};
+    LogDebug(BCLog::VALIDATION,
+             "shielded v2 contextual reject: gate=%s context=%s inputs=%u outputs=%u proof_size=%u\n",
+             gate_str.c_str(),
+             context_str.c_str(),
+             static_cast<unsigned int>(bundle.GetShieldedInputCount()),
+             static_cast<unsigned int>(bundle.GetShieldedOutputCount()),
+             static_cast<unsigned int>(bundle.GetProofSize()));
+}
+
+namespace {
+
 [[nodiscard]] bool RejectRetiredMatRiCTEnvelopeAfterDisable(const CShieldedBundle& bundle,
                                                             const Consensus::Params& consensus,
                                                             int32_t validation_height,
@@ -48,6 +100,7 @@ using namespace shielded::ringct;
 
     const auto* v2_bundle = bundle.GetV2Bundle();
     if (v2_bundle == nullptr) {
+        LogShieldedV2ContextReject("retired-matrict-v2-bundle-null", bundle);
         reject_reason = "bad-shielded-v2-contextual";
         return false;
     }
@@ -79,6 +132,9 @@ using namespace shielded::ringct;
     switch (family_id) {
     case shielded::v2::TransactionFamily::V2_SEND:
         reject_reason = "bad-shielded-v2-send-fee-bucket";
+        return false;
+    case shielded::v2::V2_SPEND_PATH_RECOVERY:
+        reject_reason = "bad-shielded-v2-spend-path-recovery-fee-bucket";
         return false;
     case shielded::v2::TransactionFamily::V2_LIFECYCLE:
         reject_reason = "bad-shielded-v2-lifecycle-fee-bucket";
@@ -251,6 +307,7 @@ using namespace shielded::ringct;
     const auto binding_kind = bundle.header.proof_envelope.settlement_binding_kind;
     switch (semantic_family) {
     case shielded::v2::TransactionFamily::V2_SEND:
+    case shielded::v2::V2_SPEND_PATH_RECOVERY:
     case shielded::v2::TransactionFamily::V2_LIFECYCLE:
     case shielded::v2::TransactionFamily::V2_INGRESS_BATCH:
     case shielded::v2::TransactionFamily::V2_EGRESS_BATCH:
@@ -1137,6 +1194,137 @@ std::optional<std::string> CShieldedProofCheck::operator()() const
             return proof_reject;
         }
         switch (semantic_family) {
+        case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+            if (m_consensus == nullptr ||
+                !m_consensus->IsShieldedSpendPathRecoveryActive(m_validation_height)) {
+                LogShieldedV2ContextReject("proof-check-v2-spend-path-recovery-disabled", bundle);
+                return std::string{"bad-shielded-v2-spend-path-recovery-disabled"};
+            }
+
+            const auto& payload = std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
+            if (!bundle.HasShieldedInputs()) return std::string{"bad-shielded-proof-missing"};
+            if (!m_tree_snapshot) return std::string{"bad-shielded-ring-tree-unavailable"};
+            if (!m_tx->vin.empty() || !m_tx->vout.empty()) {
+                return std::string{"bad-shielded-v2-spend-path-recovery-transparent"};
+            }
+            if (!RejectShieldedCanonicalFeeBucket(semantic_family,
+                                                  payload.fee,
+                                                  m_consensus,
+                                                  m_validation_height,
+                                                  proof_reject)) {
+                return proof_reject;
+            }
+
+            const shielded::v2::proof::ProofStatement statement =
+                shielded::v2::proof::DescribeSpendPathRecoveryStatement(*m_tx);
+            auto context = shielded::v2::proof::ParseSpendPathRecoveryProof(*v2_bundle, statement, proof_reject);
+            if (!context.has_value()) {
+                LogPrintf("CShieldedProofCheck spend_path_recovery parse failed txid=%s reject=%s statement=%s tree_root=%s tree_size=%u\n",
+                          m_tx->GetHash().ToString(),
+                          proof_reject,
+                          statement.envelope.statement_digest.ToString(),
+                          m_tree_snapshot->Root().ToString(),
+                          static_cast<unsigned int>(m_tree_snapshot->Size()));
+                return proof_reject;
+            }
+            const size_t ring_size = context->witness.spends.empty()
+                ? 0
+                : context->witness.spends.front().ring_positions.size();
+            if (!RejectShieldedMinimumPrivacyPool(ring_size,
+                                                  m_tree_snapshot->Size(),
+                                                  m_consensus,
+                                                  m_validation_height,
+                                                  proof_reject)) {
+                return proof_reject;
+            }
+            if (!context->IsValid(payload.spends.size(), payload.outputs.size())) {
+                LogPrintf("CShieldedProofCheck spend_path_recovery invalid context txid=%s spends=%u outputs=%u witness_spends=%u tree_root=%s tree_size=%u\n",
+                          m_tx->GetHash().ToString(),
+                          static_cast<unsigned int>(payload.spends.size()),
+                          static_cast<unsigned int>(payload.outputs.size()),
+                          static_cast<unsigned int>(context->witness.spends.size()),
+                          m_tree_snapshot->Root().ToString(),
+                          static_cast<unsigned int>(m_tree_snapshot->Size()));
+                return std::string{"bad-shielded-proof"};
+            }
+
+            if (context->witness.use_smile) {
+                if (!m_smile_public_accounts || !m_account_leaf_commitments) {
+                    return std::string{"bad-smile2-ring-member-account"};
+                }
+                if (reject_rice_codec) {
+                    smile2::SmileCTProof proof;
+                    if (auto parse_err = smile2::ParseSmile2Proof(context->witness.smile_proof_bytes,
+                                                                  payload.spends.size(),
+                                                                  payload.outputs.size(),
+                                                                  proof,
+                                                                  /*reject_rice_codec=*/true);
+                        parse_err.has_value()) {
+                        return *parse_err;
+                    }
+                }
+                std::string ring_member_error;
+                auto smile_ring_members =
+                    shielded::v2::proof::BuildSpendPathRecoverySmileRingMembers(*v2_bundle,
+                                                                                *context,
+                                                                                *m_tree_snapshot,
+                                                                                *m_smile_public_accounts,
+                                                                                *m_account_leaf_commitments,
+                                                                                ring_member_error);
+                if (!smile_ring_members.has_value()) {
+                    LogPrintf("CShieldedProofCheck spend_path_recovery SMILE ring reconstruction failed txid=%s reject=%s statement=%s tree_root=%s tree_size=%u smile_accounts=%u\n",
+                              m_tx->GetHash().ToString(),
+                              ring_member_error,
+                              statement.envelope.statement_digest.ToString(),
+                              m_tree_snapshot->Root().ToString(),
+                              static_cast<unsigned int>(m_tree_snapshot->Size()),
+                              static_cast<unsigned int>(m_smile_public_accounts->size()));
+                    return ring_member_error;
+                }
+                if (!shielded::v2::proof::VerifySpendPathRecoveryProof(*v2_bundle,
+                                                                       *context,
+                                                                       *smile_ring_members,
+                                                                       reject_rice_codec,
+                                                                       bind_smile_anonset_context)) {
+                    LogPrintf("CShieldedProofCheck spend_path_recovery SMILE verify failed txid=%s statement=%s anchor=%s fee=%lld tree_root=%s tree_size=%u\n",
+                              m_tx->GetHash().ToString(),
+                              statement.envelope.statement_digest.ToString(),
+                              payload.spend_anchor.ToString(),
+                              static_cast<long long>(payload.fee),
+                              m_tree_snapshot->Root().ToString(),
+                              static_cast<unsigned int>(m_tree_snapshot->Size()));
+                    return std::string{"bad-shielded-proof"};
+                }
+            } else {
+                std::string ring_member_error;
+                auto ring_members = shielded::v2::proof::BuildSpendPathRecoveryRingMembers(*v2_bundle,
+                                                                                            *context,
+                                                                                            *m_tree_snapshot,
+                                                                                            ring_member_error);
+                if (!ring_members.has_value()) {
+                    LogPrintf("CShieldedProofCheck spend_path_recovery ring reconstruction failed txid=%s reject=%s statement=%s tree_root=%s tree_size=%u\n",
+                              m_tx->GetHash().ToString(),
+                              ring_member_error,
+                              statement.envelope.statement_digest.ToString(),
+                              m_tree_snapshot->Root().ToString(),
+                              static_cast<unsigned int>(m_tree_snapshot->Size()));
+                    return ring_member_error;
+                }
+                if (!shielded::v2::proof::VerifySpendPathRecoveryProof(*v2_bundle,
+                                                                       *context,
+                                                                       *ring_members)) {
+                    LogPrintf("CShieldedProofCheck spend_path_recovery verify failed txid=%s statement=%s anchor=%s fee=%lld tree_root=%s tree_size=%u\n",
+                              m_tx->GetHash().ToString(),
+                              statement.envelope.statement_digest.ToString(),
+                              payload.spend_anchor.ToString(),
+                              static_cast<long long>(payload.fee),
+                              m_tree_snapshot->Root().ToString(),
+                              static_cast<unsigned int>(m_tree_snapshot->Size()));
+                    return std::string{"bad-shielded-proof"};
+                }
+            }
+            return std::nullopt;
+        }
         case shielded::v2::TransactionFamily::V2_LIFECYCLE: {
             if (m_consensus == nullptr ||
                 !m_consensus->IsShieldedMatRiCTDisabled(m_validation_height)) {
@@ -1463,8 +1651,10 @@ std::optional<std::string> CShieldedProofCheck::operator()() const
             return std::nullopt;
         }
         case shielded::v2::TransactionFamily::V2_GENERIC:
+            LogShieldedV2ContextReject("proof-check-v2-generic-family", bundle);
             return std::string{"bad-shielded-v2-contextual"};
         default:
+            LogShieldedV2ContextReject("proof-check-v2-unsupported-family", bundle);
             return std::string{"bad-shielded-v2-contextual"};
         }
     }

--- a/src/shielded/validation.h
+++ b/src/shielded/validation.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -48,6 +49,12 @@ struct ProofAuditArchive
 };
 
 } // namespace shielded::audit
+
+[[nodiscard]] const char* ShieldedV2FamilyName(shielded::v2::TransactionFamily family);
+
+[[nodiscard]] std::string DescribeShieldedV2Context(const CShieldedBundle& bundle);
+
+void LogShieldedV2ContextReject(std::string_view gate, const CShieldedBundle& bundle);
 
 /**
  * Extract deterministic nullifiers bound to ring key images encoded in a

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -180,6 +180,8 @@ add_executable(test_btx
   shielded_scan_hint_runtime_report_tests.cpp
   shielded_relay_fixture_builder.cpp
   shielded_relay_fixture_builder_tests.cpp
+  shielded_spend_path_recovery_fixture_builder.cpp
+  shielded_spend_path_recovery_fixture_builder_tests.cpp
   btx_launch_readiness_tests.cpp
   nullifier_set_tests.cpp
   ringct_commitment_tests.cpp
@@ -457,6 +459,17 @@ set_target_properties(generate_shielded_relay_fixture_tx PROPERTIES
 )
 add_test_translation_stub(generate_shielded_relay_fixture_tx)
 link_shielded_report_target(generate_shielded_relay_fixture_tx)
+
+add_executable(generate_shielded_spend_path_recovery_fixture
+  generate_shielded_spend_path_recovery_fixture.cpp
+  shielded_spend_path_recovery_fixture_builder.cpp
+)
+set_target_properties(generate_shielded_spend_path_recovery_fixture PROPERTIES
+  OUTPUT_NAME gen_shielded_spend_path_recovery_fixture
+  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+add_test_translation_stub(generate_shielded_spend_path_recovery_fixture)
+link_shielded_report_target(generate_shielded_spend_path_recovery_fixture)
 
 add_executable(generate_shielded_v2_adversarial_proof_corpus
   generate_shielded_v2_adversarial_proof_corpus.cpp

--- a/src/test/generate_shielded_spend_path_recovery_fixture.cpp
+++ b/src/test/generate_shielded_spend_path_recovery_fixture.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 The BTX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <test/shielded_spend_path_recovery_fixture_builder.h>
+
+#include <core_io.h>
+#include <primitives/transaction.h>
+#include <univalue.h>
+#include <util/fs.h>
+#include <util/strencodings.h>
+
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace {
+
+using btx::test::shielded::SpendPathRecoveryFixtureBuildInput;
+using btx::test::shielded::SpendPathRecoveryFundingInput;
+
+uint32_t ParseVout(std::string_view value)
+{
+    return static_cast<uint32_t>(std::stoul(std::string{value}));
+}
+
+CAmount ParseAmount(std::string_view value, std::string_view option_name)
+{
+    const long long parsed = std::stoll(std::string{value});
+    if (parsed <= 0) {
+        throw std::runtime_error(std::string{option_name} + " must be greater than zero");
+    }
+    return parsed;
+}
+
+SpendPathRecoveryFixtureBuildInput ParseArgs(int argc, char** argv, fs::path& output_path)
+{
+    SpendPathRecoveryFixtureBuildInput parsed;
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view arg{argv[i]};
+        if (arg == "--help") {
+            std::cout << "Usage: gen_shielded_spend_path_recovery_fixture "
+                         "--legacy-input=<txid>:<vout>:<value_sats> "
+                         "[--legacy-fee-sats=<sats>] [--recovery-fee-sats=<sats>] "
+                         "[--validation-height=<height>] "
+                         "[--matrict-disable-height=<height>] "
+                         "[--output=/path/report.json]\n";
+            std::exit(0);
+        }
+        if (arg.starts_with("--legacy-input=")) {
+            const std::string value{arg.substr(15)};
+            const auto first = value.find(':');
+            const auto second = value.find(':', first == std::string::npos ? first : first + 1);
+            if (first == std::string::npos || second == std::string::npos) {
+                throw std::runtime_error("invalid --legacy-input");
+            }
+            const auto txid_hex = value.substr(0, first);
+            const auto vout_str = value.substr(first + 1, second - first - 1);
+            const auto amount_str = value.substr(second + 1);
+            auto hash = uint256::FromHex(txid_hex);
+            if (!hash.has_value()) {
+                throw std::runtime_error("invalid --legacy-input txid");
+            }
+            parsed.legacy_funding_inputs.push_back(SpendPathRecoveryFundingInput{
+                .funding_outpoint = COutPoint{Txid::FromUint256(*hash), ParseVout(vout_str)},
+                .funding_value = ParseAmount(amount_str, "--legacy-input"),
+            });
+            continue;
+        }
+        if (arg.starts_with("--legacy-fee-sats=")) {
+            parsed.legacy_shield_fee = ParseAmount(arg.substr(18), "--legacy-fee-sats");
+            continue;
+        }
+        if (arg.starts_with("--recovery-fee-sats=")) {
+            parsed.recovery_fee = ParseAmount(arg.substr(20), "--recovery-fee-sats");
+            continue;
+        }
+        if (arg.starts_with("--validation-height=")) {
+            const long parsed_height = std::stol(std::string{arg.substr(20)});
+            if (parsed_height <= 0) {
+                throw std::runtime_error("--validation-height must be greater than zero");
+            }
+            parsed.validation_height = static_cast<int32_t>(parsed_height);
+            continue;
+        }
+        if (arg.starts_with("--matrict-disable-height=")) {
+            const long parsed_height = std::stol(std::string{arg.substr(25)});
+            if (parsed_height <= 0) {
+                throw std::runtime_error("--matrict-disable-height must be greater than zero");
+            }
+            parsed.matrict_disable_height = static_cast<int32_t>(parsed_height);
+            continue;
+        }
+        if (arg.starts_with("--output=")) {
+            output_path = fs::PathFromString(std::string{arg.substr(9)});
+            continue;
+        }
+        throw std::runtime_error("unknown argument: " + std::string{arg});
+    }
+    return parsed;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    try {
+        fs::path output_path;
+        const auto parsed = ParseArgs(argc, argv, output_path);
+
+        std::string reject_reason;
+        const auto built =
+            btx::test::shielded::BuildSpendPathRecoveryFixture(parsed, reject_reason);
+        if (!built.has_value()) {
+            throw std::runtime_error(reject_reason.empty()
+                                         ? "failed to build spend-path recovery fixture"
+                                         : reject_reason);
+        }
+
+        UniValue out(UniValue::VOBJ);
+        out.pushKV("validation_height", parsed.validation_height);
+        out.pushKV("matrict_disable_height", parsed.matrict_disable_height);
+        out.pushKV("legacy_anchor", built->legacy_anchor.GetHex());
+        out.pushKV("recovery_anchor", built->recovery_anchor.GetHex());
+        out.pushKV("recovery_input_note_commitment", built->recovery_input_note_commitment.GetHex());
+        out.pushKV("recovery_output_note_commitment", built->recovery_output_note_commitment.GetHex());
+        out.pushKV("recovery_tx_hex", EncodeHexTx(CTransaction{built->recovery_tx}));
+        out.pushKV("recovery_txid", built->recovery_tx.GetHash().GetHex());
+
+        UniValue legacy_txs(UniValue::VARR);
+        for (size_t i = 0; i < built->legacy_txs.size(); ++i) {
+            UniValue tx(UniValue::VOBJ);
+            tx.pushKV("tx_hex", EncodeHexTx(CTransaction{built->legacy_txs[i]}));
+            tx.pushKV("note_commitment", built->legacy_note_commitments[i].GetHex());
+            legacy_txs.push_back(std::move(tx));
+        }
+        out.pushKV("legacy_txs", std::move(legacy_txs));
+
+        const std::string json = out.write(2) + '\n';
+        if (output_path.empty()) {
+            std::cout << json;
+        } else {
+            std::ofstream output{output_path};
+            if (!output.is_open()) {
+                throw std::runtime_error("unable to open output path");
+            }
+            output << json;
+        }
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "gen_shielded_spend_path_recovery_fixture: " << e.what() << '\n';
+        return 1;
+    }
+}

--- a/src/test/shielded_mempool_tests.cpp
+++ b/src/test/shielded_mempool_tests.cpp
@@ -105,6 +105,66 @@ CMutableTransaction BuildShieldedV2SendTx(const Nullifier& nf,
     return mtx;
 }
 
+CMutableTransaction BuildShieldedV2SpendPathRecoveryTx(
+    const Nullifier& nf,
+    const uint256& spend_anchor)
+{
+    using namespace shielded::v2;
+
+    const auto spend_account = MakeSmileAccount(0x70);
+    const uint256 spend_note_commitment = uint256{0x71};
+    const auto registry_witness =
+        test::shielded::MakeSingleLeafRegistryWitness(spend_note_commitment, spend_account);
+    BOOST_REQUIRE(registry_witness.has_value());
+
+    EncryptedNotePayload encrypted_note;
+    encrypted_note.scan_domain = ScanDomain::OPAQUE;
+    encrypted_note.scan_hint.fill(0x41);
+    encrypted_note.ciphertext = {0x61, 0x62};
+    encrypted_note.ephemeral_key = ComputeLegacyPayloadEphemeralKey(
+        Span<const uint8_t>{encrypted_note.ciphertext.data(), encrypted_note.ciphertext.size()});
+
+    SpendDescription spend;
+    spend.nullifier = nf;
+    spend.merkle_anchor = spend_anchor;
+    spend.account_leaf_commitment = registry_witness->second.account_leaf_commitment;
+    spend.account_registry_proof = registry_witness->second;
+    spend.note_commitment = spend_note_commitment;
+    spend.value_commitment = uint256{0x72};
+
+    OutputDescription output;
+    output.note_class = NoteClass::USER;
+    output.smile_account = MakeSmileAccount(0x73);
+    output.note_commitment = smile2::ComputeCompactPublicAccountHash(*output.smile_account);
+    output.value_commitment = uint256{0x74};
+    output.encrypted_note = encrypted_note;
+
+    SpendPathRecoveryPayload payload;
+    payload.spend_anchor = spend_anchor;
+    payload.spends = {spend};
+    payload.outputs = {output};
+    payload.fee = 1;
+
+    ProofEnvelope envelope;
+    envelope.proof_kind = ProofKind::DIRECT_SMILE;
+    envelope.membership_proof_kind = ProofComponentKind::SMILE_MEMBERSHIP;
+    envelope.amount_proof_kind = ProofComponentKind::SMILE_BALANCE;
+    envelope.balance_proof_kind = ProofComponentKind::SMILE_BALANCE;
+    envelope.settlement_binding_kind = SettlementBindingKind::NONE;
+    envelope.statement_digest = uint256{0x75};
+
+    TransactionBundle tx_bundle;
+    tx_bundle.header.family_id = V2_SPEND_PATH_RECOVERY;
+    tx_bundle.header.proof_envelope = envelope;
+    tx_bundle.header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(payload);
+    tx_bundle.payload = payload;
+    tx_bundle.proof_payload = {0x81, 0x82};
+
+    CMutableTransaction mtx;
+    mtx.shielded_bundle.v2_bundle = tx_bundle;
+    return mtx;
+}
+
 } // namespace
 
 BOOST_FIXTURE_TEST_SUITE(shielded_mempool_tests, BasicTestingSetup)
@@ -148,6 +208,20 @@ BOOST_AUTO_TEST_CASE(shielded_v2_nullifier_conflict_detected)
     BOOST_CHECK(pool.HasShieldedNullifierConflict(tx));
 }
 
+BOOST_AUTO_TEST_CASE(shielded_v2_spend_path_recovery_nullifier_conflict_detected)
+{
+    bilingual_str error;
+    CTxMemPool pool{MemPoolOptionsForTest(m_node), error};
+    BOOST_REQUIRE(error.empty());
+
+    const Nullifier nf = GetRandHash();
+    const CTransaction tx{BuildShieldedV2SpendPathRecoveryTx(nf, GetRandHash())};
+
+    LOCK(pool.cs);
+    pool.m_shielded_nullifiers.emplace(nf, Txid::FromUint256(GetRandHash()));
+    BOOST_CHECK(pool.HasShieldedNullifierConflict(tx));
+}
+
 BOOST_AUTO_TEST_CASE(shielded_nullifier_conflict_reports_direct_conflict_txid)
 {
     bilingual_str error;
@@ -176,6 +250,25 @@ BOOST_AUTO_TEST_CASE(shielded_nullifier_duplicate_within_tx_detected)
     CMutableTransaction mtx = BuildShieldedTx(nf);
     CShieldedInput dup = mtx.shielded_bundle.shielded_inputs.front();
     mtx.shielded_bundle.shielded_inputs.push_back(dup);
+
+    LOCK(pool.cs);
+    BOOST_CHECK(pool.HasShieldedNullifierConflict(CTransaction{mtx}));
+}
+
+BOOST_AUTO_TEST_CASE(shielded_v2_spend_path_recovery_duplicate_within_tx_detected)
+{
+    bilingual_str error;
+    CTxMemPool pool{MemPoolOptionsForTest(m_node), error};
+    BOOST_REQUIRE(error.empty());
+
+    const Nullifier nf = GetRandHash();
+    CMutableTransaction mtx = BuildShieldedV2SpendPathRecoveryTx(nf, GetRandHash());
+    auto& payload = std::get<shielded::v2::SpendPathRecoveryPayload>(
+        mtx.shielded_bundle.v2_bundle->payload);
+    auto dup = payload.spends.front();
+    payload.spends.push_back(dup);
+    mtx.shielded_bundle.v2_bundle->header.payload_digest =
+        shielded::v2::ComputeSpendPathRecoveryPayloadDigest(payload);
 
     LOCK(pool.cs);
     BOOST_CHECK(pool.HasShieldedNullifierConflict(CTransaction{mtx}));

--- a/src/test/shielded_spend_path_recovery_fixture_builder.cpp
+++ b/src/test/shielded_spend_path_recovery_fixture_builder.cpp
@@ -1,0 +1,447 @@
+// Copyright (c) 2026 The BTX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <test/shielded_spend_path_recovery_fixture_builder.h>
+
+#include <crypto/chacha20poly1305.h>
+#include <crypto/ml_kem.h>
+#include <hash.h>
+#include <primitives/transaction.h>
+#include <shielded/account_registry.h>
+#include <shielded/lattice/params.h>
+#include <shielded/note_encryption.h>
+#include <shielded/ringct/matrict.h>
+#include <shielded/smile2/wallet_bridge.h>
+#include <shielded/v2_bundle.h>
+#include <shielded/v2_proof.h>
+#include <streams.h>
+#include <test/util/shielded_account_registry_test_util.h>
+#include <util/check.h>
+
+#include <array>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace btx::test::shielded {
+namespace {
+
+namespace sh = ::shielded;
+using namespace ::shielded::ringct;
+namespace v2proof = ::shielded::v2::proof;
+
+template <size_t N>
+[[nodiscard]] std::array<uint8_t, N> FilledArray(unsigned char value)
+{
+    std::array<uint8_t, N> out{};
+    out.fill(value);
+    return out;
+}
+
+[[nodiscard]] ShieldedNote MakeLegacyNote(CAmount value, unsigned char seed)
+{
+    ShieldedNote note;
+    note.value = value;
+    note.recipient_pk_hash = uint256{seed};
+    note.rho = uint256{static_cast<unsigned char>(seed + 1)};
+    note.rcm = uint256{static_cast<unsigned char>(seed + 2)};
+    return note;
+}
+
+[[nodiscard]] mlkem::KeyPair BuildRecipientKeyPair(unsigned char seed)
+{
+    return mlkem::KeyGenDerand(FilledArray<mlkem::KEYGEN_SEEDBYTES>(seed));
+}
+
+[[nodiscard]] sh::EncryptedNote EncryptLegacyNote(const ShieldedNote& note,
+                                                  const mlkem::PublicKey& recipient_pk,
+                                                  unsigned char seed)
+{
+    return sh::NoteEncryption::EncryptDeterministic(
+        note,
+        recipient_pk,
+        FilledArray<mlkem::ENCAPS_SEEDBYTES>(seed),
+        FilledArray<12>(static_cast<unsigned char>(seed + 1)));
+}
+
+[[nodiscard]] sh::v2::OutputDescription BuildRecoveryOutput(const ShieldedNote& note,
+                                                            const mlkem::PublicKey& recipient_pk,
+                                                            unsigned char seed,
+                                                            std::string& reject_reason)
+{
+    auto encoded_note = sh::v2::EncodeLegacyEncryptedNotePayload(
+        EncryptLegacyNote(note, recipient_pk, seed),
+        recipient_pk,
+        sh::v2::ScanDomain::OPAQUE);
+    if (!encoded_note.has_value()) {
+        reject_reason = "failed to encode spend-path recovery output payload";
+        return {};
+    }
+
+    sh::v2::OutputDescription output;
+    output.note_class = sh::v2::NoteClass::USER;
+    output.smile_account = smile2::wallet::BuildCompactPublicAccountFromNote(
+        smile2::wallet::SMILE_GLOBAL_SEED,
+        note);
+    if (!output.smile_account.has_value()) {
+        reject_reason = "failed to build spend-path recovery smile account";
+        return {};
+    }
+    output.note_commitment = smile2::ComputeCompactPublicAccountHash(*output.smile_account);
+    output.value_commitment = uint256{static_cast<unsigned char>(seed + 2)};
+    output.encrypted_note = *encoded_note;
+    if (!output.IsValid()) {
+        reject_reason = "invalid spend-path recovery output";
+        return {};
+    }
+    return output;
+}
+
+[[nodiscard]] std::vector<uint64_t> BuildRingPositions()
+{
+    std::vector<uint64_t> positions;
+    positions.reserve(sh::lattice::RING_SIZE);
+    for (size_t i = 0; i < sh::lattice::RING_SIZE; ++i) {
+        positions.push_back(i);
+    }
+    return positions;
+}
+
+[[nodiscard]] std::vector<uint256> BuildRingMembers(const sh::ShieldedMerkleTree& tree,
+                                                    const std::vector<uint64_t>& ring_positions)
+{
+    std::vector<uint256> ring_members;
+    ring_members.reserve(ring_positions.size());
+    for (const uint64_t pos : ring_positions) {
+        const auto commitment = tree.CommitmentAt(pos);
+        Assert(commitment.has_value());
+        ring_members.push_back(*commitment);
+    }
+    return ring_members;
+}
+
+[[nodiscard]] std::optional<CMutableTransaction> BuildUnsignedLegacyShieldOnlyTx(
+    const SpendPathRecoveryFundingInput& funding_input,
+    const uint256& legacy_anchor,
+    const ShieldedNote& note,
+    const mlkem::PublicKey& recipient_kem_pk,
+    unsigned char seed,
+    CAmount fee,
+    std::string& reject_reason)
+{
+    if (funding_input.funding_outpoint.IsNull()) {
+        reject_reason = "missing legacy funding outpoint";
+        return std::nullopt;
+    }
+    if (!MoneyRange(funding_input.funding_value) || funding_input.funding_value <= fee) {
+        reject_reason = "invalid legacy funding amount";
+        return std::nullopt;
+    }
+    if (legacy_anchor.IsNull()) {
+        reject_reason = "missing legacy shield anchor";
+        return std::nullopt;
+    }
+
+    CMutableTransaction tx;
+    tx.version = CTransaction::CURRENT_VERSION;
+    tx.nLockTime = seed;
+    tx.vin = {CTxIn{funding_input.funding_outpoint}};
+
+    CShieldedOutput output;
+    output.note_commitment = note.GetCommitment();
+    output.encrypted_note = EncryptLegacyNote(note, recipient_kem_pk, seed);
+    output.merkle_anchor = legacy_anchor;
+    tx.shielded_bundle.shielded_outputs.push_back(std::move(output));
+    tx.shielded_bundle.value_balance = -(funding_input.funding_value - fee);
+    return tx;
+}
+
+[[nodiscard]] bool ApplyRecoveryWireEnvelope(sh::v2::TransactionBundle& bundle)
+{
+    using namespace ::shielded::v2;
+
+    bundle.header.family_id = V2_SPEND_PATH_RECOVERY;
+    bundle.header.proof_envelope.proof_kind = ProofKind::DIRECT_MATRICT;
+    bundle.header.proof_envelope.membership_proof_kind = ProofComponentKind::MATRICT;
+    bundle.header.proof_envelope.amount_proof_kind = ProofComponentKind::RANGE;
+    bundle.header.proof_envelope.balance_proof_kind = ProofComponentKind::BALANCE;
+    bundle.header.proof_envelope.settlement_binding_kind = SettlementBindingKind::NONE;
+    bundle.header.proof_envelope.extension_digest = uint256::ZERO;
+    bundle.proof_shards.clear();
+    bundle.header.proof_shard_count = 0;
+    bundle.header.proof_shard_root = uint256::ZERO;
+    bundle.output_chunks.clear();
+    bundle.header.output_chunk_root = uint256::ZERO;
+    bundle.header.output_chunk_count = 0;
+
+    if (UseDerivedGenericOutputChunkWire(bundle.header, bundle.payload)) {
+        auto output_chunks = BuildDerivedGenericOutputChunks(bundle.payload);
+        if (!output_chunks.has_value()) return false;
+        bundle.output_chunks = std::move(*output_chunks);
+        bundle.header.output_chunk_root = bundle.output_chunks.empty()
+            ? uint256::ZERO
+            : ComputeOutputChunkRoot(
+                  Span<const sh::v2::OutputChunkDescriptor>{bundle.output_chunks.data(),
+                                                            bundle.output_chunks.size()});
+        bundle.header.output_chunk_count = bundle.output_chunks.size();
+    }
+    return true;
+}
+
+[[nodiscard]] std::optional<CMutableTransaction> BuildRecoveryTx(
+    const std::vector<ShieldedNote>& ring_notes,
+    const sh::ShieldedMerkleTree& tree,
+    CAmount recovery_fee,
+    unsigned char seed_base,
+    uint256& recovery_output_note_commitment,
+    std::string& reject_reason)
+{
+    using namespace ::shielded::v2;
+
+    if (ring_notes.size() != sh::lattice::RING_SIZE) {
+        reject_reason = "spend-path recovery ring size mismatch";
+        return std::nullopt;
+    }
+
+    const ShieldedNote& input_note = ring_notes.front();
+    if (input_note.value <= recovery_fee) {
+        reject_reason = "spend-path recovery input note below fee";
+        return std::nullopt;
+    }
+
+    const std::vector<unsigned char> spending_key(32, static_cast<unsigned char>(seed_base + 0x11));
+    const std::vector<uint64_t> ring_positions = BuildRingPositions();
+    const std::vector<std::vector<uint256>> ring_members{BuildRingMembers(tree, ring_positions)};
+    const std::vector<size_t> real_indices{0};
+
+    ShieldedNote output_note = MakeLegacyNote(input_note.value - recovery_fee,
+                                              static_cast<unsigned char>(seed_base + 0x70));
+    const auto output_recipient = BuildRecipientKeyPair(static_cast<unsigned char>(seed_base + 0x71));
+
+    SpendDescription spend;
+    if (!DeriveInputNullifierForNote(spend.nullifier,
+                                     spending_key,
+                                     input_note,
+                                     ring_members.front().front())) {
+        reject_reason = "failed to derive spend-path recovery nullifier";
+        return std::nullopt;
+    }
+    spend.note_commitment = ring_members.front().front();
+    spend.merkle_anchor = tree.Root();
+    const auto account_leaf_commitment = sh::registry::ComputeAccountLeafCommitmentFromNote(
+        input_note,
+        spend.note_commitment,
+        sh::registry::MakeDirectSendAccountLeafHint());
+    if (!account_leaf_commitment.has_value()) {
+        reject_reason = "failed to derive spend-path recovery account leaf";
+        return std::nullopt;
+    }
+    spend.account_leaf_commitment = *account_leaf_commitment;
+    const auto input_account = smile2::wallet::BuildCompactPublicAccountFromNote(
+        smile2::wallet::SMILE_GLOBAL_SEED,
+        input_note);
+    if (!input_account.has_value()) {
+        reject_reason = "failed to derive spend-path recovery input account";
+        return std::nullopt;
+    }
+    const auto account_registry_witness = ::test::shielded::MakeSingleLeafRegistryWitness(
+        spend.note_commitment,
+        *input_account);
+    if (!account_registry_witness.has_value()) {
+        reject_reason = "failed to build spend-path recovery registry witness";
+        return std::nullopt;
+    }
+    spend.account_registry_proof = account_registry_witness->second;
+    spend.value_commitment = uint256{static_cast<unsigned char>(seed_base + 0x12)};
+
+    auto output = BuildRecoveryOutput(output_note,
+                                      output_recipient.pk,
+                                      static_cast<unsigned char>(seed_base + 0x21),
+                                      reject_reason);
+    if (!reject_reason.empty()) return std::nullopt;
+
+    SpendPathRecoveryPayload payload;
+    payload.spend_anchor = tree.Root();
+    payload.spends = {spend};
+    payload.outputs = {output};
+    payload.fee = recovery_fee;
+
+    TransactionBundle bundle;
+    bundle.payload = payload;
+    bundle.header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(payload);
+    if (!ApplyRecoveryWireEnvelope(bundle)) {
+        reject_reason = "failed to derive spend-path recovery output chunks";
+        return std::nullopt;
+    }
+
+    CMutableTransaction tx;
+    tx.version = CTransaction::CURRENT_VERSION;
+    tx.nLockTime = seed_base;
+    tx.shielded_bundle.v2_bundle = bundle;
+
+    std::vector<Nullifier> input_nullifiers{spend.nullifier};
+    std::vector<uint256> output_note_commitments{output.note_commitment};
+
+    const uint256 provisional_statement_digest =
+        v2proof::ComputeSpendPathRecoveryStatementDigest(CTransaction{tx});
+    MatRiCTProof provisional_proof;
+    if (!CreateMatRiCTProof(provisional_proof,
+                            {input_note},
+                            {output_note},
+                            Span<const uint256>{output_note_commitments.data(),
+                                                output_note_commitments.size()},
+                            input_nullifiers,
+                            ring_members,
+                            real_indices,
+                            spending_key,
+                            recovery_fee,
+                            provisional_statement_digest)) {
+        reject_reason = "failed to build provisional spend-path recovery proof";
+        return std::nullopt;
+    }
+
+    spend.value_commitment = CommitmentHash(provisional_proof.input_commitments[0]);
+    output.value_commitment = CommitmentHash(provisional_proof.output_commitments[0]);
+    payload.spends = {spend};
+    payload.outputs = {output};
+    bundle.payload = payload;
+    bundle.header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(payload);
+    if (!ApplyRecoveryWireEnvelope(bundle)) {
+        reject_reason = "failed to refresh spend-path recovery output chunks";
+        return std::nullopt;
+    }
+    tx.shielded_bundle.v2_bundle = bundle;
+
+    const uint256 statement_digest =
+        v2proof::ComputeSpendPathRecoveryStatementDigest(CTransaction{tx});
+    MatRiCTProof proof;
+    if (!CreateMatRiCTProof(proof,
+                            {input_note},
+                            {output_note},
+                            Span<const uint256>{output_note_commitments.data(),
+                                                output_note_commitments.size()},
+                            input_nullifiers,
+                            ring_members,
+                            real_indices,
+                            spending_key,
+                            recovery_fee,
+                            statement_digest)) {
+        reject_reason = "failed to build spend-path recovery proof";
+        return std::nullopt;
+    }
+
+    v2proof::V2SendWitness witness;
+    v2proof::V2SendSpendWitness spend_witness;
+    spend_witness.real_index = 0;
+    spend_witness.ring_positions = ring_positions;
+    witness.spends = {spend_witness};
+    witness.native_proof = proof;
+
+    DataStream witness_stream;
+    witness_stream << witness;
+    const auto* witness_begin = reinterpret_cast<const unsigned char*>(witness_stream.data());
+    bundle.header.proof_envelope.statement_digest = statement_digest;
+    bundle.proof_payload.assign(witness_begin, witness_begin + witness_stream.size());
+    bundle.payload = payload;
+    bundle.header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(payload);
+    if (!ApplyRecoveryWireEnvelope(bundle)) {
+        reject_reason = "failed to finalize spend-path recovery output chunks";
+        return std::nullopt;
+    }
+    bundle.header.proof_envelope.statement_digest = statement_digest;
+    if (!bundle.IsValid()) {
+        reject_reason = "invalid spend-path recovery bundle";
+        return std::nullopt;
+    }
+    tx.shielded_bundle.v2_bundle = bundle;
+    recovery_output_note_commitment = output.note_commitment;
+    return tx;
+}
+
+} // namespace
+
+std::optional<SpendPathRecoveryFixtureBuildResult> BuildSpendPathRecoveryFixture(
+    const SpendPathRecoveryFixtureBuildInput& input,
+    std::string& reject_reason)
+{
+    SpendPathRecoveryFixtureBuildResult result;
+    if (input.legacy_funding_inputs.size() != sh::lattice::RING_SIZE) {
+        reject_reason = "spend-path recovery fixture requires exactly one funding input per ring member";
+        return std::nullopt;
+    }
+    if (input.validation_height <= 0) {
+        reject_reason = "spend-path recovery fixture requires a positive validation height";
+        return std::nullopt;
+    }
+    if (input.matrict_disable_height <= 0) {
+        reject_reason = "spend-path recovery fixture requires a positive MatRiCT disable height";
+        return std::nullopt;
+    }
+    if (input.validation_height >= input.matrict_disable_height) {
+        reject_reason =
+            "state-aware spend-path recovery fixture currently supports pre-disable MatRiCT heights only";
+        return std::nullopt;
+    }
+    if (!MoneyRange(input.legacy_shield_fee) || input.legacy_shield_fee <= 0 ||
+        !MoneyRange(input.recovery_fee) || input.recovery_fee <= 0) {
+        reject_reason = "invalid spend-path recovery fee configuration";
+        return std::nullopt;
+    }
+
+    sh::ShieldedMerkleTree tree;
+    result.legacy_anchor = tree.Root();
+    if (result.legacy_anchor.IsNull()) {
+        reject_reason = "empty shielded tree root is unavailable";
+        return std::nullopt;
+    }
+
+    std::vector<ShieldedNote> ring_notes;
+    ring_notes.reserve(input.legacy_funding_inputs.size());
+    result.legacy_txs.reserve(input.legacy_funding_inputs.size());
+    result.legacy_note_commitments.reserve(input.legacy_funding_inputs.size());
+
+    for (size_t i = 0; i < input.legacy_funding_inputs.size(); ++i) {
+        const auto& funding = input.legacy_funding_inputs[i];
+        if (!MoneyRange(funding.funding_value) || funding.funding_value <= input.legacy_shield_fee) {
+            reject_reason = "legacy funding amount does not cover fee";
+            return std::nullopt;
+        }
+        const auto note_value = funding.funding_value - input.legacy_shield_fee;
+        ShieldedNote note = MakeLegacyNote(note_value,
+                                           static_cast<unsigned char>(input.seed_base + i * 3));
+        const auto recipient = BuildRecipientKeyPair(
+            static_cast<unsigned char>(input.seed_base + 0x40 + i));
+        const uint256 current_legacy_anchor = tree.Root();
+        auto tx = BuildUnsignedLegacyShieldOnlyTx(funding,
+                                                  current_legacy_anchor,
+                                                  note,
+                                                  recipient.pk,
+                                                  static_cast<unsigned char>(input.seed_base + i),
+                                                  input.legacy_shield_fee,
+                                                  reject_reason);
+        if (!tx.has_value()) {
+            return std::nullopt;
+        }
+        result.legacy_note_commitments.push_back(note.GetCommitment());
+        tree.Append(note.GetCommitment());
+        ring_notes.push_back(std::move(note));
+        result.legacy_txs.push_back(std::move(*tx));
+    }
+
+    result.recovery_anchor = tree.Root();
+    result.recovery_input_note_commitment = result.legacy_note_commitments.front();
+    auto recovery_tx = BuildRecoveryTx(ring_notes,
+                                       tree,
+                                       input.recovery_fee,
+                                       static_cast<unsigned char>(input.seed_base + 0x80),
+                                       result.recovery_output_note_commitment,
+                                       reject_reason);
+    if (!recovery_tx.has_value()) {
+        return std::nullopt;
+    }
+    result.recovery_tx = std::move(*recovery_tx);
+    return result;
+}
+
+} // namespace btx::test::shielded

--- a/src/test/shielded_spend_path_recovery_fixture_builder.h
+++ b/src/test/shielded_spend_path_recovery_fixture_builder.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 The BTX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BTX_TEST_SHIELDED_SPEND_PATH_RECOVERY_FIXTURE_BUILDER_H
+#define BTX_TEST_SHIELDED_SPEND_PATH_RECOVERY_FIXTURE_BUILDER_H
+
+#include <consensus/amount.h>
+#include <primitives/transaction.h>
+#include <uint256.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace btx::test::shielded {
+
+struct SpendPathRecoveryFundingInput
+{
+    COutPoint funding_outpoint;
+    CAmount funding_value{0};
+};
+
+struct SpendPathRecoveryFixtureBuildInput
+{
+    std::vector<SpendPathRecoveryFundingInput> legacy_funding_inputs;
+    CAmount legacy_shield_fee{1000};
+    CAmount recovery_fee{1000};
+    unsigned char seed_base{0x61};
+    int32_t validation_height{1};
+    int32_t matrict_disable_height{132};
+};
+
+struct SpendPathRecoveryFixtureBuildResult
+{
+    std::vector<CMutableTransaction> legacy_txs;
+    std::vector<uint256> legacy_note_commitments;
+    CMutableTransaction recovery_tx;
+    uint256 legacy_anchor;
+    uint256 recovery_anchor;
+    uint256 recovery_input_note_commitment;
+    uint256 recovery_output_note_commitment;
+};
+
+[[nodiscard]] std::optional<SpendPathRecoveryFixtureBuildResult> BuildSpendPathRecoveryFixture(
+    const SpendPathRecoveryFixtureBuildInput& input,
+    std::string& reject_reason);
+
+} // namespace btx::test::shielded
+
+#endif // BTX_TEST_SHIELDED_SPEND_PATH_RECOVERY_FIXTURE_BUILDER_H

--- a/src/test/shielded_spend_path_recovery_fixture_builder_tests.cpp
+++ b/src/test/shielded_spend_path_recovery_fixture_builder_tests.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 The BTX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <chainparams.h>
+#include <shielded/validation.h>
+#include <test/shielded_spend_path_recovery_fixture_builder.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+
+namespace {
+
+BOOST_FIXTURE_TEST_SUITE(shielded_spend_path_recovery_fixture_builder_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(state_aware_fixture_builds_prefork_recovery_tx_that_validates_with_tree_snapshot)
+{
+    const auto& base_consensus = Params().GetConsensus();
+    const int32_t activation_height = std::max<int32_t>(1, base_consensus.nShieldedMatRiCTDisableHeight - 1);
+
+    btx::test::shielded::SpendPathRecoveryFixtureBuildInput input;
+    input.validation_height = activation_height;
+    input.matrict_disable_height = base_consensus.nShieldedMatRiCTDisableHeight;
+    input.legacy_funding_inputs.resize(shielded::lattice::RING_SIZE);
+    for (size_t i = 0; i < input.legacy_funding_inputs.size(); ++i) {
+        input.legacy_funding_inputs[i].funding_outpoint =
+            COutPoint{Txid::FromUint256(uint256{static_cast<unsigned char>(0x20 + i)}), 0};
+        input.legacy_funding_inputs[i].funding_value = 60'000 + static_cast<CAmount>(i) * 1'000;
+    }
+
+    std::string reject_reason;
+    const auto fixture =
+        btx::test::shielded::BuildSpendPathRecoveryFixture(input, reject_reason);
+    BOOST_REQUIRE_MESSAGE(fixture.has_value(), reject_reason);
+    BOOST_REQUIRE_EQUAL(fixture->legacy_txs.size(), shielded::lattice::RING_SIZE);
+    BOOST_REQUIRE_EQUAL(fixture->legacy_note_commitments.size(), shielded::lattice::RING_SIZE);
+    BOOST_CHECK(!fixture->recovery_anchor.IsNull());
+
+    shielded::ShieldedMerkleTree tree;
+    for (const auto& commitment : fixture->legacy_note_commitments) {
+        tree.Append(commitment);
+    }
+    BOOST_CHECK_EQUAL(tree.Root(), fixture->recovery_anchor);
+
+    auto consensus = base_consensus;
+    consensus.nShieldedSpendPathRecoveryActivationHeight = activation_height;
+
+    const CTransaction tx{fixture->recovery_tx};
+    CShieldedProofCheck check(tx,
+                              consensus,
+                              activation_height,
+                              std::make_shared<shielded::ShieldedMerkleTree>(tree),
+                              nullptr,
+                              nullptr);
+    const auto res = check();
+    BOOST_CHECK_MESSAGE(!res.has_value(), res.value_or("unexpected spend-path recovery failure"));
+}
+
+BOOST_AUTO_TEST_CASE(state_aware_fixture_rejects_incorrect_ring_input_count)
+{
+    btx::test::shielded::SpendPathRecoveryFixtureBuildInput input;
+    input.validation_height = 1;
+    input.matrict_disable_height = Params().GetConsensus().nShieldedMatRiCTDisableHeight;
+    input.legacy_funding_inputs.resize(shielded::lattice::RING_SIZE - 1);
+    for (size_t i = 0; i < input.legacy_funding_inputs.size(); ++i) {
+        input.legacy_funding_inputs[i].funding_outpoint =
+            COutPoint{Txid::FromUint256(uint256{static_cast<unsigned char>(0x50 + i)}), 0};
+        input.legacy_funding_inputs[i].funding_value = 60'000;
+    }
+
+    std::string reject_reason;
+    const auto fixture =
+        btx::test::shielded::BuildSpendPathRecoveryFixture(input, reject_reason);
+    BOOST_CHECK(!fixture.has_value());
+    BOOST_CHECK_EQUAL(reject_reason,
+                      "spend-path recovery fixture requires exactly one funding input per ring member");
+}
+
+BOOST_AUTO_TEST_CASE(state_aware_fixture_rejects_post_disable_validation_height)
+{
+    auto consensus = Params().GetConsensus();
+    const int32_t post_disable_height = consensus.nShieldedMatRiCTDisableHeight;
+    BOOST_REQUIRE(post_disable_height > 0);
+
+    btx::test::shielded::SpendPathRecoveryFixtureBuildInput input;
+    input.validation_height = post_disable_height;
+    input.matrict_disable_height = post_disable_height;
+    input.legacy_funding_inputs.resize(shielded::lattice::RING_SIZE);
+    for (size_t i = 0; i < input.legacy_funding_inputs.size(); ++i) {
+        input.legacy_funding_inputs[i].funding_outpoint =
+            COutPoint{Txid::FromUint256(uint256{static_cast<unsigned char>(0x70 + i)}), 0};
+        input.legacy_funding_inputs[i].funding_value = 60'000;
+    }
+
+    std::string reject_reason;
+    const auto fixture =
+        btx::test::shielded::BuildSpendPathRecoveryFixture(input, reject_reason);
+    BOOST_CHECK(!fixture.has_value());
+    BOOST_CHECK_EQUAL(reject_reason,
+                      "state-aware spend-path recovery fixture currently supports pre-disable MatRiCT heights only");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} // namespace

--- a/src/test/shielded_v2_bundle_tests.cpp
+++ b/src/test/shielded_v2_bundle_tests.cpp
@@ -662,6 +662,134 @@ BOOST_AUTO_TEST_CASE(send_bundle_roundtrip_and_bundle_id_commits_to_proof_payloa
     BOOST_CHECK(ComputeTransactionBundleId(different_proof) != ComputeTransactionBundleId(bundle));
 }
 
+BOOST_AUTO_TEST_CASE(spend_path_recovery_bundle_roundtrip_and_payload_digest_are_stable)
+{
+    SpendPathRecoveryPayload payload;
+    payload.spend_anchor = uint256{0x11};
+    payload.spends = {MakeSpend(0x12), MakeSpend(0x22)};
+    for (auto& spend : payload.spends) {
+        spend.merkle_anchor = payload.spend_anchor;
+    }
+    payload.outputs = {MakeOutput(NoteClass::USER, ScanDomain::USER, 0x32),
+                       MakeOutput(NoteClass::USER, ScanDomain::USER, 0x42)};
+    payload.fee = COIN;
+
+    TransactionBundle bundle;
+    bundle.header = MakeBaseHeader(V2_SPEND_PATH_RECOVERY,
+                                   ProofKind::NONE,
+                                   SettlementBindingKind::NONE,
+                                   uint256::ZERO);
+    bundle.payload = payload;
+    bundle.header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(payload);
+
+    BOOST_REQUIRE(bundle.IsValid());
+
+    DataStream ss{};
+    ss << bundle;
+
+    TransactionBundle decoded;
+    ss >> decoded;
+    BOOST_REQUIRE(decoded.IsValid());
+    BOOST_CHECK(BundleHasSemanticFamily(decoded, V2_SPEND_PATH_RECOVERY));
+    BOOST_CHECK(std::holds_alternative<SpendPathRecoveryPayload>(decoded.payload));
+    BOOST_CHECK(ComputePayloadDigest(decoded.payload) == bundle.header.payload_digest);
+    BOOST_CHECK(ComputeTransactionBundleId(decoded) == ComputeTransactionBundleId(bundle));
+}
+
+BOOST_AUTO_TEST_CASE(postfork_generic_spend_path_recovery_bundle_roundtrip_uses_opaque_payload_encoding)
+{
+    SpendPathRecoveryPayload payload;
+    payload.spend_anchor = uint256{0x51};
+    payload.spends = {MakeSpend(0x52)};
+    payload.spends.front().merkle_anchor = payload.spend_anchor;
+    payload.outputs = {MakeOutput(NoteClass::USER, ScanDomain::USER, 0x62)};
+
+    TransactionBundle generic_bundle;
+    generic_bundle.header = MakeBaseHeader(TransactionFamily::V2_GENERIC,
+                                           ProofKind::NONE,
+                                           SettlementBindingKind::GENERIC_POSTFORK,
+                                           uint256::ZERO);
+    generic_bundle.payload = payload;
+    generic_bundle.header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(payload);
+    ApplyDerivedGenericOutputChunks(generic_bundle);
+
+    BOOST_REQUIRE(generic_bundle.IsValid());
+
+    const auto opaque_bytes = SerializePayloadBytes(payload, V2_SPEND_PATH_RECOVERY);
+    BOOST_REQUIRE(!opaque_bytes.empty());
+    BOOST_CHECK_EQUAL(opaque_bytes.size() % OPAQUE_FAMILY_PAYLOAD_PAD_QUANTUM, 0U);
+
+    DataStream ss{};
+    ss << generic_bundle;
+
+    TransactionBundle decoded;
+    ss >> decoded;
+    BOOST_REQUIRE(decoded.IsValid());
+    BOOST_CHECK_EQUAL(decoded.header.family_id, TransactionFamily::V2_GENERIC);
+    BOOST_CHECK(BundleHasSemanticFamily(decoded, V2_SPEND_PATH_RECOVERY));
+    BOOST_CHECK(std::holds_alternative<SpendPathRecoveryPayload>(decoded.payload));
+    BOOST_CHECK(ComputeTransactionBundleId(decoded) == ComputeTransactionBundleId(generic_bundle));
+}
+
+BOOST_AUTO_TEST_CASE(spend_path_recovery_bundle_roundtrip_accepts_proof_payload_scaffold)
+{
+    SpendPathRecoveryPayload payload;
+    payload.spend_anchor = uint256{0x71};
+    payload.spends = {MakeSpend(0x72)};
+    payload.spends.front().merkle_anchor = payload.spend_anchor;
+    payload.outputs = {MakeOutput(NoteClass::USER, ScanDomain::OPAQUE, 0x82)};
+    payload.fee = COIN / 10;
+
+    TransactionBundle bundle;
+    bundle.header = MakeBaseHeader(V2_SPEND_PATH_RECOVERY,
+                                   ProofKind::GENERIC_OPAQUE,
+                                   SettlementBindingKind::NONE,
+                                   uint256{0x73});
+    bundle.payload = payload;
+    bundle.proof_payload = {0xaa, 0xbb, 0xcc, 0xdd};
+    bundle.header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(payload);
+
+    BOOST_REQUIRE(bundle.IsValid());
+
+    DataStream ss{};
+    ss << bundle;
+
+    TransactionBundle decoded;
+    ss >> decoded;
+    BOOST_REQUIRE(decoded.IsValid());
+    BOOST_CHECK(BundleHasSemanticFamily(decoded, V2_SPEND_PATH_RECOVERY));
+    BOOST_CHECK(decoded.proof_payload == bundle.proof_payload);
+    BOOST_CHECK(ComputeTransactionBundleId(decoded) == ComputeTransactionBundleId(bundle));
+}
+
+BOOST_AUTO_TEST_CASE(spend_path_recovery_bundle_uses_fee_as_state_value_balance)
+{
+    SpendPathRecoveryPayload payload;
+    payload.spend_anchor = uint256{0x91};
+    payload.spends = {MakeSpend(0x92)};
+    payload.spends.front().merkle_anchor = payload.spend_anchor;
+    payload.outputs = {MakeOutput(NoteClass::USER, ScanDomain::OPAQUE, 0x93)};
+    payload.fee = COIN / 20;
+
+    TransactionBundle bundle;
+    bundle.header = MakeBaseHeader(V2_SPEND_PATH_RECOVERY,
+                                   ProofKind::NONE,
+                                   SettlementBindingKind::NONE,
+                                   uint256::ZERO);
+    bundle.payload = payload;
+    bundle.header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(payload);
+    BOOST_REQUIRE(bundle.IsValid());
+
+    CShieldedBundle shielded_bundle;
+    shielded_bundle.v2_bundle = bundle;
+
+    std::string reject_reason;
+    const auto state_value_balance = TryGetShieldedStateValueBalance(shielded_bundle, reject_reason);
+    BOOST_REQUIRE_MESSAGE(state_value_balance.has_value(), reject_reason);
+    BOOST_CHECK_EQUAL(*state_value_balance, payload.fee);
+    BOOST_CHECK_EQUAL(GetShieldedTxValueBalance(shielded_bundle), payload.fee);
+}
+
 BOOST_AUTO_TEST_CASE(postfork_generic_send_bundle_roundtrip_uses_opaque_payload_encoding)
 {
     SendPayload payload;

--- a/src/test/shielded_v2_proof_tests.cpp
+++ b/src/test/shielded_v2_proof_tests.cpp
@@ -534,6 +534,85 @@ shielded::v2::TransactionBundle BuildPostforkGenericSmileSendBundle()
     return *bundle;
 }
 
+SmileV2SendFixture BuildPostforkSpendPathRecoveryFixture(unsigned char seed_base = 0x61)
+{
+    using namespace shielded::v2;
+
+    auto fixture = BuildSmileV2SendFixture(seed_base);
+    auto* bundle = fixture.tx.shielded_bundle.v2_bundle ? &*fixture.tx.shielded_bundle.v2_bundle : nullptr;
+    BOOST_REQUIRE(bundle != nullptr);
+
+    const auto send = std::get<SendPayload>(bundle->payload);
+    SpendPathRecoveryPayload recovery;
+    recovery.spend_anchor = send.spend_anchor;
+    recovery.spends = send.spends;
+    recovery.outputs = send.outputs;
+    recovery.fee = send.fee;
+    for (auto& spend : recovery.spends) {
+        spend.merkle_anchor = recovery.spend_anchor;
+        if (spend.note_commitment.IsNull()) {
+            const auto recovered_commitment =
+                std::find_if(fixture.account_leaf_commitments.begin(),
+                             fixture.account_leaf_commitments.end(),
+                             [&](const auto& entry) {
+                                 return entry.second == spend.account_leaf_commitment;
+                             });
+            BOOST_REQUIRE(recovered_commitment != fixture.account_leaf_commitments.end());
+            spend.note_commitment = recovered_commitment->first;
+        }
+    }
+    for (auto& output : recovery.outputs) {
+        output.encrypted_note.scan_domain = ScanDomain::OPAQUE;
+    }
+
+    const auto& consensus = Params().GetConsensus();
+    const int32_t postfork_height = consensus.nShieldedMatRiCTDisableHeight;
+    BOOST_REQUIRE(postfork_height >= 0);
+
+    bundle->header.family_id = GetWireTransactionFamilyForValidationHeight(
+        V2_SPEND_PATH_RECOVERY,
+        &consensus,
+        postfork_height);
+    bundle->header.proof_envelope.proof_kind = GetWireProofKindForValidationHeight(
+        V2_SPEND_PATH_RECOVERY,
+        ProofKind::DIRECT_SMILE,
+        &consensus,
+        postfork_height);
+    bundle->header.proof_envelope.membership_proof_kind =
+        GetWireProofComponentKindForValidationHeight(ProofComponentKind::SMILE_MEMBERSHIP,
+                                                     &consensus,
+                                                     postfork_height);
+    bundle->header.proof_envelope.amount_proof_kind =
+        GetWireProofComponentKindForValidationHeight(ProofComponentKind::SMILE_BALANCE,
+                                                     &consensus,
+                                                     postfork_height);
+    bundle->header.proof_envelope.balance_proof_kind =
+        GetWireProofComponentKindForValidationHeight(ProofComponentKind::SMILE_BALANCE,
+                                                     &consensus,
+                                                     postfork_height);
+    bundle->header.proof_envelope.settlement_binding_kind =
+        GetWireSettlementBindingKindForValidationHeight(V2_SPEND_PATH_RECOVERY,
+                                                        SettlementBindingKind::NONE,
+                                                        &consensus,
+                                                        postfork_height);
+    bundle->payload = recovery;
+    bundle->header.payload_digest = ComputeSpendPathRecoveryPayloadDigest(recovery);
+
+    auto output_chunks = BuildDerivedGenericOutputChunks(bundle->payload);
+    BOOST_REQUIRE(output_chunks.has_value());
+    bundle->output_chunks = std::move(*output_chunks);
+    bundle->header.output_chunk_root = bundle->output_chunks.empty()
+        ? uint256::ZERO
+        : ComputeOutputChunkRoot(Span<const OutputChunkDescriptor>{bundle->output_chunks.data(),
+                                                                   bundle->output_chunks.size()});
+    bundle->header.output_chunk_count = bundle->output_chunks.size();
+    bundle->header.proof_envelope.statement_digest =
+        v2proof::ComputeSpendPathRecoveryStatementDigest(CTransaction{fixture.tx});
+
+    BOOST_REQUIRE(bundle->IsValid());
+    return fixture;
+}
+
 DataStream SerializeBundleWithExplicitProofPayload(
     const shielded::v2::TransactionBundle& bundle,
     Span<const uint8_t> proof_payload_bytes)
@@ -786,6 +865,28 @@ BOOST_AUTO_TEST_CASE(v2_send_statement_tracks_stripped_tx_digest)
                 statement.envelope.statement_digest);
 }
 
+BOOST_AUTO_TEST_CASE(spend_path_recovery_statement_tracks_stripped_tx_digest)
+{
+    auto fixture = BuildPostforkSpendPathRecoveryFixture();
+    const CTransaction tx{fixture.tx};
+
+    const v2proof::ProofStatement statement = v2proof::DescribeSpendPathRecoveryStatement(tx);
+    BOOST_CHECK(statement.IsValid());
+    BOOST_CHECK(statement.domain == v2proof::VerificationDomain::SPEND_PATH_RECOVERY);
+    BOOST_CHECK(statement.envelope.statement_digest ==
+                v2proof::ComputeSpendPathRecoveryStatementDigest(tx));
+
+    CMutableTransaction proof_mutated = fixture.tx;
+    proof_mutated.shielded_bundle.v2_bundle->proof_payload.push_back(0xff);
+    BOOST_CHECK(v2proof::ComputeSpendPathRecoveryStatementDigest(CTransaction{proof_mutated}) ==
+                statement.envelope.statement_digest);
+
+    CMutableTransaction tx_context_mutated = fixture.tx;
+    tx_context_mutated.nLockTime ^= 1;
+    BOOST_CHECK(v2proof::ComputeSpendPathRecoveryStatementDigest(
+                    CTransaction{tx_context_mutated}) != statement.envelope.statement_digest);
+}
+
 BOOST_AUTO_TEST_CASE(v2_send_statement_digest_binds_genesis_after_disable_height)
 {
     auto fixture = BuildSmileV2SendFixture();
@@ -850,6 +951,104 @@ BOOST_AUTO_TEST_CASE(v2_send_context_parses_and_verifies)
                                                              reject_reason);
     BOOST_REQUIRE(ring_members.has_value());
     BOOST_CHECK(v2proof::VerifyV2SendProof(bundle, *context, *ring_members));
+}
+
+BOOST_AUTO_TEST_CASE(spend_path_recovery_context_parses_under_disabled_scaffold)
+{
+    auto fixture = BuildPostforkSpendPathRecoveryFixture();
+    const CTransaction tx{fixture.tx};
+    const auto& bundle = *fixture.tx.shielded_bundle.v2_bundle;
+
+    const v2proof::ProofStatement statement =
+        v2proof::DescribeSpendPathRecoveryStatement(tx);
+    std::string reject_reason;
+    auto context = v2proof::ParseSpendPathRecoveryProof(bundle, statement, reject_reason);
+    BOOST_REQUIRE_MESSAGE(context.has_value(), reject_reason);
+    BOOST_CHECK(context->IsValid(/*expected_input_count=*/1, /*expected_output_count=*/1));
+    BOOST_CHECK(context->material.statement.domain ==
+                v2proof::VerificationDomain::SPEND_PATH_RECOVERY);
+    BOOST_CHECK(context->material.payload_location == v2proof::PayloadLocation::INLINE_WITNESS);
+    BOOST_REQUIRE_EQUAL(context->material.proof_shards.size(), 1U);
+    BOOST_CHECK_EQUAL(context->material.proof_shards[0].leaf_count, 1U);
+    BOOST_CHECK_EQUAL(context->material.proof_shards[0].proof_payload_size,
+                      bundle.proof_payload.size());
+
+    auto nullifiers = v2proof::ExtractBoundNullifiers(*context,
+                                                      /*expected_input_count=*/1,
+                                                      /*expected_output_count=*/1,
+                                                      reject_reason);
+    BOOST_REQUIRE(nullifiers.has_value());
+    BOOST_CHECK_EQUAL(nullifiers->size(), 1U);
+    BOOST_CHECK((*nullifiers)[0] ==
+                std::get<shielded::v2::SpendPathRecoveryPayload>(bundle.payload).spends[0].nullifier);
+}
+
+BOOST_AUTO_TEST_CASE(spend_path_recovery_context_rejects_wrong_statement_digest)
+{
+    auto fixture = BuildPostforkSpendPathRecoveryFixture();
+    CMutableTransaction mutated = fixture.tx;
+    mutated.nLockTime ^= 1;
+
+    std::string reject_reason;
+    auto context = v2proof::ParseSpendPathRecoveryProof(
+        *mutated.shielded_bundle.v2_bundle,
+        v2proof::DescribeSpendPathRecoveryStatement(CTransaction{mutated}),
+        reject_reason);
+    BOOST_CHECK(!context.has_value());
+    BOOST_CHECK_EQUAL(reject_reason, "bad-shielded-proof");
+}
+
+BOOST_AUTO_TEST_CASE(spend_path_recovery_context_rejects_missing_proof_payload)
+{
+    auto fixture = BuildPostforkSpendPathRecoveryFixture();
+    fixture.tx.shielded_bundle.v2_bundle->proof_payload.clear();
+
+    std::string reject_reason;
+    auto context = v2proof::ParseSpendPathRecoveryProof(
+        *fixture.tx.shielded_bundle.v2_bundle,
+        v2proof::DescribeSpendPathRecoveryStatement(CTransaction{fixture.tx}),
+        reject_reason);
+    BOOST_CHECK(!context.has_value());
+    BOOST_CHECK_EQUAL(reject_reason, "bad-shielded-proof-missing");
+}
+
+BOOST_AUTO_TEST_CASE(spend_path_recovery_context_rejects_malformed_witness_encoding)
+{
+    auto fixture = BuildPostforkSpendPathRecoveryFixture();
+    fixture.tx.shielded_bundle.v2_bundle->proof_payload = {0x80};
+
+    std::string reject_reason;
+    auto context = v2proof::ParseSpendPathRecoveryProof(
+        *fixture.tx.shielded_bundle.v2_bundle,
+        v2proof::DescribeSpendPathRecoveryStatement(CTransaction{fixture.tx}),
+        reject_reason);
+    BOOST_CHECK(!context.has_value());
+    BOOST_CHECK_EQUAL(reject_reason, "bad-shielded-proof-encoding");
+}
+
+BOOST_AUTO_TEST_CASE(spend_path_recovery_smile_proof_verifies_against_recovery_context)
+{
+    auto fixture = BuildPostforkSpendPathRecoveryFixture();
+    const auto& bundle = *fixture.tx.shielded_bundle.v2_bundle;
+    const auto statement =
+        v2proof::DescribeSpendPathRecoveryStatement(CTransaction{fixture.tx});
+
+    std::string reject_reason;
+    auto context = v2proof::ParseSpendPathRecoveryProof(bundle, statement, reject_reason);
+    BOOST_REQUIRE_MESSAGE(context.has_value(), reject_reason);
+
+    auto ring_members = v2proof::BuildSpendPathRecoverySmileRingMembers(
+        bundle,
+        *context,
+        fixture.tree,
+        fixture.public_accounts,
+        fixture.account_leaf_commitments,
+        reject_reason);
+    BOOST_REQUIRE_MESSAGE(ring_members.has_value(), reject_reason);
+
+    BOOST_CHECK(v2proof::VerifySpendPathRecoveryProof(bundle,
+                                                      *context,
+                                                      *ring_members));
 }
 
 BOOST_AUTO_TEST_CASE(v2_send_context_rejects_wrong_statement_digest)

--- a/src/test/shielded_v2_wire_tests.cpp
+++ b/src/test/shielded_v2_wire_tests.cpp
@@ -143,9 +143,13 @@ BOOST_AUTO_TEST_CASE(family_id_inventory_is_stable)
     BOOST_CHECK_EQUAL(static_cast<uint8_t>(TransactionFamily::V2_REBALANCE), 4);
     BOOST_CHECK_EQUAL(static_cast<uint8_t>(TransactionFamily::V2_SETTLEMENT_ANCHOR), 5);
     BOOST_CHECK_EQUAL(static_cast<uint8_t>(TransactionFamily::V2_GENERIC), 6);
+    BOOST_CHECK_EQUAL(static_cast<uint8_t>(TransactionFamily::V2_LIFECYCLE), 7);
+    BOOST_CHECK_EQUAL(static_cast<uint8_t>(V2_SPEND_PATH_RECOVERY), 8);
 
     BOOST_CHECK_EQUAL(GetTransactionFamilyName(TransactionFamily::V2_EGRESS_BATCH), "v2_egress_batch");
     BOOST_CHECK_EQUAL(GetTransactionFamilyName(TransactionFamily::V2_GENERIC), "shielded_v2");
+    BOOST_CHECK_EQUAL(GetTransactionFamilyName(V2_SPEND_PATH_RECOVERY), "v2_spend_path_recovery");
+    BOOST_CHECK(IsValidTransactionFamily(V2_SPEND_PATH_RECOVERY));
 }
 
 BOOST_AUTO_TEST_CASE(proof_kind_inventory_is_stable)
@@ -197,6 +201,16 @@ BOOST_AUTO_TEST_CASE(generic_wire_family_activates_at_disable_height)
         TransactionFamily::V2_GENERIC);
     BOOST_CHECK_EQUAL(
         GetWireTransactionFamilyForValidationHeight(TransactionFamily::V2_SETTLEMENT_ANCHOR,
+                                                    &consensus,
+                                                    activation_height),
+        TransactionFamily::V2_GENERIC);
+    BOOST_CHECK_EQUAL(
+        GetWireTransactionFamilyForValidationHeight(V2_SPEND_PATH_RECOVERY,
+                                                    &consensus,
+                                                    activation_height - 1),
+        V2_SPEND_PATH_RECOVERY);
+    BOOST_CHECK_EQUAL(
+        GetWireTransactionFamilyForValidationHeight(V2_SPEND_PATH_RECOVERY,
                                                     &consensus,
                                                     activation_height),
         TransactionFamily::V2_GENERIC);

--- a/src/test/shielded_validation_checks_tests.cpp
+++ b/src/test/shielded_validation_checks_tests.cpp
@@ -884,6 +884,35 @@ V2SendFixture BuildV2SendFixture(CAmount fee = 0,
 
 BOOST_FIXTURE_TEST_SUITE(shielded_validation_checks_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(describe_shielded_v2_context_reports_expected_family_names)
+{
+    CShieldedBundle legacy_bundle;
+    BOOST_CHECK_EQUAL(DescribeShieldedV2Context(legacy_bundle), "legacy-bundle");
+
+    auto send_tx = BuildLegacyLifecycleSendTx(Params().GetConsensus(),
+                                              Params().GetConsensus().nShieldedMatRiCTDisableHeight - 1);
+    BOOST_REQUIRE(send_tx.HasShieldedBundle());
+    BOOST_CHECK_EQUAL(DescribeShieldedV2Context(send_tx.GetShieldedBundle()), "v2-family-send");
+
+    auto lifecycle_tx = BuildLifecycleControlTx();
+    BOOST_REQUIRE(lifecycle_tx.HasShieldedBundle());
+    BOOST_CHECK_EQUAL(DescribeShieldedV2Context(lifecycle_tx.GetShieldedBundle()),
+                      "v2-family-lifecycle");
+
+    auto generic_tx = BuildPostforkGenericSendLifecycleControlTx(
+        Params().GetConsensus(),
+        Params().GetConsensus().nShieldedMatRiCTDisableHeight);
+    BOOST_REQUIRE(generic_tx.HasShieldedBundle());
+    BOOST_CHECK_EQUAL(DescribeShieldedV2Context(generic_tx.GetShieldedBundle()), "v2-family-send");
+
+    BOOST_CHECK_EQUAL(ShieldedV2FamilyName(shielded::v2::TransactionFamily::V2_INGRESS_BATCH),
+                      "ingress-batch");
+    BOOST_CHECK_EQUAL(ShieldedV2FamilyName(shielded::v2::TransactionFamily::V2_GENERIC),
+                      "generic");
+    BOOST_CHECK_EQUAL(ShieldedV2FamilyName(shielded::v2::V2_SPEND_PATH_RECOVERY),
+                      "spend-path-recovery");
+}
+
 BOOST_AUTO_TEST_CASE(proof_check_accepts_valid_bundle)
 {
     CMutableTransaction mtx;
@@ -1045,6 +1074,412 @@ BOOST_AUTO_TEST_CASE(proof_check_rejects_postfork_legacy_v2_send_wire_family)
     const auto res = check();
     BOOST_REQUIRE(res.has_value());
     BOOST_CHECK_EQUAL(*res, "bad-shielded-v2-family-wire");
+}
+
+void PrepareFixtureAsSpendPathRecovery(V2SendFixture& fixture, bool keep_proof_surface = false)
+{
+    auto& bundle = *fixture.tx.shielded_bundle.v2_bundle;
+    const auto send = std::get<shielded::v2::SendPayload>(bundle.payload);
+
+    shielded::v2::SpendPathRecoveryPayload payload;
+    payload.spend_anchor = send.spend_anchor;
+    payload.spends = send.spends;
+    for (auto& spend : payload.spends) {
+        spend.merkle_anchor = payload.spend_anchor;
+        if (spend.note_commitment.IsNull()) {
+            const auto recovered_commitment =
+                std::find_if(fixture.account_leaf_commitments.begin(),
+                             fixture.account_leaf_commitments.end(),
+                             [&](const auto& entry) {
+                                 return entry.second == spend.account_leaf_commitment;
+                             });
+            BOOST_REQUIRE(recovered_commitment != fixture.account_leaf_commitments.end());
+            spend.note_commitment = recovered_commitment->first;
+        }
+    }
+    payload.outputs = send.outputs;
+    payload.fee = send.fee;
+
+    bundle.payload = payload;
+    bundle.proof_shards.clear();
+    bundle.header.proof_shard_count = 0;
+    bundle.header.proof_shard_root = uint256::ZERO;
+    if (!keep_proof_surface) {
+        bundle.proof_payload.clear();
+        bundle.header.proof_envelope = {};
+        bundle.header.proof_envelope.proof_kind = shielded::v2::ProofKind::NONE;
+        bundle.header.proof_envelope.membership_proof_kind = shielded::v2::ProofComponentKind::NONE;
+        bundle.header.proof_envelope.amount_proof_kind = shielded::v2::ProofComponentKind::NONE;
+        bundle.header.proof_envelope.balance_proof_kind = shielded::v2::ProofComponentKind::NONE;
+    } else {
+        bundle.header.proof_envelope.proof_kind =
+            shielded::v2::GetWireProofKindForValidationHeight(
+                shielded::v2::V2_SPEND_PATH_RECOVERY,
+                shielded::v2::ProofKind::DIRECT_SMILE,
+                fixture.consensus,
+                fixture.validation_height);
+        bundle.header.proof_envelope.membership_proof_kind =
+            shielded::v2::GetWireProofComponentKindForValidationHeight(
+                shielded::v2::ProofComponentKind::SMILE_MEMBERSHIP,
+                fixture.consensus,
+                fixture.validation_height);
+        bundle.header.proof_envelope.amount_proof_kind =
+            shielded::v2::GetWireProofComponentKindForValidationHeight(
+                shielded::v2::ProofComponentKind::SMILE_BALANCE,
+                fixture.consensus,
+                fixture.validation_height);
+        bundle.header.proof_envelope.balance_proof_kind =
+            shielded::v2::GetWireProofComponentKindForValidationHeight(
+                shielded::v2::ProofComponentKind::SMILE_BALANCE,
+                fixture.consensus,
+                fixture.validation_height);
+    }
+    bundle.header.proof_envelope.settlement_binding_kind =
+        shielded::v2::GetWireSettlementBindingKindForValidationHeight(
+            shielded::v2::V2_SPEND_PATH_RECOVERY,
+            shielded::v2::SettlementBindingKind::NONE,
+            fixture.consensus,
+            fixture.validation_height);
+    bundle.header.family_id = shielded::v2::GetWireTransactionFamilyForValidationHeight(
+        shielded::v2::V2_SPEND_PATH_RECOVERY,
+        fixture.consensus,
+        fixture.validation_height);
+    bundle.header.proof_envelope.extension_digest = uint256::ZERO;
+    bundle.header.payload_digest = shielded::v2::ComputeSpendPathRecoveryPayloadDigest(payload);
+    RefreshFixtureWireOutputChunks(bundle);
+    bundle.header.proof_envelope.statement_digest = keep_proof_surface
+        ? shielded::v2::proof::ComputeSpendPathRecoveryStatementDigest(CTransaction{fixture.tx})
+        : uint256::ZERO;
+    BOOST_REQUIRE(bundle.IsValid());
+}
+
+BOOST_AUTO_TEST_CASE(prefork_spend_path_recovery_bundle_is_serializable)
+{
+    const auto& consensus = Params().GetConsensus();
+    const int32_t prefork_height = consensus.nShieldedMatRiCTDisableHeight - 1;
+    BOOST_REQUIRE(prefork_height >= 0);
+
+    auto fixture = BuildV2SendFixture(/*fee=*/0,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      prefork_height);
+    PrepareFixtureAsSpendPathRecovery(fixture);
+    auto* bundle = fixture.tx.shielded_bundle.v2_bundle ? &*fixture.tx.shielded_bundle.v2_bundle : nullptr;
+    BOOST_REQUIRE(bundle != nullptr);
+    DataStream ss{};
+    BOOST_CHECK_NO_THROW(ss << *bundle);
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_rejects_prefork_spend_path_recovery_family_as_disabled)
+{
+    const auto& consensus = Params().GetConsensus();
+    const int32_t prefork_height = consensus.nShieldedMatRiCTDisableHeight - 1;
+    BOOST_REQUIRE(prefork_height >= 0);
+
+    auto fixture = BuildV2SendFixture(/*fee=*/0,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      prefork_height);
+    PrepareFixtureAsSpendPathRecovery(fixture);
+
+    const CTransaction tx{fixture.tx};
+    CShieldedProofCheck check(tx,
+                              consensus,
+                              prefork_height,
+                              std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree),
+                              std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(
+                                  fixture.public_accounts),
+                              std::make_shared<const std::map<uint256, uint256>>(
+                                  fixture.account_leaf_commitments));
+    const auto res = check();
+    BOOST_REQUIRE(res.has_value());
+    BOOST_CHECK_EQUAL(*res, "bad-shielded-v2-spend-path-recovery-disabled");
+}
+
+BOOST_AUTO_TEST_CASE(postfork_spend_path_recovery_bundle_is_serializable)
+{
+    auto fixture = BuildV2SendFixture();
+    PrepareFixtureAsSpendPathRecovery(fixture);
+    auto* bundle = fixture.tx.shielded_bundle.v2_bundle ? &*fixture.tx.shielded_bundle.v2_bundle : nullptr;
+    BOOST_REQUIRE(bundle != nullptr);
+    DataStream ss{};
+    BOOST_CHECK_NO_THROW(ss << *bundle);
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_rejects_postfork_spend_path_recovery_family_as_disabled)
+{
+    auto fixture = BuildV2SendFixture();
+    PrepareFixtureAsSpendPathRecovery(fixture);
+
+    const CTransaction tx{fixture.tx};
+    CShieldedProofCheck check(tx,
+                              *fixture.consensus,
+                              fixture.validation_height,
+                              std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree),
+                              std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(
+                                  fixture.public_accounts),
+                              std::make_shared<const std::map<uint256, uint256>>(
+                                  fixture.account_leaf_commitments));
+    const auto res = check();
+    BOOST_REQUIRE(res.has_value());
+    BOOST_CHECK_EQUAL(*res, "bad-shielded-v2-spend-path-recovery-disabled");
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_rejects_postfork_spend_path_recovery_proof_surface_as_disabled)
+{
+    auto fixture = BuildV2SendFixture();
+    PrepareFixtureAsSpendPathRecovery(fixture, /*keep_proof_surface=*/true);
+
+    const CTransaction tx{fixture.tx};
+    CShieldedProofCheck check(tx,
+                              *fixture.consensus,
+                              fixture.validation_height,
+                              std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree),
+                              std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(
+                                  fixture.public_accounts),
+                              std::make_shared<const std::map<uint256, uint256>>(
+                                  fixture.account_leaf_commitments));
+    const auto res = check();
+    BOOST_REQUIRE(res.has_value());
+    BOOST_CHECK_EQUAL(*res, "bad-shielded-v2-spend-path-recovery-disabled");
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_accepts_prefork_spend_path_recovery_when_activated)
+{
+    auto consensus = Params().GetConsensus();
+    const int32_t activation_height = consensus.nShieldedMatRiCTDisableHeight - 1;
+    BOOST_REQUIRE(activation_height >= 0);
+    consensus.nShieldedSpendPathRecoveryActivationHeight = activation_height;
+
+    auto fixture = BuildV2SendFixture(/*fee=*/shielded::SHIELDED_PRIVACY_FEE_QUANTUM,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      activation_height);
+    PrepareFixtureAsSpendPathRecovery(fixture, /*keep_proof_surface=*/true);
+
+    const CTransaction tx{fixture.tx};
+    CShieldedProofCheck check(tx,
+                              consensus,
+                              activation_height,
+                              std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree),
+                              std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(
+                                  fixture.public_accounts),
+                              std::make_shared<const std::map<uint256, uint256>>(
+                                  fixture.account_leaf_commitments));
+    const auto res = check();
+    BOOST_CHECK_MESSAGE(!res.has_value(), res.value_or("unexpected spend-path recovery failure"));
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_accepts_postfork_spend_path_recovery_when_activated)
+{
+    auto consensus = Params().GetConsensus();
+    const int32_t activation_height = consensus.nShieldedMatRiCTDisableHeight;
+    BOOST_REQUIRE(activation_height >= 0);
+    consensus.nShieldedSpendPathRecoveryActivationHeight = activation_height;
+
+    auto fixture = BuildV2SendFixture(/*fee=*/shielded::SHIELDED_PRIVACY_FEE_QUANTUM,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      activation_height);
+    PrepareFixtureAsSpendPathRecovery(fixture, /*keep_proof_surface=*/true);
+
+    const CTransaction tx{fixture.tx};
+    CShieldedProofCheck check(tx,
+                              consensus,
+                              activation_height,
+                              std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree),
+                              std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(
+                                  fixture.public_accounts),
+                              std::make_shared<const std::map<uint256, uint256>>(
+                                  fixture.account_leaf_commitments));
+    const auto res = check();
+    BOOST_CHECK_MESSAGE(!res.has_value(), res.value_or("unexpected postfork spend-path recovery failure"));
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_prefork_spend_path_recovery_enforces_activation_boundary)
+{
+    auto consensus = Params().GetConsensus();
+    const int32_t activation_height = consensus.nShieldedMatRiCTDisableHeight - 1;
+    BOOST_REQUIRE(activation_height > 0);
+    consensus.nShieldedSpendPathRecoveryActivationHeight = activation_height;
+
+    auto fixture = BuildV2SendFixture(/*fee=*/shielded::SHIELDED_PRIVACY_FEE_QUANTUM,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      activation_height);
+    PrepareFixtureAsSpendPathRecovery(fixture, /*keep_proof_surface=*/true);
+
+    const auto tree = std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree);
+    const auto public_accounts =
+        std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(fixture.public_accounts);
+    const auto account_leaf_commitments =
+        std::make_shared<const std::map<uint256, uint256>>(fixture.account_leaf_commitments);
+    const CTransaction tx{fixture.tx};
+
+    CShieldedProofCheck pre_activation_check(tx,
+                                             consensus,
+                                             activation_height - 1,
+                                             tree,
+                                             public_accounts,
+                                             account_leaf_commitments);
+    const auto pre_activation_result = pre_activation_check();
+    BOOST_REQUIRE(pre_activation_result.has_value());
+    BOOST_CHECK_EQUAL(*pre_activation_result, "bad-shielded-v2-spend-path-recovery-disabled");
+
+    CShieldedProofCheck at_activation_check(tx,
+                                            consensus,
+                                            activation_height,
+                                            tree,
+                                            public_accounts,
+                                            account_leaf_commitments);
+    const auto at_activation_result = at_activation_check();
+    BOOST_CHECK_MESSAGE(!at_activation_result.has_value(),
+                        at_activation_result.value_or("unexpected prefork activation-boundary failure"));
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_postfork_spend_path_recovery_enforces_activation_boundary)
+{
+    auto consensus = Params().GetConsensus();
+    const int32_t activation_height = consensus.nShieldedMatRiCTDisableHeight + 1;
+    consensus.nShieldedSpendPathRecoveryActivationHeight = activation_height;
+
+    auto fixture = BuildV2SendFixture(/*fee=*/shielded::SHIELDED_PRIVACY_FEE_QUANTUM,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      activation_height);
+    PrepareFixtureAsSpendPathRecovery(fixture, /*keep_proof_surface=*/true);
+
+    const auto tree = std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree);
+    const auto public_accounts =
+        std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(fixture.public_accounts);
+    const auto account_leaf_commitments =
+        std::make_shared<const std::map<uint256, uint256>>(fixture.account_leaf_commitments);
+    const CTransaction tx{fixture.tx};
+
+    CShieldedProofCheck pre_activation_check(tx,
+                                             consensus,
+                                             activation_height - 1,
+                                             tree,
+                                             public_accounts,
+                                             account_leaf_commitments);
+    const auto pre_activation_result = pre_activation_check();
+    BOOST_REQUIRE(pre_activation_result.has_value());
+    BOOST_CHECK_EQUAL(*pre_activation_result, "bad-shielded-v2-spend-path-recovery-disabled");
+
+    CShieldedProofCheck at_activation_check(tx,
+                                            consensus,
+                                            activation_height,
+                                            tree,
+                                            public_accounts,
+                                            account_leaf_commitments);
+    const auto at_activation_result = at_activation_check();
+    BOOST_CHECK_MESSAGE(!at_activation_result.has_value(),
+                        at_activation_result.value_or("unexpected postfork activation-boundary failure"));
+}
+
+BOOST_AUTO_TEST_CASE(prefork_activated_spend_path_recovery_smile_proof_verifies_at_proof_layer)
+{
+    auto consensus = Params().GetConsensus();
+    const int32_t activation_height = consensus.nShieldedMatRiCTDisableHeight - 1;
+    BOOST_REQUIRE(activation_height >= 0);
+    consensus.nShieldedSpendPathRecoveryActivationHeight = activation_height;
+
+    auto fixture = BuildV2SendFixture(/*fee=*/shielded::SHIELDED_PRIVACY_FEE_QUANTUM,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      activation_height);
+    PrepareFixtureAsSpendPathRecovery(fixture, /*keep_proof_surface=*/true);
+
+    const auto& bundle = *fixture.tx.shielded_bundle.v2_bundle;
+    const auto statement =
+        shielded::v2::proof::DescribeSpendPathRecoveryStatement(CTransaction{fixture.tx});
+    std::string reject_reason;
+    auto context = shielded::v2::proof::ParseSpendPathRecoveryProof(bundle, statement, reject_reason);
+    BOOST_REQUIRE_MESSAGE(context.has_value(), reject_reason);
+    auto ring_members = shielded::v2::proof::BuildSpendPathRecoverySmileRingMembers(
+        bundle,
+        *context,
+        fixture.tree,
+        fixture.public_accounts,
+        fixture.account_leaf_commitments,
+        reject_reason);
+    BOOST_REQUIRE_MESSAGE(ring_members.has_value(), reject_reason);
+    BOOST_CHECK(shielded::v2::proof::VerifySpendPathRecoveryProof(bundle,
+                                                                  *context,
+                                                                  *ring_members));
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_rejects_prefork_activated_spend_path_recovery_with_tampered_nullifier)
+{
+    auto consensus = Params().GetConsensus();
+    const int32_t activation_height = consensus.nShieldedMatRiCTDisableHeight - 1;
+    BOOST_REQUIRE(activation_height >= 0);
+    consensus.nShieldedSpendPathRecoveryActivationHeight = activation_height;
+
+    auto fixture = BuildV2SendFixture(/*fee=*/shielded::SHIELDED_PRIVACY_FEE_QUANTUM,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      activation_height);
+    PrepareFixtureAsSpendPathRecovery(fixture, /*keep_proof_surface=*/true);
+
+    auto* bundle = fixture.tx.shielded_bundle.v2_bundle ? &*fixture.tx.shielded_bundle.v2_bundle : nullptr;
+    BOOST_REQUIRE(bundle != nullptr);
+    auto& payload = std::get<shielded::v2::SpendPathRecoveryPayload>(bundle->payload);
+    payload.spends[0].nullifier = uint256{0x44};
+    bundle->header.payload_digest = shielded::v2::ComputeSpendPathRecoveryPayloadDigest(payload);
+    bundle->header.proof_envelope.statement_digest =
+        shielded::v2::proof::ComputeSpendPathRecoveryStatementDigest(CTransaction{fixture.tx});
+    BOOST_REQUIRE(bundle->IsValid());
+
+    const CTransaction tx{fixture.tx};
+    CShieldedProofCheck check(tx,
+                              consensus,
+                              activation_height,
+                              std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree),
+                              std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(
+                                  fixture.public_accounts),
+                              std::make_shared<const std::map<uint256, uint256>>(
+                                  fixture.account_leaf_commitments));
+    const auto res = check();
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "expected reject for tampered spend-path recovery nullifier");
+    BOOST_CHECK_EQUAL(*res, "bad-shielded-proof");
+}
+
+BOOST_AUTO_TEST_CASE(proof_check_rejects_postfork_activated_spend_path_recovery_with_tampered_nullifier)
+{
+    auto consensus = Params().GetConsensus();
+    const int32_t activation_height = consensus.nShieldedMatRiCTDisableHeight;
+    BOOST_REQUIRE(activation_height >= 0);
+    consensus.nShieldedSpendPathRecoveryActivationHeight = activation_height;
+
+    auto fixture = BuildV2SendFixture(/*fee=*/shielded::SHIELDED_PRIVACY_FEE_QUANTUM,
+                                      smile2::SmileProofCodecPolicy::CANONICAL_NO_RICE,
+                                      &consensus,
+                                      activation_height);
+    PrepareFixtureAsSpendPathRecovery(fixture, /*keep_proof_surface=*/true);
+
+    auto* bundle = fixture.tx.shielded_bundle.v2_bundle ? &*fixture.tx.shielded_bundle.v2_bundle : nullptr;
+    BOOST_REQUIRE(bundle != nullptr);
+    auto& payload = std::get<shielded::v2::SpendPathRecoveryPayload>(bundle->payload);
+    payload.spends[0].nullifier = uint256{0x54};
+    bundle->header.payload_digest = shielded::v2::ComputeSpendPathRecoveryPayloadDigest(payload);
+    RefreshFixtureWireOutputChunks(*bundle);
+    bundle->header.proof_envelope.statement_digest =
+        shielded::v2::proof::ComputeSpendPathRecoveryStatementDigest(CTransaction{fixture.tx});
+    BOOST_REQUIRE(bundle->IsValid());
+
+    const CTransaction tx{fixture.tx};
+    CShieldedProofCheck check(tx,
+                              consensus,
+                              activation_height,
+                              std::make_shared<shielded::ShieldedMerkleTree>(fixture.tree),
+                              std::make_shared<const std::map<uint256, smile2::CompactPublicAccount>>(
+                                  fixture.public_accounts),
+                              std::make_shared<const std::map<uint256, uint256>>(
+                                  fixture.account_leaf_commitments));
+    const auto res = check();
+    BOOST_REQUIRE_MESSAGE(res.has_value(), "expected reject for tampered postfork spend-path recovery nullifier");
+    BOOST_CHECK_EQUAL(*res, "bad-shielded-proof");
 }
 
 BOOST_AUTO_TEST_CASE(proof_check_rejects_prefork_generic_v2_send_proof_wire)

--- a/src/test/shielded_wallet_chunk_discovery_tests.cpp
+++ b/src/test/shielded_wallet_chunk_discovery_tests.cpp
@@ -12,8 +12,10 @@
 #include <noui.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <shielded/bundle.h>
 #include <shielded/note.h>
 #include <shielded/note_encryption.h>
+#include <script/sign.h>
 #include <streams.h>
 #include <shielded/smile2/wallet_bridge.h>
 #include <shielded/v2_ingress.h>
@@ -27,6 +29,7 @@
 #include <wallet/shielded_wallet.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
+#include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -255,6 +258,29 @@ std::vector<smile2::wallet::SmileRingMember> BuildIngressSpendSmileRingMembers(
             smile2::wallet::SMILE_GLOBAL_SEED,
             ring_members[i]));
     }
+    return members;
+}
+
+std::vector<smile2::wallet::SmileRingMember> BuildDirectSpendSmileRingMembers(
+    const std::vector<uint256>& ring_members,
+    const ShieldedNote& real_note,
+    const uint256& real_note_commitment,
+    size_t real_index)
+{
+    std::vector<smile2::wallet::SmileRingMember> members;
+    members.reserve(ring_members.size());
+    for (const uint256& commitment : ring_members) {
+        members.push_back(
+            smile2::wallet::BuildPlaceholderRingMember(smile2::wallet::SMILE_GLOBAL_SEED, commitment));
+    }
+
+    auto real_member = smile2::wallet::BuildRingMemberFromNote(smile2::wallet::SMILE_GLOBAL_SEED,
+                                                               real_note,
+                                                               real_note_commitment);
+    if (!real_member.has_value()) {
+        throw std::runtime_error("failed to encode real direct smile ring member fixture");
+    }
+    members[real_index] = *real_member;
     return members;
 }
 
@@ -590,6 +616,83 @@ CTransaction BuildMinimalV2SendTransaction(const uint256& recipient_pk_hash,
     return CTransaction{tx};
 }
 
+CMutableTransaction BuildLegacyShieldOnlyTransaction(TestChain100Setup& setup,
+                                                     const CTransactionRef& funding_tx,
+                                                     const uint256& merkle_anchor,
+                                                     const ShieldedNote& note,
+                                                     const mlkem::PublicKey& recipient_kem_pk,
+                                                     uint32_t seed,
+                                                     CAmount fee = shielded::SHIELDED_PRIVACY_FEE_QUANTUM)
+{
+    BOOST_REQUIRE_GT(funding_tx->vout.size(), 0U);
+    BOOST_REQUIRE_GT(funding_tx->vout[0].nValue, fee);
+    BOOST_REQUIRE(!merkle_anchor.IsNull());
+
+    CMutableTransaction tx;
+    tx.vin = {CTxIn{COutPoint{funding_tx->GetHash(), 0}}};
+    tx.version = CTransaction::CURRENT_VERSION;
+    tx.nLockTime = seed;
+
+    CShieldedOutput output;
+    output.note_commitment = note.GetCommitment();
+    output.encrypted_note = EncryptNote(note, recipient_kem_pk, seed + 1);
+    output.merkle_anchor = merkle_anchor;
+    tx.shielded_bundle.shielded_outputs.push_back(std::move(output));
+    tx.shielded_bundle.value_balance = -(funding_tx->vout[0].nValue - fee);
+
+    FillableSigningProvider keystore;
+    BOOST_REQUIRE(keystore.AddKey(setup.coinbaseKey));
+    std::map<COutPoint, Coin> input_coins;
+    input_coins.emplace(COutPoint{funding_tx->GetHash(), 0},
+                        Coin{funding_tx->vout[0], /*nHeight=*/0, /*coinbase=*/true});
+    std::map<int, bilingual_str> input_errors;
+    BOOST_REQUIRE(SignTransaction(tx, &keystore, input_coins, SIGHASH_ALL, input_errors));
+    return tx;
+}
+
+void ConvertBuiltV2SendToSpendPathRecovery(CMutableTransaction& tx,
+                                          Span<const uint256> spend_note_commitments)
+{
+    auto* bundle = tx.shielded_bundle.v2_bundle ? &*tx.shielded_bundle.v2_bundle : nullptr;
+    BOOST_REQUIRE(bundle != nullptr);
+    BOOST_REQUIRE(
+        shielded::v2::BundleHasSemanticFamily(*bundle, shielded::v2::TransactionFamily::V2_SEND));
+
+    const auto send = std::get<shielded::v2::SendPayload>(bundle->payload);
+
+    shielded::v2::SpendPathRecoveryPayload payload;
+    payload.spend_anchor = send.spend_anchor;
+    payload.spends = send.spends;
+    BOOST_REQUIRE_EQUAL(payload.spends.size(), spend_note_commitments.size());
+    for (auto& spend : payload.spends) {
+        spend.merkle_anchor = payload.spend_anchor;
+        if (spend.note_commitment.IsNull()) {
+            const size_t spend_index = static_cast<size_t>(&spend - payload.spends.data());
+            spend.note_commitment = spend_note_commitments[spend_index];
+        }
+    }
+    payload.outputs = send.outputs;
+    payload.fee = send.fee;
+
+    bundle->payload = payload;
+    bundle->proof_shards.clear();
+    bundle->proof_payload.clear();
+    bundle->header.family_id = shielded::v2::V2_SPEND_PATH_RECOVERY;
+    bundle->header.proof_shard_count = 0;
+    bundle->header.proof_shard_root = uint256::ZERO;
+    bundle->header.proof_envelope = {};
+    bundle->header.proof_envelope.proof_kind = shielded::v2::ProofKind::NONE;
+    bundle->header.proof_envelope.membership_proof_kind = shielded::v2::ProofComponentKind::NONE;
+    bundle->header.proof_envelope.amount_proof_kind = shielded::v2::ProofComponentKind::NONE;
+    bundle->header.proof_envelope.balance_proof_kind = shielded::v2::ProofComponentKind::NONE;
+    bundle->header.proof_envelope.settlement_binding_kind =
+        shielded::v2::SettlementBindingKind::NONE;
+    bundle->header.proof_envelope.statement_digest = uint256::ZERO;
+    bundle->header.proof_envelope.extension_digest = uint256::ZERO;
+    bundle->header.payload_digest = shielded::v2::ComputeSpendPathRecoveryPayloadDigest(payload);
+    BOOST_REQUIRE(bundle->IsValid());
+}
+
 BOOST_AUTO_TEST_CASE(unencrypted_wallet_runtime_paths_skip_master_seed_noise)
 {
     wallet::CWallet unencrypted_wallet(
@@ -839,6 +942,282 @@ BOOST_AUTO_TEST_CASE(locked_scan_owned_note_rehydrates_to_spendable_on_unlock)
         BOOST_CHECK_EQUAL(shielded_wallet->GetShieldedBalance(/*min_depth=*/0), value);
         BOOST_REQUIRE_EQUAL(shielded_wallet->GetSpendableNotes(/*min_depth=*/0).size(), 1U);
     }
+}
+
+BOOST_AUTO_TEST_CASE(owned_legacy_note_is_counted_as_spendable_but_cannot_build_ordinary_v2_send)
+{
+    constexpr size_t tree_size = 16;
+    mineBlocks(COINBASE_MATURITY);
+    const ShieldedNote owned_note = MakeNote(owned_addr.pk_hash, 21 * COIN, 0x130);
+    uint256 legacy_anchor;
+    {
+        LOCK(cs_main);
+        legacy_anchor = Assert(m_node.chainman)->GetShieldedMerkleTree().Root();
+    }
+    BOOST_REQUIRE(!legacy_anchor.IsNull());
+
+    std::vector<CMutableTransaction> legacy_txs;
+    legacy_txs.reserve(tree_size);
+    legacy_txs.push_back(BuildLegacyShieldOnlyTransaction(*this,
+                                                          m_coinbase_txns[1],
+                                                          legacy_anchor,
+                                                          owned_note,
+                                                          owned_kem_pk,
+                                                          0x140));
+    for (size_t i = 1; i < tree_size; ++i) {
+        const auto foreign_key =
+            BuildKeyPair("BTX_ShieldedV2_ChunkScan_LegacyForeign", static_cast<uint32_t>(i));
+        const uint256 foreign_pk_hash =
+            DeriveUint256("BTX_ShieldedV2_ChunkScan_LegacyForeignPkHash", static_cast<uint32_t>(i));
+        legacy_txs.push_back(BuildLegacyShieldOnlyTransaction(
+            *this,
+            m_coinbase_txns[i + 1],
+            legacy_anchor,
+            MakeNote(foreign_pk_hash,
+                     5 * COIN + static_cast<CAmount>(i) * COIN / 10,
+                     0x130 + static_cast<uint32_t>(i)),
+            foreign_key.pk,
+            0x140 + static_cast<uint32_t>(i)));
+    }
+
+    const auto account_leaf_commitments =
+        CollectShieldedOutputAccountLeafCommitments(legacy_txs.front().shielded_bundle);
+    BOOST_REQUIRE(account_leaf_commitments.has_value());
+    BOOST_CHECK(account_leaf_commitments->empty());
+
+    const auto script_pub_key = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
+    const CBlock accepted_block = CreateAndProcessBlock(legacy_txs, script_pub_key);
+    BOOST_REQUIRE_EQUAL(accepted_block.vtx.size(), tree_size + 1U);
+
+    LOCK2(wallet.cs_wallet, shielded_wallet->cs_shielded);
+    const int block_height = m_node.chain->getHeight().value_or(0);
+    BOOST_REQUIRE_GT(block_height, 0);
+    shielded_wallet->ScanBlock(accepted_block, block_height);
+
+    const auto unspent = shielded_wallet->GetUnspentNotes(/*min_depth=*/1);
+    BOOST_REQUIRE_EQUAL(unspent.size(), 1U);
+    BOOST_CHECK(unspent.front().is_mine_spend);
+    BOOST_CHECK(!unspent.front().account_leaf_hint.has_value());
+    BOOST_CHECK_EQUAL(unspent.front().note.value, owned_note.value);
+
+    const auto spendable = shielded_wallet->GetSpendableNotes(/*min_depth=*/1);
+    BOOST_REQUIRE_EQUAL(spendable.size(), 1U);
+    BOOST_CHECK_EQUAL(spendable.front().commitment, unspent.front().commitment);
+    BOOST_CHECK(!spendable.front().account_leaf_hint.has_value());
+
+    const auto summary = shielded_wallet->GetShieldedBalanceSummary(/*min_depth=*/1);
+    BOOST_CHECK_EQUAL(summary.spendable, owned_note.value);
+    BOOST_CHECK_EQUAL(summary.watchonly, 0);
+    BOOST_CHECK_EQUAL(summary.spendable_note_count, 1);
+
+    const auto cached_view = shielded_wallet->GetCachedTransactionView(legacy_txs.front().GetHash());
+    BOOST_REQUIRE(cached_view.has_value());
+    BOOST_CHECK_EQUAL(cached_view->family, "legacy_shield");
+    BOOST_REQUIRE_EQUAL(cached_view->outputs.size(), 1U);
+    BOOST_CHECK(cached_view->output_chunks.empty());
+
+    const size_t real_index = 3;
+    const auto tree = BuildSpendTree(spendable.front().commitment, real_index);
+    const auto ring_positions = BuildRingPositions();
+    const auto ring_members = BuildRingMembers(tree, ring_positions);
+    auto smile_ring_members = BuildIngressSpendSmileRingMembers(ring_members,
+                                                                spendable.front().note,
+                                                                spendable.front().commitment,
+                                                                real_index);
+    BOOST_REQUIRE_EQUAL(smile_ring_members.size(), ring_members.size());
+
+    shielded::v2::V2SendSpendInput spend_input;
+    spend_input.note = spendable.front().note;
+    spend_input.note_commitment = spendable.front().commitment;
+    spend_input.ring_positions = ring_positions;
+    spend_input.ring_members = ring_members;
+    spend_input.smile_ring_members = std::move(smile_ring_members);
+    spend_input.real_index = real_index;
+
+    const auto destination = shielded_wallet->GenerateNewAddress();
+    mlkem::PublicKey destination_kem_pk{};
+    BOOST_REQUIRE(shielded_wallet->GetKEMPublicKey(destination, destination_kem_pk));
+    const ShieldedNote destination_note = MakeNote(destination.pk_hash, 5 * COIN, 0x1f0);
+    const auto destination_payload = EncodeLegacyEncryptedNotePayload(
+        EncryptNote(destination_note, destination_kem_pk, 0x1f1),
+        destination_kem_pk,
+        ScanDomain::USER);
+    BOOST_REQUIRE(destination_payload.has_value());
+
+    shielded::v2::V2SendOutputInput output_input;
+    output_input.note_class = NoteClass::USER;
+    output_input.note = destination_note;
+    output_input.encrypted_note = *destination_payload;
+
+    std::string reject_reason;
+    const auto built = shielded::v2::BuildV2SendTransaction(CMutableTransaction{},
+                                                            tree.Root(),
+                                                            {spend_input},
+                                                            {output_input},
+                                                            /*fee=*/COIN / 10,
+                                                            std::vector<unsigned char>(32, 0x42),
+                                                            reject_reason);
+    BOOST_CHECK(!built.has_value());
+    BOOST_CHECK_EQUAL(reject_reason, "bad-shielded-v2-builder-input");
+}
+
+BOOST_AUTO_TEST_CASE(scanned_spend_path_recovery_output_rehydrates_to_ordinary_spend_shape)
+{
+    const CAmount first_fee = COIN / 20;
+    const std::vector<unsigned char> first_spending_key(32, 0x23);
+    std::array<unsigned char, 32> first_rng_entropy{};
+    first_rng_entropy.fill(0x24);
+    const ShieldedNote spend_input_note = MakeNote(owned_addr.pk_hash, 17 * COIN, 0x220);
+    const uint256 spend_note_commitment = spend_input_note.GetCommitment();
+    const size_t spend_real_index = 5;
+    const auto spend_tree = BuildSpendTree(spend_note_commitment, spend_real_index);
+    const auto ring_positions = BuildRingPositions();
+    const auto ring_members = BuildRingMembers(spend_tree, ring_positions);
+    auto smile_ring_members = BuildIngressSpendSmileRingMembers(ring_members,
+                                                                spend_input_note,
+                                                                spend_note_commitment,
+                                                                spend_real_index);
+    BOOST_REQUIRE_EQUAL(smile_ring_members.size(), ring_members.size());
+
+    shielded::v2::V2SendSpendInput spend_input;
+    spend_input.note = spend_input_note;
+    spend_input.note_commitment = spend_note_commitment;
+    spend_input.account_leaf_hint = shielded::registry::MakeDirectSendAccountLeafHint();
+    spend_input.ring_positions = ring_positions;
+    spend_input.ring_members = ring_members;
+    spend_input.smile_ring_members = smile_ring_members;
+    spend_input.real_index = spend_real_index;
+    BOOST_REQUIRE(test::shielded::AttachAccountRegistryWitness(spend_input));
+
+    const ShieldedNote migrated_note =
+        MakeNote(owned_addr.pk_hash, spend_input_note.value - first_fee, 0x221);
+    auto migrated_payload = EncodeLegacyEncryptedNotePayload(
+        EncryptNote(migrated_note, owned_kem_pk, 0x222),
+        owned_kem_pk,
+        ScanDomain::USER);
+    BOOST_REQUIRE(migrated_payload.has_value());
+
+    shielded::v2::V2SendOutputInput migrated_output;
+    migrated_output.note_class = NoteClass::USER;
+    migrated_output.note = migrated_note;
+    migrated_output.encrypted_note = *migrated_payload;
+
+    std::string reject_reason;
+    auto built = shielded::v2::BuildV2SendTransaction(CMutableTransaction{},
+                                                      spend_tree.Root(),
+                                                      {spend_input},
+                                                      {migrated_output},
+                                                      first_fee,
+                                                      first_spending_key,
+                                                      reject_reason,
+                                                      Span<const unsigned char>{first_rng_entropy.data(),
+                                                                               first_rng_entropy.size()});
+    BOOST_REQUIRE_MESSAGE(built.has_value(), reject_reason);
+    const std::array<uint256, 1> recovery_spend_commitments{spend_note_commitment};
+    ConvertBuiltV2SendToSpendPathRecovery(
+        built->tx,
+        Span<const uint256>{recovery_spend_commitments.data(), recovery_spend_commitments.size()});
+
+    const CTransaction recovery_tx{built->tx};
+    BOOST_REQUIRE(recovery_tx.HasShieldedBundle());
+    const auto recovery_family = recovery_tx.GetShieldedBundle().GetTransactionFamily();
+    BOOST_REQUIRE(recovery_family.has_value());
+    BOOST_CHECK_EQUAL(*recovery_family, shielded::v2::V2_SPEND_PATH_RECOVERY);
+
+    const auto recovery_leaves =
+        CollectShieldedOutputAccountLeafCommitments(recovery_tx.GetShieldedBundle());
+    BOOST_REQUIRE(recovery_leaves.has_value());
+    BOOST_REQUIRE_EQUAL(recovery_leaves->size(), 1U);
+
+    CBlock block;
+    block.vtx.push_back(MakeTransactionRef(recovery_tx));
+
+    LOCK2(wallet.cs_wallet, shielded_wallet->cs_shielded);
+    shielded_wallet->ScanBlock(block, /*height=*/1);
+
+    const auto notes = shielded_wallet->GetUnspentNotes(/*min_depth=*/0);
+    BOOST_REQUIRE_EQUAL(notes.size(), 1U);
+    BOOST_CHECK(notes.front().is_mine_spend);
+    BOOST_REQUIRE(notes.front().account_leaf_hint.has_value());
+    BOOST_CHECK(notes.front().account_leaf_hint->domain ==
+                shielded::registry::AccountDomain::DIRECT_SEND);
+    BOOST_CHECK_EQUAL(notes.front().note.value, migrated_note.value);
+
+    const auto summary = shielded_wallet->GetShieldedBalanceSummary(/*min_depth=*/0);
+    BOOST_CHECK_EQUAL(summary.spendable, migrated_note.value);
+    BOOST_CHECK_EQUAL(summary.watchonly, 0);
+    BOOST_CHECK_EQUAL(summary.spendable_note_count, 1);
+
+    const auto cached_view = shielded_wallet->GetCachedTransactionView(recovery_tx.GetHash());
+    BOOST_REQUIRE(cached_view.has_value());
+    BOOST_CHECK_EQUAL(cached_view->family, "v2_spend_path_recovery");
+    BOOST_REQUIRE_EQUAL(cached_view->outputs.size(), 1U);
+    BOOST_CHECK(cached_view->outputs[0].is_ours);
+    BOOST_CHECK_EQUAL(cached_view->outputs[0].amount, migrated_note.value);
+
+    const auto spendable = shielded_wallet->GetSpendableNotes(/*min_depth=*/0);
+    BOOST_REQUIRE_EQUAL(spendable.size(), 1U);
+    BOOST_REQUIRE(spendable.front().account_leaf_hint.has_value());
+    BOOST_CHECK(spendable.front().account_leaf_hint->domain ==
+                shielded::registry::AccountDomain::DIRECT_SEND);
+
+    const size_t next_real_index = 3;
+    const auto next_tree = BuildSpendTree(spendable.front().commitment, next_real_index);
+    const auto next_ring_positions = BuildRingPositions();
+    const auto next_ring_members = BuildRingMembers(next_tree, next_ring_positions);
+    auto next_smile_ring_members = BuildDirectSpendSmileRingMembers(next_ring_members,
+                                                                    spendable.front().note,
+                                                                    spendable.front().commitment,
+                                                                    next_real_index);
+    BOOST_REQUIRE_EQUAL(next_smile_ring_members.size(), next_ring_members.size());
+
+    shielded::v2::V2SendSpendInput ordinary_spend_input;
+    ordinary_spend_input.note = spendable.front().note;
+    ordinary_spend_input.note_commitment = spendable.front().commitment;
+    ordinary_spend_input.account_leaf_hint = spendable.front().account_leaf_hint;
+    ordinary_spend_input.ring_positions = next_ring_positions;
+    ordinary_spend_input.ring_members = next_ring_members;
+    ordinary_spend_input.smile_ring_members = std::move(next_smile_ring_members);
+    ordinary_spend_input.real_index = next_real_index;
+    BOOST_REQUIRE(test::shielded::AttachAccountRegistryWitness(ordinary_spend_input));
+    BOOST_REQUIRE(ordinary_spend_input.account_leaf_hint.has_value());
+    BOOST_REQUIRE(ordinary_spend_input.account_registry_proof.has_value());
+    BOOST_CHECK_EQUAL(ordinary_spend_input.ring_members[next_real_index],
+                      ordinary_spend_input.note_commitment);
+    BOOST_CHECK_EQUAL(ordinary_spend_input.smile_ring_members[next_real_index].note_commitment,
+                      ordinary_spend_input.note_commitment);
+    BOOST_REQUIRE(ordinary_spend_input.IsValid());
+
+    const auto destination = shielded_wallet->GenerateNewAddress();
+    mlkem::PublicKey destination_kem_pk{};
+    BOOST_REQUIRE(shielded_wallet->GetKEMPublicKey(destination, destination_kem_pk));
+    const CAmount second_fee = COIN / 20;
+    const std::vector<unsigned char> second_spending_key(32, 0x25);
+    std::array<unsigned char, 32> second_rng_entropy{};
+    second_rng_entropy.fill(0x26);
+    const ShieldedNote ordinary_note =
+        MakeNote(destination.pk_hash, migrated_note.value - second_fee, 0x223);
+    auto ordinary_payload = EncodeLegacyEncryptedNotePayload(
+        EncryptNote(ordinary_note, destination_kem_pk, 0x224),
+        destination_kem_pk,
+        ScanDomain::USER);
+    BOOST_REQUIRE(ordinary_payload.has_value());
+
+    shielded::v2::V2SendOutputInput ordinary_output;
+    ordinary_output.note_class = NoteClass::USER;
+    ordinary_output.note = ordinary_note;
+    ordinary_output.encrypted_note = *ordinary_payload;
+
+    auto ordinary_built = shielded::v2::BuildV2SendTransaction(CMutableTransaction{},
+                                                               next_tree.Root(),
+                                                               {ordinary_spend_input},
+                                                               {ordinary_output},
+                                                               second_fee,
+                                                               second_spending_key,
+                                                               reject_reason,
+                                                               Span<const unsigned char>{second_rng_entropy.data(),
+                                                                                        second_rng_entropy.size()});
+    BOOST_REQUIRE_MESSAGE(ordinary_built.has_value(), reject_reason);
 }
 
 BOOST_AUTO_TEST_CASE(block_scan_deduplicates_v2_send_commitments_across_transactions)

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -152,6 +152,25 @@ BOOST_AUTO_TEST_CASE(regtest_shielded_matrict_disable_height_rejects_negative)
     BOOST_CHECK_THROW(CreateChainParams(args, ChainType::REGTEST), std::runtime_error);
 }
 
+BOOST_AUTO_TEST_CASE(regtest_shielded_spend_path_recovery_activation_height_override)
+{
+    ArgsManager args;
+    args.ForceSetArg("-regtestshieldedspendpathrecoveryactivationheight", "245");
+
+    const auto params = CreateChainParams(args, ChainType::REGTEST);
+    BOOST_REQUIRE(params);
+    BOOST_CHECK_EQUAL(params->GetConsensus().nShieldedSpendPathRecoveryActivationHeight, 245);
+    BOOST_CHECK(!params->GetConsensus().IsShieldedSpendPathRecoveryActive(244));
+    BOOST_CHECK(params->GetConsensus().IsShieldedSpendPathRecoveryActive(245));
+}
+
+BOOST_AUTO_TEST_CASE(regtest_shielded_spend_path_recovery_activation_height_rejects_negative)
+{
+    ArgsManager args;
+    args.ForceSetArg("-regtestshieldedspendpathrecoveryactivationheight", "-1");
+    BOOST_CHECK_THROW(CreateChainParams(args, ChainType::REGTEST), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_CASE(regtest_shielded_pq128_upgrade_height_override)
 {
     ArgsManager args;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -554,6 +554,7 @@ namespace {
 
     const auto* v2_bundle = bundle.GetV2Bundle();
     if (v2_bundle == nullptr) {
+        LogShieldedV2ContextReject("retired-matrict-v2-bundle-null", bundle);
         reject_reason = "bad-shielded-v2-contextual";
         return false;
     }
@@ -604,6 +605,7 @@ namespace {
     if (bundle.HasV2Bundle()) {
         const auto* v2_bundle = bundle.GetV2Bundle();
         if (v2_bundle == nullptr) {
+            LogShieldedV2ContextReject("precheck-ring-positions-v2-bundle-null", bundle);
             reject_reason = "bad-shielded-v2-contextual";
             return false;
         }
@@ -622,7 +624,13 @@ namespace {
             }
             return true;
         }
+        case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+            auto witness = shielded::v2::proof::ParseSpendPathRecoveryWitness(*v2_bundle, reject_reason);
+            if (!witness.has_value()) return false;
+            return check_ring_positions(witness->spends);
+        }
         default:
+            LogShieldedV2ContextReject("precheck-ring-positions-unsupported-family", bundle);
             reject_reason = "bad-shielded-v2-contextual";
             return false;
         }
@@ -645,6 +653,7 @@ namespace {
 
     const auto* v2_bundle = bundle.GetV2Bundle();
     if (v2_bundle == nullptr) {
+        LogShieldedV2ContextReject("reject-small-privacy-pool-v2-bundle-null", bundle);
         reject_reason = "bad-shielded-v2-contextual";
         return false;
     }
@@ -789,6 +798,7 @@ template <typename Spend>
 
     const auto* v2_bundle = bundle.GetV2Bundle();
     if (v2_bundle == nullptr) {
+        LogShieldedV2ContextReject("account-registry-refs-v2-bundle-null", bundle);
         reject_reason = "bad-shielded-v2-contextual";
         return false;
     }
@@ -811,6 +821,7 @@ template <typename Spend>
             chainman,
             reject_reason);
     }
+    case shielded::v2::V2_SPEND_PATH_RECOVERY:
     case shielded::v2::TransactionFamily::V2_EGRESS_BATCH:
     case shielded::v2::TransactionFamily::V2_REBALANCE:
     case shielded::v2::TransactionFamily::V2_SETTLEMENT_ANCHOR:
@@ -818,6 +829,7 @@ template <typename Spend>
     case shielded::v2::TransactionFamily::V2_GENERIC:
         return true;
     }
+    LogShieldedV2ContextReject("account-registry-refs-unsupported-family", bundle);
     reject_reason = "bad-shielded-v2-contextual";
     return false;
 }
@@ -1027,6 +1039,7 @@ template <typename Spend>
     return bundle.HasShieldedInputs() ||
            (bundle.HasV2Bundle() &&
             (bundle.GetTransactionFamily() == shielded::v2::TransactionFamily::V2_SEND ||
+             bundle.GetTransactionFamily() == shielded::v2::V2_SPEND_PATH_RECOVERY ||
              bundle.GetTransactionFamily() == shielded::v2::TransactionFamily::V2_EGRESS_BATCH ||
              bundle.GetTransactionFamily() == shielded::v2::TransactionFamily::V2_SETTLEMENT_ANCHOR ||
              bundle.GetTransactionFamily() == shielded::v2::TransactionFamily::V2_LIFECYCLE));
@@ -2906,12 +2919,22 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             }
         }
         if (bundle.HasV2Bundle() &&
+            bundle.GetTransactionFamily() == shielded::v2::V2_SPEND_PATH_RECOVERY) {
+            if (!consensus.IsShieldedSpendPathRecoveryActive(next_block_height)) {
+                LogShieldedV2ContextReject("mempool-v2-spend-path-recovery-disabled", bundle);
+                return state.Invalid(TxValidationResult::TX_CONSENSUS,
+                                     "bad-shielded-v2-spend-path-recovery-disabled");
+            }
+        }
+        if (bundle.HasV2Bundle() &&
             bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_SEND &&
+            bundle.GetTransactionFamily() != shielded::v2::V2_SPEND_PATH_RECOVERY &&
             bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_INGRESS_BATCH &&
             bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_EGRESS_BATCH &&
             bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_SETTLEMENT_ANCHOR &&
             bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_REBALANCE &&
             bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_LIFECYCLE) {
+            LogShieldedV2ContextReject("mempool-allowed-family", bundle);
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-shielded-v2-contextual");
         }
         std::string retired_matrict_reject;
@@ -3002,6 +3025,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             case shielded::v2::TransactionFamily::V2_LIFECYCLE:
                 break;
             case shielded::v2::TransactionFamily::V2_GENERIC:
+                LogShieldedV2ContextReject("mempool-v2-generic-family", bundle);
                 return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-shielded-v2-contextual");
             }
         }
@@ -5684,12 +5708,23 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             }
 
             if (bundle.HasV2Bundle() &&
+                bundle.GetTransactionFamily() == shielded::v2::V2_SPEND_PATH_RECOVERY) {
+                if (!params.GetConsensus().IsShieldedSpendPathRecoveryActive(pindex->nHeight)) {
+                    LogShieldedV2ContextReject("block-v2-spend-path-recovery-disabled", bundle);
+                    state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
+                                  "bad-shielded-v2-spend-path-recovery-disabled");
+                    break;
+                }
+            }
+            if (bundle.HasV2Bundle() &&
                 bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_SEND &&
+                bundle.GetTransactionFamily() != shielded::v2::V2_SPEND_PATH_RECOVERY &&
                 bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_INGRESS_BATCH &&
                 bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_EGRESS_BATCH &&
                 bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_SETTLEMENT_ANCHOR &&
                 bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_REBALANCE &&
                 bundle.GetTransactionFamily() != shielded::v2::TransactionFamily::V2_LIFECYCLE) {
+                LogShieldedV2ContextReject("block-allowed-family", bundle);
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-shielded-v2-contextual");
                 break;
             }
@@ -5913,6 +5948,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
                 case shielded::v2::TransactionFamily::V2_LIFECYCLE:
                     break;
                 case shielded::v2::TransactionFamily::V2_GENERIC:
+                    LogShieldedV2ContextReject("block-v2-generic-family", bundle);
                     state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-shielded-v2-contextual");
                     break;
                 }

--- a/src/wallet/shielded_rpc.cpp
+++ b/src/wallet/shielded_rpc.cpp
@@ -378,6 +378,8 @@ void EnsureShieldedViewingKeyWalletOrThrow(const CWallet& wallet)
         switch (*family) {
         case shielded::v2::TransactionFamily::V2_SEND:
             return "v2_send";
+        case shielded::v2::V2_SPEND_PATH_RECOVERY:
+            return "v2_spend_path_recovery";
         case shielded::v2::TransactionFamily::V2_LIFECYCLE:
             return "v2_lifecycle";
         case shielded::v2::TransactionFamily::V2_INGRESS_BATCH:

--- a/src/wallet/shielded_wallet.cpp
+++ b/src/wallet/shielded_wallet.cpp
@@ -883,6 +883,8 @@ void RegisterAccountLeafCommitment(std::map<uint256, uint256>& account_leaf_comm
         switch (*family) {
         case shielded::v2::TransactionFamily::V2_SEND:
             return "v2_send";
+        case shielded::v2::V2_SPEND_PATH_RECOVERY:
+            return "v2_spend_path_recovery";
         case shielded::v2::TransactionFamily::V2_LIFECYCLE:
             return "v2_lifecycle";
         case shielded::v2::TransactionFamily::V2_INGRESS_BATCH:
@@ -2170,6 +2172,23 @@ void CShieldedWallet::ScanBlock(const CBlock& block, int height)
                     }
                     break;
                 }
+                case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+                    const auto& payload =
+                        std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
+                    const shielded::registry::AccountLeafHint account_leaf_hint =
+                        shielded::registry::MakeDirectSendAccountLeafHint();
+                    for (const auto& output : payload.outputs) {
+                        RecordScannedOutput(block,
+                                            height,
+                                            output,
+                                            account_leaf_hint,
+                                            master_seed,
+                                            block_commitments_seen,
+                                            tx_view,
+                                            tx_has_local_visibility);
+                    }
+                    break;
+                }
                 case shielded::v2::TransactionFamily::V2_LIFECYCLE:
                     break;
                 case shielded::v2::TransactionFamily::V2_INGRESS_BATCH: {
@@ -2439,6 +2458,21 @@ void CShieldedWallet::TransactionAddedToMempool(const CTransaction& tx)
             switch (shielded::v2::GetBundleSemanticFamily(*v2_bundle)) {
             case shielded::v2::TransactionFamily::V2_SEND: {
                 const auto& payload = std::get<shielded::v2::SendPayload>(v2_bundle->payload);
+                const shielded::registry::AccountLeafHint account_leaf_hint =
+                    shielded::registry::MakeDirectSendAccountLeafHint();
+                for (const auto& output : payload.outputs) {
+                    RecordMempoolOutput(txid,
+                                        output,
+                                        account_leaf_hint,
+                                        master_seed,
+                                        tx_view,
+                                        tx_has_local_visibility);
+                }
+                break;
+            }
+            case shielded::v2::V2_SPEND_PATH_RECOVERY: {
+                const auto& payload =
+                    std::get<shielded::v2::SpendPathRecoveryPayload>(v2_bundle->payload);
                 const shielded::registry::AccountLeafHint account_leaf_hint =
                     shielded::registry::MakeDirectSendAccountLeafHint();
                 for (const auto& output : payload.outputs) {

--- a/test/functional/feature_spend_path_recovery_activation_compat.py
+++ b/test/functional/feature_spend_path_recovery_activation_compat.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+"""Exercise spend-path recovery compatibility across activation boundaries."""
+
+import os
+from pathlib import Path
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.bridge_utils import build_spend_path_recovery_fixture
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+LATTICE_RING_SIZE = 8
+REGTEST_MATRICT_DISABLE_HEIGHT = 132
+
+
+class SpendPathRecoveryActivationCompatTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.rpc_timeout = 600
+        self._baseline_bitcoind = os.getenv("BTX_BASELINE_BITCOIND")
+        self._baseline_bitcoincli = os.getenv("BTX_BASELINE_BITCOINCLI")
+        self.extra_args = [
+            [
+                "-autoshieldcoinbase=0",
+                "-dandelion=0",
+                f"-regtestshieldedmatrictdisableheight={REGTEST_MATRICT_DISABLE_HEIGHT}",
+                "-regtestshieldedspendpathrecoveryactivationheight=1",
+            ],
+            [
+                "-autoshieldcoinbase=0",
+                "-dandelion=0",
+                f"-regtestshieldedmatrictdisableheight={REGTEST_MATRICT_DISABLE_HEIGHT}",
+            ],
+        ]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def setup_nodes(self):
+        if bool(self._baseline_bitcoind) != bool(self._baseline_bitcoincli):
+            raise AssertionError(
+                "BTX_BASELINE_BITCOIND and BTX_BASELINE_BITCOINCLI must be provided together"
+            )
+
+        if self._baseline_bitcoind is None:
+            self.add_nodes(self.num_nodes, self.extra_args)
+        else:
+            baseline_bitcoind = Path(self._baseline_bitcoind)
+            baseline_bitcoincli = Path(self._baseline_bitcoincli)
+            if not baseline_bitcoind.is_file():
+                raise AssertionError(f"Baseline daemon not found: {baseline_bitcoind}")
+            if not baseline_bitcoincli.is_file():
+                raise AssertionError(f"Baseline CLI not found: {baseline_bitcoincli}")
+
+            self.add_nodes(
+                self.num_nodes,
+                extra_args=self.extra_args,
+                binary=[self.options.bitcoind, str(baseline_bitcoind)],
+                binary_cli=[self.options.bitcoincli, str(baseline_bitcoincli)],
+            )
+        self.start_nodes()
+
+    def mine_and_sync(self, node, address, blocks=1):
+        hashes = self.generatetoaddress(node, blocks, address, sync_fun=self.no_op)
+        self.sync_blocks(self.nodes)
+        return hashes
+
+    def run_test(self):
+        upgraded_node, feature_off_node = self.nodes
+        self.connect_nodes(0, 1)
+        if self._baseline_bitcoind is not None:
+            self.log.info("Running strict patched-binary vs baseline-binary compatibility coverage")
+        else:
+            self.log.info("Running activation-split coverage with the same binary on both nodes")
+
+        upgraded_node.createwallet(wallet_name="miner", descriptors=True)
+        miner = upgraded_node.get_wallet_rpc("miner")
+        mine_addr = miner.getnewaddress(address_type="p2mr")
+
+        self.log.info("Mine enough mature wallet-owned outputs while staying below the MatRiCT disable height")
+        self.mine_and_sync(upgraded_node, mine_addr, COINBASE_MATURITY + LATTICE_RING_SIZE)
+
+        funding_utxos = sorted(
+            miner.listunspent(COINBASE_MATURITY),
+            key=lambda utxo: (utxo["txid"], utxo["vout"]),
+        )[:LATTICE_RING_SIZE]
+        assert_equal(len(funding_utxos), LATTICE_RING_SIZE)
+
+        self.log.info("Build a deterministic spend-path recovery fixture against the next validation height")
+        fixture = build_spend_path_recovery_fixture(
+            self,
+            funding_utxos,
+            validation_height=upgraded_node.getblockcount() + 1,
+            matrict_disable_height=REGTEST_MATRICT_DISABLE_HEIGHT,
+            legacy_fee_sats=20_000,
+            recovery_fee_sats=100_000,
+        )
+        assert_equal(len(fixture["legacy_txs"]), LATTICE_RING_SIZE)
+
+        self.log.info("Sign and mine the legacy shield-only funding transactions in deterministic tree order")
+        for legacy_tx in fixture["legacy_txs"]:
+            signed = miner.signrawtransactionwithwallet(legacy_tx["tx_hex"])
+            assert_equal(signed["complete"], True)
+            legacy_accept = feature_off_node.testmempoolaccept(rawtxs=[signed["hex"]], maxfeerate=0)[0]
+            assert legacy_accept["allowed"], legacy_accept
+            upgraded_node.sendrawtransaction(signed["hex"])
+            self.mine_and_sync(upgraded_node, mine_addr, 1)
+
+        self.log.info("The upgraded node should accept the recovery tx while the feature-off node rejects it")
+        recovery_tx_hex = fixture["recovery_tx_hex"]
+        upgraded_accept = upgraded_node.testmempoolaccept(rawtxs=[recovery_tx_hex], maxfeerate=0)[0]
+        assert upgraded_accept["allowed"], upgraded_accept
+
+        try:
+            feature_off_accept = feature_off_node.testmempoolaccept(rawtxs=[recovery_tx_hex], maxfeerate=0)[0]
+            assert not feature_off_accept["allowed"], feature_off_accept
+            assert "spend-path-recovery-disabled" in feature_off_accept["reject-reason"]
+        except JSONRPCException as exc:
+            if self._baseline_bitcoind is None:
+                raise
+            assert "TX decode failed" in exc.error["message"], exc.error
+
+        recovery_txid = upgraded_node.sendrawtransaction(recovery_tx_hex)
+        self.wait_until(lambda: recovery_txid in upgraded_node.getrawmempool(), timeout=60)
+
+        self.log.info("Mine the recovery tx on the upgraded node and confirm the feature-off peer falls behind")
+        recovery_block = self.generatetoaddress(upgraded_node, 1, mine_addr, sync_fun=self.no_op)[0]
+        self.wait_until(
+            lambda: feature_off_node.getblockcount() == upgraded_node.getblockcount() - 1,
+            timeout=60,
+        )
+        assert feature_off_node.getbestblockhash() != upgraded_node.getbestblockhash()
+
+        mined_recovery = upgraded_node.getrawtransaction(recovery_txid, True, recovery_block)
+        assert_equal(mined_recovery["txid"], recovery_txid)
+        assert_equal(mined_recovery["shielded"]["bundle_type"], "v2")
+        assert_equal(mined_recovery["shielded"]["family"], "v2_spend_path_recovery")
+
+
+if __name__ == "__main__":
+    SpendPathRecoveryActivationCompatTest(__file__).main()

--- a/test/functional/feature_spend_path_recovery_reorg.py
+++ b/test/functional/feature_spend_path_recovery_reorg.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+"""Exercise spend-path recovery block disconnect/reconnect behavior."""
+
+from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.bridge_utils import build_spend_path_recovery_fixture
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+LATTICE_RING_SIZE = 8
+REGTEST_MATRICT_DISABLE_HEIGHT = 132
+
+
+class SpendPathRecoveryReorgTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.rpc_timeout = 600
+        self.extra_args = [[
+            "-autoshieldcoinbase=0",
+            "-dandelion=0",
+            f"-regtestshieldedmatrictdisableheight={REGTEST_MATRICT_DISABLE_HEIGHT}",
+            "-regtestshieldedspendpathrecoveryactivationheight=1",
+        ]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        node.createwallet(wallet_name="miner", descriptors=True)
+        miner = node.get_wallet_rpc("miner")
+        mine_addr = miner.getnewaddress(address_type="p2mr")
+
+        self.log.info("Mine enough mature outputs below the MatRiCT disable height")
+        self.generatetoaddress(node, COINBASE_MATURITY + LATTICE_RING_SIZE, mine_addr, sync_fun=self.no_op)
+
+        funding_utxos = sorted(
+            miner.listunspent(COINBASE_MATURITY),
+            key=lambda utxo: (utxo["txid"], utxo["vout"]),
+        )[:LATTICE_RING_SIZE]
+        assert_equal(len(funding_utxos), LATTICE_RING_SIZE)
+
+        self.log.info("Build a deterministic spend-path recovery fixture at the next height")
+        fixture = build_spend_path_recovery_fixture(
+            self,
+            funding_utxos,
+            validation_height=node.getblockcount() + 1,
+            matrict_disable_height=REGTEST_MATRICT_DISABLE_HEIGHT,
+            legacy_fee_sats=20_000,
+            recovery_fee_sats=100_000,
+        )
+        assert_equal(len(fixture["legacy_txs"]), LATTICE_RING_SIZE)
+
+        self.log.info("Mine the deterministic legacy funding chain")
+        for legacy_tx in fixture["legacy_txs"]:
+            signed = miner.signrawtransactionwithwallet(legacy_tx["tx_hex"])
+            assert_equal(signed["complete"], True)
+            legacy_accept = node.testmempoolaccept(rawtxs=[signed["hex"]], maxfeerate=0)[0]
+            assert legacy_accept["allowed"], legacy_accept
+            node.sendrawtransaction(signed["hex"])
+            self.generatetoaddress(node, 1, mine_addr, sync_fun=self.no_op)
+
+        recovery_tx_hex = fixture["recovery_tx_hex"]
+        recovery_accept = node.testmempoolaccept(rawtxs=[recovery_tx_hex], maxfeerate=0)[0]
+        assert recovery_accept["allowed"], recovery_accept
+
+        self.log.info("Mine a recovery block, invalidate it, then reconnect it")
+        recovery_txid = node.sendrawtransaction(recovery_tx_hex)
+        recovery_block = self.generatetoaddress(node, 1, mine_addr, sync_fun=self.no_op)[0]
+
+        mined_recovery = node.getrawtransaction(recovery_txid, True, recovery_block)
+        assert_equal(mined_recovery["shielded"]["bundle_type"], "v2")
+        assert_equal(mined_recovery["shielded"]["family"], "v2_spend_path_recovery")
+        assert recovery_txid not in node.getrawmempool()
+
+        node.invalidateblock(recovery_block)
+        self.wait_until(lambda: recovery_txid in node.getrawmempool(), timeout=60)
+        assert node.getbestblockhash() != recovery_block
+
+        node.reconsiderblock(recovery_block)
+        self.wait_until(lambda: node.getbestblockhash() == recovery_block, timeout=60)
+        self.wait_until(lambda: recovery_txid not in node.getrawmempool(), timeout=60)
+
+        reconnected_recovery = node.getrawtransaction(recovery_txid, True, recovery_block)
+        assert_equal(reconnected_recovery["txid"], recovery_txid)
+        assert_equal(reconnected_recovery["confirmations"], 1)
+        assert_equal(reconnected_recovery["shielded"]["family"], "v2_spend_path_recovery")
+
+
+if __name__ == "__main__":
+    SpendPathRecoveryReorgTest(__file__).main()

--- a/test/functional/test_framework/bridge_utils.py
+++ b/test/functional/test_framework/bridge_utils.py
@@ -86,6 +86,14 @@ def _shielded_relay_fixture_binary(test):
     )
 
 
+def _spend_path_recovery_fixture_binary(test):
+    return (
+        Path(test.config["environment"]["BUILDDIR"])
+        / "bin"
+        / f"gen_shielded_spend_path_recovery_fixture{test.config['environment']['EXEEXT']}"
+    )
+
+
 def build_signed_shielded_relay_fixture_tx(
     test,
     node,
@@ -137,6 +145,31 @@ def build_unsigned_shielded_relay_fixture_tx(test, node, family, *, require_memp
         accept = node.testmempoolaccept(rawtxs=[fixture["tx_hex"]], maxfeerate=0)[0]
         assert_equal(accept["allowed"], True)
     return fixture
+
+
+def build_spend_path_recovery_fixture(
+    test,
+    funding_utxos,
+    *,
+    validation_height,
+    matrict_disable_height,
+    legacy_fee_sats=1_000,
+    recovery_fee_sats=1_000,
+):
+    args = [
+        str(_spend_path_recovery_fixture_binary(test)),
+        f"--validation-height={validation_height}",
+        f"--matrict-disable-height={matrict_disable_height}",
+        f"--legacy-fee-sats={legacy_fee_sats}",
+        f"--recovery-fee-sats={recovery_fee_sats}",
+    ]
+    for utxo in funding_utxos:
+        args.append(
+            "--legacy-input="
+            f"{utxo['txid']}:{utxo['vout']}:"
+            f"{int(Decimal(str(utxo['amount'])) * 100_000_000)}"
+        )
+    return json.loads(subprocess.check_output(args, text=True))
 
 
 def planin(wallet, amount, refund_lock_height, *, bridge_id, operation_id, recipient=None,

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -183,6 +183,8 @@ BASE_SCRIPTS = [
     'wallet_shielded_transfer_builder_locks.py --descriptors',
     'wallet_smile_v2_benchmark.py',
     'wallet_smile_v2_full_lifecycle.py',
+    'feature_spend_path_recovery_activation_compat.py',
+    'feature_spend_path_recovery_reorg.py',
     'rpc_pq_multisig.py',
     'feature_p2mr_end_to_end.py',
     'p2mr_end_to_end.py',


### PR DESCRIPTION
# PR Cover Note

## Title

Add activation-gated post-fork spend-path recovery for stranded shielded notes

## Summary

This PR introduces a narrow, activation-gated recovery path for shielded notes
that remain owned and balance-visible after a shielded-model transition but no
longer have an accepted ordinary spend path.

The patch adds a dedicated `v2_spend_path_recovery` transaction family that:

- remains disabled by default on all networks
- activates only when the dedicated consensus height is set
- consumes eligible stranded notes
- recreates ordinary modern spendable outputs
- scans those outputs back into the wallet as ordinary direct-send-shaped notes

The PR does not weaken ordinary `V2_SEND` or `V2_INGRESS_BATCH` rules and does
not attempt any global historical backfill scheme.

## Problem

Some wallets can still:

- decrypt affected shielded notes
- account for them in balance
- prove ownership of them

but cannot spend them through the ordinary modern shielded path because the
required registry or witness context no longer exists for those note classes.

That leaves custody intact while spendability is lost.

## What This PR Changes

- reserves and implements the `v2_spend_path_recovery` family
- adds activation-gated validation and proof plumbing
- adds replay and nullifier conflict handling for recovery spends
- adds wallet-side recovery-output scanning so migrated outputs come back as
  ordinary spendable notes
- adds deterministic fixture generation and functional activation tests

## What This PR Does Not Change

- no default-on activation on any public network
- no relaxation of ordinary modern spend rules
- no unrelated relay-policy widening
- no automatic wallet migration without explicit activation

## Evidence Included

This patch is supported by:

- synthetic unit and integration coverage
- mixed-version activation-split functional coverage
- recovery-block disconnect and reconnect coverage
- a real-batch trusted-state replay against copied affected-wallet data

The real-batch replay showed that a real affected batch can be regenerated
under current trusted state and accepted by the patched proof and validation
path when anchored to current state.

## Operational Note

Real recovery transactions can be very large.

Local testing showed that ordinary mempool admission can still reject them for
`tx-size`, even when proof validation succeeds. That means activation of this
consensus path should not assume generic network relay for oversized recovery
transactions. Direct miner or block-template inclusion may still be required.

## Review Guidance

Reviewers should focus on:

- activation boundaries and default-off behavior
- recovery-family proof and contextual validation
- nullifier and replay handling
- wallet-side output rehydration into ordinary spend shape
- mixed-version divergence behavior after activation

## Suggested Testing

- focused `test_btx` spend-path-recovery suite
- `feature_spend_path_recovery_activation_compat.py`
- `feature_spend_path_recovery_reorg.py`
- strict patched-vs-baseline compatibility run

## Rollout Position

This PR is suitable for review as a narrow recovery patch.

Activation, miner coordination, and any relay-policy discussion should remain
separate rollout decisions after code review.
