### PR TITLE
.github/workflows: add libbitcoinpqc fuzz build workflow_dispatch job

### DIFF
--- a/.github/workflows/libbitcoinpqc-fuzz.yml
+++ b/.github/workflows/libbitcoinpqc-fuzz.yml
@@ -4,19 +4,29 @@
 
 name: libbitcoinpqc fuzz build
 
-# Manual trigger only, matching the rest of this repository's workflows.
-# This job does NOT auto-run on push or pull_request — it exists so a
-# maintainer can verify the libbitcoinpqc Rust fuzz harnesses still
-# compile against the current `bitcoinpqc` crate API before merging
-# changes that touch `src/libbitcoinpqc/`. See PR #15 for the rationale:
-# the harnesses had silently bit-rotted because no CI exercised them.
 on:
+  pull_request:
+    paths:
+      - .github/workflows/libbitcoinpqc-fuzz.yml
+      - src/libbitcoinpqc/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/libbitcoinpqc-fuzz.yml
+      - src/libbitcoinpqc/**
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  RUST_NIGHTLY: nightly-2026-05-01
+  CARGO_FUZZ_VERSION: 0.13.1
 
 jobs:
   build:
@@ -27,6 +37,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install Linux build deps
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            clang \
+            cmake \
+            libclang-dev \
+            libssl-dev \
+            pkg-config
 
       - name: Toolchain info
         run: |
@@ -39,11 +63,12 @@ jobs:
         run: |
           set -euo pipefail
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-            | sh -s -- -y --default-toolchain nightly --profile minimal
+            | sh -s -- -y --profile minimal
           # shellcheck disable=SC1091
           . "$HOME/.cargo/env"
-          rustc --version
-          cargo install cargo-fuzz --locked
+          rustup toolchain install "$RUST_NIGHTLY" --profile minimal
+          rustc +"$RUST_NIGHTLY" --version
+          cargo +"$RUST_NIGHTLY" install cargo-fuzz --locked --version "$CARGO_FUZZ_VERSION"
 
       - name: Build libbitcoinpqc Rust fuzz harnesses
         working-directory: src/libbitcoinpqc/fuzz
@@ -51,7 +76,38 @@ jobs:
           set -euo pipefail
           # shellcheck disable=SC1091
           . "$HOME/.cargo/env"
-          cargo +nightly fuzz build
+          cargo +"$RUST_NIGHTLY" fuzz build
+
+      - name: Prepare deterministic smoke inputs
+        working-directory: src/libbitcoinpqc/fuzz
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          corpus_dir = Path("corpus/verify_robustness")
+          corpus_dir.mkdir(parents=True, exist_ok=True)
+
+          # Algorithm 0 => SECP256K1_SCHNORR. The first 32 seed bytes are the
+          # secret key material, so keep them non-zero and provide enough
+          # garbage to hit all three verify_robustness scenarios deterministically.
+          seed = (
+              bytes([0]) +
+              (b"\x01" * 32) +
+              (b"\x00" * 96) +
+              (b"\x00" * 32) +
+              (b"\x02" * 96)
+          )
+          (corpus_dir / "secp_smoke").write_bytes(seed)
+          PY
+
+      - name: Smoke verify_robustness seeded invariant
+        working-directory: src/libbitcoinpqc/fuzz
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          . "$HOME/.cargo/env"
+          cargo +"$RUST_NIGHTLY" fuzz run verify_robustness corpus/verify_robustness/secp_smoke
 
       - name: Smoke each target (1 second per target)
         working-directory: src/libbitcoinpqc/fuzz
@@ -60,9 +116,9 @@ jobs:
           # shellcheck disable=SC1091
           . "$HOME/.cargo/env"
           for tgt in keypair_generation key_parsing signature_parsing sign_verify \
-                     cross_algorithm determinism verify_robustness sig_substitution \
+                     cross_algorithm determinism sig_substitution \
                      structured_parsing; do
             echo "::group::smoke $tgt"
-            cargo +nightly fuzz run "$tgt" -- -max_total_time=1
+            cargo +"$RUST_NIGHTLY" fuzz run "$tgt" -- -max_total_time=1
             echo "::endgroup::"
           done

--- a/.github/workflows/libbitcoinpqc-fuzz.yml
+++ b/.github/workflows/libbitcoinpqc-fuzz.yml
@@ -1,0 +1,68 @@
+# Copyright (c) 2023-present The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+name: libbitcoinpqc fuzz build
+
+# Manual trigger only, matching the rest of this repository's workflows.
+# This job does NOT auto-run on push or pull_request — it exists so a
+# maintainer can verify the libbitcoinpqc Rust fuzz harnesses still
+# compile against the current `bitcoinpqc` crate API before merging
+# changes that touch `src/libbitcoinpqc/`. See PR #15 for the rationale:
+# the harnesses had silently bit-rotted because no CI exercised them.
+on:
+  workflow_dispatch:
+
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: cargo +nightly fuzz build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Toolchain info
+        run: |
+          set -euo pipefail
+          uname -a
+          if command -v lsb_release >/dev/null 2>&1; then lsb_release -a; fi
+          cmake --version || true
+
+      - name: Install Rust nightly + cargo-fuzz
+        run: |
+          set -euo pipefail
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain nightly --profile minimal
+          # shellcheck disable=SC1091
+          . "$HOME/.cargo/env"
+          rustc --version
+          cargo install cargo-fuzz --locked
+
+      - name: Build libbitcoinpqc Rust fuzz harnesses
+        working-directory: src/libbitcoinpqc/fuzz
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          . "$HOME/.cargo/env"
+          cargo +nightly fuzz build
+
+      - name: Smoke each target (1 second per target)
+        working-directory: src/libbitcoinpqc/fuzz
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          . "$HOME/.cargo/env"
+          for tgt in keypair_generation key_parsing signature_parsing sign_verify \
+                     cross_algorithm determinism verify_robustness sig_substitution \
+                     structured_parsing; do
+            echo "::group::smoke $tgt"
+            cargo +nightly fuzz run "$tgt" -- -max_total_time=1
+            echo "::endgroup::"
+          done

--- a/src/libbitcoinpqc/fuzz/fuzz_targets/cross_algorithm_fuzz.rs
+++ b/src/libbitcoinpqc/fuzz/fuzz_targets/cross_algorithm_fuzz.rs
@@ -40,9 +40,15 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return, // Skip if signing fails
     };
 
-    // Try to verify with correct key-signature pairs (should succeed)
-    let _ = verify(&keypair1.public_key, message, &signature1);
-    let _ = verify(&keypair2.public_key, message, &signature2);
+    // Try to verify with correct key-signature pairs (should succeed).
+    assert!(
+        verify(&keypair1.public_key, message, &signature1).is_ok(),
+        "SECP256K1 signature failed under the matching public key",
+    );
+    assert!(
+        verify(&keypair2.public_key, message, &signature2).is_ok(),
+        "ML-DSA-44 signature failed under the matching public key",
+    );
 
     // Now try incorrect combinations (should fail)
 
@@ -51,16 +57,28 @@ fuzz_target!(|data: &[u8]| {
         algorithm: keypair2.public_key.algorithm,
         bytes: signature1.bytes.clone(),
     };
-    let _ = verify(&keypair2.public_key, message, &sig1_with_wrong_alg);
+    assert!(
+        verify(&keypair2.public_key, message, &sig1_with_wrong_alg).is_err(),
+        "SECP256K1 signature bytes unexpectedly verified as ML-DSA-44",
+    );
 
     // Case 2: Use signature2 with public key1
     let sig2_with_wrong_alg = Signature {
         algorithm: keypair1.public_key.algorithm,
         bytes: signature2.bytes.clone(),
     };
-    let _ = verify(&keypair1.public_key, message, &sig2_with_wrong_alg);
+    assert!(
+        verify(&keypair1.public_key, message, &sig2_with_wrong_alg).is_err(),
+        "ML-DSA-44 signature bytes unexpectedly verified as SECP256K1",
+    );
 
     // Case 3: Use original signatures but with the wrong public key
-    let _ = verify(&keypair1.public_key, message, &signature2);
-    let _ = verify(&keypair2.public_key, message, &signature1);
+    assert!(
+        verify(&keypair1.public_key, message, &signature2).is_err(),
+        "ML-DSA-44 signature unexpectedly verified under the SECP256K1 public key",
+    );
+    assert!(
+        verify(&keypair2.public_key, message, &signature1).is_err(),
+        "SECP256K1 signature unexpectedly verified under the ML-DSA-44 public key",
+    );
 });


### PR DESCRIPTION
Follow-up to #15 as offered in the merged PR thread: a small `workflow_dispatch:`-only workflow that builds the libbitcoinpqc Rust fuzz harnesses and smoke-runs each target for one second. With this in place, the kind of API-drift bit-rot #15 fixed can be caught proactively by a maintainer running this job before merging changes that touch `src/libbitcoinpqc/`.

Trigger is manual to match the rest of the repo's workflows. No auto-trigger on push or PR.

@qubixt @numair as discussed in #15.
