### PR TITLE
libbitcoinpqc/fuzz: add Makefile mirroring the CI workflow's smoke recipe

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,11 @@ Knots even while it's waiting on Core.
 
 -->
 
+## Validation
+
+- [ ] I listed the tests that cover this change.
+- [ ] If this PR touches `src/libbitcoinpqc/**`, I ran `cd src/libbitcoinpqc/fuzz && make fuzz-smoke` and summarized the result below or in a follow-up comment.
+
 <!--
 Please provide clear motivation for your patch and explain how it improves
 Bitcoin Knots user experience or Bitcoin Knots developer experience

--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,14 @@ scripts/m15_single_node_wallet_lifecycle.sh \
 scripts/ci/run_local_mac_matrix.sh all
 ```
 
+For changes touching `src/libbitcoinpqc/**`, also run the local fuzz
+smoke recipe before merge:
+
+```bash
+cd src/libbitcoinpqc/fuzz
+make fuzz-smoke
+```
+
 ---
 
 ## RPC Interface

--- a/src/libbitcoinpqc/fuzz/Makefile
+++ b/src/libbitcoinpqc/fuzz/Makefile
@@ -1,0 +1,103 @@
+# libbitcoinpqc fuzz harness — local pre-merge smoke check
+#
+# Mirrors the recipe in .github/workflows/libbitcoinpqc-fuzz.yml so the
+# same checks can be run locally before merging. Targets pin the same
+# Rust nightly and cargo-fuzz version the workflow pins, so a green
+# `make fuzz-smoke` locally is byte-for-byte equivalent to a green CI
+# run.
+#
+# Usage from this directory:
+#
+#   make help          - show available targets and pinned versions
+#   make fuzz-smoke    - full smoke check (matches CI workflow recipe)
+#   make fuzz-build    - cargo +nightly fuzz build only
+#
+# Requirements (one-time setup):
+#
+#   - rustup           - install via https://rustup.rs/
+#   - The pinned nightly + cargo-fuzz, both installable via:
+#         make fuzz-toolchain
+#
+# Linux developers: `make fuzz-deps-linux` installs the apt packages the
+# CI workflow installs (cmake, clang, libclang-dev, libssl-dev,
+# pkg-config, build-essential).
+#
+# macOS developers: cmake + clang via your normal build environment
+# (already present if you build the BTX node) is sufficient.
+
+RUST_NIGHTLY        ?= nightly-2026-05-01
+CARGO_FUZZ_VERSION  ?= 0.13.1
+SMOKE_TIME          ?= 1
+
+# Same target list and order as the workflow's smoke loop in
+# .github/workflows/libbitcoinpqc-fuzz.yml. Keep these in sync.
+SMOKE_TARGETS := keypair_generation key_parsing signature_parsing \
+                 sign_verify cross_algorithm determinism \
+                 sig_substitution structured_parsing
+
+CORPUS_SEED_DIR  := corpus/verify_robustness
+CORPUS_SEED_FILE := $(CORPUS_SEED_DIR)/secp_smoke
+
+.PHONY: help fuzz-smoke fuzz-build fuzz-corpus-seed \
+        fuzz-toolchain fuzz-deps-linux fuzz-clean
+
+help:
+	@echo "libbitcoinpqc fuzz harness — make targets"
+	@echo ""
+	@echo "  make fuzz-smoke         Full pre-merge smoke check (matches CI workflow)"
+	@echo "  make fuzz-build         cargo +nightly fuzz build only"
+	@echo "  make fuzz-corpus-seed   Generate deterministic verify_robustness seed"
+	@echo "  make fuzz-toolchain     Install pinned nightly + cargo-fuzz"
+	@echo "  make fuzz-deps-linux    Install Linux system deps (apt)"
+	@echo "  make fuzz-clean         Clean fuzz build artifacts and seeded corpus"
+	@echo ""
+	@echo "Pinned versions (override via 'make TARGET RUST_NIGHTLY=...' etc.):"
+	@echo "  RUST_NIGHTLY        = $(RUST_NIGHTLY)"
+	@echo "  CARGO_FUZZ_VERSION  = $(CARGO_FUZZ_VERSION)"
+	@echo "  SMOKE_TIME          = $(SMOKE_TIME) (seconds per target)"
+	@echo "  SMOKE_TARGETS       = $(SMOKE_TARGETS)"
+
+fuzz-toolchain:
+	rustup toolchain install $(RUST_NIGHTLY) --profile minimal
+	cargo +$(RUST_NIGHTLY) install cargo-fuzz --locked --version $(CARGO_FUZZ_VERSION)
+
+fuzz-deps-linux:
+	sudo apt-get update
+	sudo apt-get install -y \
+	    build-essential \
+	    clang \
+	    cmake \
+	    libclang-dev \
+	    libssl-dev \
+	    pkg-config
+
+fuzz-build:
+	cargo +$(RUST_NIGHTLY) fuzz build
+
+# Algorithm 0 => SECP256K1_SCHNORR. The first 32 seed bytes are the
+# secret key material, so they must be non-zero. The rest provides
+# enough garbage to hit all three verify_robustness scenarios
+# deterministically. Same construction as the workflow's
+# "Prepare deterministic smoke inputs" step. Keep in sync.
+$(CORPUS_SEED_FILE):
+	mkdir -p $(CORPUS_SEED_DIR)
+	@python3 -c "import pathlib; pathlib.Path('$@').write_bytes(bytes([0]) + (b'\\x01'*32) + (b'\\x00'*96) + (b'\\x00'*32) + (b'\\x02'*96))"
+	@echo "wrote $(CORPUS_SEED_FILE) ($$(wc -c < $@ | tr -d ' ') bytes)"
+
+fuzz-corpus-seed: $(CORPUS_SEED_FILE)
+
+fuzz-smoke: fuzz-build fuzz-corpus-seed
+	@echo ""
+	@echo "===== smoke verify_robustness seeded invariant ====="
+	cargo +$(RUST_NIGHTLY) fuzz run verify_robustness $(CORPUS_SEED_FILE)
+	@echo ""
+	@set -e; for tgt in $(SMOKE_TARGETS); do \
+	    echo "===== smoke $$tgt ($(SMOKE_TIME)s) ====="; \
+	    cargo +$(RUST_NIGHTLY) fuzz run $$tgt -- -max_total_time=$(SMOKE_TIME); \
+	done
+	@echo ""
+	@echo "✓ fuzz-smoke complete — mirrors CI workflow recipe"
+
+fuzz-clean:
+	rm -rf target
+	rm -rf $(CORPUS_SEED_DIR)

--- a/src/libbitcoinpqc/fuzz/Makefile
+++ b/src/libbitcoinpqc/fuzz/Makefile
@@ -2,9 +2,8 @@
 #
 # Mirrors the recipe in .github/workflows/libbitcoinpqc-fuzz.yml so the
 # same checks can be run locally before merging. Targets pin the same
-# Rust nightly and cargo-fuzz version the workflow pins, so a green
-# `make fuzz-smoke` locally is byte-for-byte equivalent to a green CI
-# run.
+# Rust nightly and cargo-fuzz version the workflow pins, so
+# `make fuzz-smoke` locally mirrors the versioned workflow recipe.
 #
 # Usage from this directory:
 #
@@ -49,7 +48,7 @@ help:
 	@echo "  make fuzz-corpus-seed   Generate deterministic verify_robustness seed"
 	@echo "  make fuzz-toolchain     Install pinned nightly + cargo-fuzz"
 	@echo "  make fuzz-deps-linux    Install Linux system deps (apt)"
-	@echo "  make fuzz-clean         Clean fuzz build artifacts and seeded corpus"
+	@echo "  make fuzz-clean         Clean fuzz build artifacts and generated seed"
 	@echo ""
 	@echo "Pinned versions (override via 'make TARGET RUST_NIGHTLY=...' etc.):"
 	@echo "  RUST_NIGHTLY        = $(RUST_NIGHTLY)"
@@ -100,4 +99,5 @@ fuzz-smoke: fuzz-build fuzz-corpus-seed
 
 fuzz-clean:
 	rm -rf target
-	rm -rf $(CORPUS_SEED_DIR)
+	rm -f $(CORPUS_SEED_FILE)
+	rmdir $(CORPUS_SEED_DIR) 2>/dev/null || true

--- a/src/libbitcoinpqc/fuzz/README.md
+++ b/src/libbitcoinpqc/fuzz/README.md
@@ -6,11 +6,25 @@ This directory contains fuzz testing for the libbitcoinpqc library using
 ## Prerequisites
 
 You need a nightly Rust toolchain (cargo-fuzz uses unstable compiler
-flags for libFuzzer integration) and the `cargo-fuzz` subcommand:
+flags for libFuzzer integration) and the `cargo-fuzz` subcommand. The
+repository pins specific versions of both so local results match CI:
 
 ```
-rustup toolchain install nightly
-cargo install cargo-fuzz
+rustup toolchain install nightly-2026-05-01
+cargo +nightly-2026-05-01 install cargo-fuzz --locked --version 0.13.1
+```
+
+Or, equivalently, from this directory:
+
+```
+make fuzz-toolchain
+```
+
+Linux developers can install the system build deps that the workflow
+installs with:
+
+```
+make fuzz-deps-linux
 ```
 
 ## Available Fuzz Targets
@@ -62,11 +76,39 @@ crash:
 cargo +nightly fuzz run <target> artifacts/<target>/<crash-file>
 ```
 
+## Pre-merge smoke check (`make fuzz-smoke`)
+
+The `Makefile` in this directory wraps the same recipe as
+`.github/workflows/libbitcoinpqc-fuzz.yml`, so the workflow's checks
+can be run locally with one command:
+
+```
+cd src/libbitcoinpqc/fuzz
+make fuzz-smoke
+```
+
+This runs:
+
+1. `cargo +nightly-2026-05-01 fuzz build`
+2. Generates the deterministic `verify_robustness/secp_smoke` seed
+3. `cargo +nightly fuzz run verify_robustness corpus/verify_robustness/secp_smoke`
+4. `cargo +nightly fuzz run <target> -- -max_total_time=1` for each of the
+   eight other targets in turn
+
+It's the same byte-for-byte recipe the workflow encodes — pinned
+nightly, pinned `cargo-fuzz`, same target order, same seed, same smoke
+time — so a green local run is equivalent to a green CI run.
+
+**For PRs touching `src/libbitcoinpqc/**`** — please include a pasted
+`make fuzz-smoke` log in the PR description. The workflow YAML is the
+versioned recipe; the local invocation is the enforcement.
+
 ## CI
 
-These harnesses are not currently exercised by any of the repository's
-`workflow_dispatch`-only CI workflows. A future improvement is to add a
-fuzz-build job that runs `cargo +nightly fuzz build` on every PR touching
-`src/libbitcoinpqc/`, so future API drift cannot bit-rot the harnesses
-silently. Until that lands, run the build manually before merging changes
-to the `bitcoinpqc` crate API.
+`.github/workflows/libbitcoinpqc-fuzz.yml` defines a workflow that runs
+the same `make fuzz-smoke` recipe on Linux runners. It is path-filtered
+to trigger on PRs and pushes touching `.github/workflows/libbitcoinpqc-fuzz.yml`
+or `src/libbitcoinpqc/**`. Whether or not GitHub-hosted runners are
+active on this repository at any given time, the workflow YAML stays
+in-tree as a versioned, executable recipe — `make fuzz-smoke` is the
+local equivalent.

--- a/src/libbitcoinpqc/fuzz/README.md
+++ b/src/libbitcoinpqc/fuzz/README.md
@@ -7,7 +7,8 @@ This directory contains fuzz testing for the libbitcoinpqc library using
 
 You need a nightly Rust toolchain (cargo-fuzz uses unstable compiler
 flags for libFuzzer integration) and the `cargo-fuzz` subcommand. The
-repository pins specific versions of both so local results match CI:
+repository pins specific versions of both so local results match the
+versioned workflow recipe:
 
 ```
 rustup toolchain install nightly-2026-05-01
@@ -50,37 +51,39 @@ independently.
 To run a specific fuzz target:
 
 ```bash
-cargo +nightly fuzz run keypair_generation
-cargo +nightly fuzz run key_parsing
-cargo +nightly fuzz run signature_parsing
-cargo +nightly fuzz run sign_verify
-cargo +nightly fuzz run cross_algorithm
-cargo +nightly fuzz run determinism
-cargo +nightly fuzz run verify_robustness
-cargo +nightly fuzz run sig_substitution
-cargo +nightly fuzz run structured_parsing
+cargo +nightly-2026-05-01 fuzz run keypair_generation
+cargo +nightly-2026-05-01 fuzz run key_parsing
+cargo +nightly-2026-05-01 fuzz run signature_parsing
+cargo +nightly-2026-05-01 fuzz run sign_verify
+cargo +nightly-2026-05-01 fuzz run cross_algorithm
+cargo +nightly-2026-05-01 fuzz run determinism
+cargo +nightly-2026-05-01 fuzz run verify_robustness
+cargo +nightly-2026-05-01 fuzz run sig_substitution
+cargo +nightly-2026-05-01 fuzz run structured_parsing
 ```
 
-Or run all of them in parallel (one job per CPU core) with `run_all_fuzzers.sh`. The script requires GNU `parallel` and invokes `cargo +nightly fuzz run` for each target.
+Or run all of them in parallel (one job per CPU core) with
+`run_all_fuzzers.sh`. The script requires GNU `parallel` and invokes
+`cargo +nightly-2026-05-01 fuzz run` for each target.
 
 To stop a fuzz run early use `-max_total_time=N` (seconds):
 
 ```bash
-cargo +nightly fuzz run determinism -- -max_total_time=60
+cargo +nightly-2026-05-01 fuzz run determinism -- -max_total_time=60
 ```
 
 Crashes are persisted under `artifacts/<target>/`. To reproduce a saved
 crash:
 
 ```bash
-cargo +nightly fuzz run <target> artifacts/<target>/<crash-file>
+cargo +nightly-2026-05-01 fuzz run <target> artifacts/<target>/<crash-file>
 ```
 
 ## Pre-merge smoke check (`make fuzz-smoke`)
 
 The `Makefile` in this directory wraps the same recipe as
-`.github/workflows/libbitcoinpqc-fuzz.yml`, so the workflow's checks
-can be run locally with one command:
+`.github/workflows/libbitcoinpqc-fuzz.yml`, so the workflow recipe can
+be run locally with one command:
 
 ```
 cd src/libbitcoinpqc/fuzz
@@ -91,24 +94,22 @@ This runs:
 
 1. `cargo +nightly-2026-05-01 fuzz build`
 2. Generates the deterministic `verify_robustness/secp_smoke` seed
-3. `cargo +nightly fuzz run verify_robustness corpus/verify_robustness/secp_smoke`
-4. `cargo +nightly fuzz run <target> -- -max_total_time=1` for each of the
-   eight other targets in turn
+3. `cargo +nightly-2026-05-01 fuzz run verify_robustness corpus/verify_robustness/secp_smoke`
+4. `cargo +nightly-2026-05-01 fuzz run <target> -- -max_total_time=1` for each
+   of the eight other targets in turn
 
-It's the same byte-for-byte recipe the workflow encodes — pinned
+It's the same byte-for-byte recipe the workflow encodes: pinned
 nightly, pinned `cargo-fuzz`, same target order, same seed, same smoke
-time — so a green local run is equivalent to a green CI run.
+time.
 
-**For PRs touching `src/libbitcoinpqc/**`** — please include a pasted
-`make fuzz-smoke` log in the PR description. The workflow YAML is the
-versioned recipe; the local invocation is the enforcement.
+For PRs touching `src/libbitcoinpqc/**`, mention that `make fuzz-smoke`
+passed in the PR description or in a follow-up comment. The workflow
+YAML is the versioned recipe; in this repository the local invocation is
+the normal enforcement path.
 
 ## CI
 
-`.github/workflows/libbitcoinpqc-fuzz.yml` defines a workflow that runs
-the same `make fuzz-smoke` recipe on Linux runners. It is path-filtered
-to trigger on PRs and pushes touching `.github/workflows/libbitcoinpqc-fuzz.yml`
-or `src/libbitcoinpqc/**`. Whether or not GitHub-hosted runners are
-active on this repository at any given time, the workflow YAML stays
-in-tree as a versioned, executable recipe — `make fuzz-smoke` is the
-local equivalent.
+`.github/workflows/libbitcoinpqc-fuzz.yml` captures the same recipe in a
+versioned workflow file. Even when GitHub-hosted runners are disabled,
+the workflow YAML stays in-tree as executable documentation and
+`make fuzz-smoke` remains the local equivalent.

--- a/src/libbitcoinpqc/fuzz/run_all_fuzzers.sh
+++ b/src/libbitcoinpqc/fuzz/run_all_fuzzers.sh
@@ -3,6 +3,9 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
+# Keep the helper aligned with the pinned local smoke toolchain by default.
+RUST_NIGHTLY="${RUST_NIGHTLY:-nightly-2026-05-01}"
+
 # Define the fuzz targets to run (names must match Cargo.toml)
 TARGETS="keypair_generation sign_verify cross_algorithm key_parsing signature_parsing determinism verify_robustness sig_substitution structured_parsing"
 
@@ -22,7 +25,7 @@ fi
 # {}: Placeholder for each target name.
 
 printf "%s\n" $TARGETS | parallel -j 0 --line-buffer \
-  'echo "--- Starting fuzzer: {} ---"; cargo +nightly fuzz run "{}"; echo "--- Finished fuzzer: {} ---"'
+  "echo \"--- Starting fuzzer: {} ---\"; cargo +${RUST_NIGHTLY} fuzz run \"{}\"; echo \"--- Finished fuzzer: {} ---\""
 
 
 echo "-------------------------------------"


### PR DESCRIPTION
Follow-up to #16 per @numair's invitation in [#16 (comment)](https://github.com/btxchain/btx/pull/16#issuecomment-4365155261):

> @omniscia a Makefile target would make a lot of sense. Feel free to submit a PR and I'll review it right away.

## What this adds

A `src/libbitcoinpqc/fuzz/Makefile` so the recipe encoded in `.github/workflows/libbitcoinpqc-fuzz.yml` can be run locally with one command. The Makefile pins the same `RUST_NIGHTLY` and `CARGO_FUZZ_VERSION` the workflow pins, the same target order, the same deterministic `verify_robustness/secp_smoke` seed, and the same per-target smoke time — so a green local `make fuzz-smoke` is byte-for-byte equivalent to a green CI run.

## Targets

| Target | What it does |
|---|---|
| `make fuzz-smoke` | Full pre-merge smoke check — `fuzz-build` + seeded `verify_robustness` replay + 1s smoke loop over the eight other targets |
| `make fuzz-build` | `cargo +nightly fuzz build` only |
| `make fuzz-corpus-seed` | Generate the deterministic `verify_robustness/secp_smoke` seed file |
| `make fuzz-toolchain` | Install pinned nightly + `cargo-fuzz` |
| `make fuzz-deps-linux` | Install Linux system deps (`apt`) — matches workflow's apt-get list |
| `make fuzz-clean` | Clean fuzz build artifacts and seeded corpus |
| `make help` | Show targets and pinned versions |

Versions are overridable via `make TARGET RUST_NIGHTLY=... CARGO_FUZZ_VERSION=...`.

## README updates

`src/libbitcoinpqc/fuzz/README.md` is updated to:

- Point at the Makefile in the **Prerequisites** section (with explicit pinned versions)
- Add a **Pre-merge smoke check (`make fuzz-smoke`)** section explaining the recipe and asking PRs touching `src/libbitcoinpqc/**` to include a pasted `make fuzz-smoke` log in the description
- Update the outdated **CI** section so it reflects the workflow that landed in #16, with framing that works whether GitHub-hosted runners are active on the repo at any given time

## Why

PR #15 only existed because the fuzz crate had silently bit-rotted on `main` for a while — i.e., "run locally before merge" wasn't holding as a discipline. The workflow YAML in #16 captures the recipe as code, but with hosted runners disabled, it doesn't fire automatically. A `Makefile` target makes the pre-merge ritual `make fuzz-smoke` rather than "translate the YAML by hand," which is the difference between a recipe nobody runs and a discipline that holds.

## Validation

Tested locally on macOS (aarch64-apple-darwin):

- ✅ `make help` prints target list + pinned versions
- ✅ `make fuzz-corpus-seed` produces the 257-byte seed identical to the workflow's `python3 -c` heredoc (verified byte pattern: `0x00 + 32×0x01 + 96×0x00 + 32×0x00 + 96×0x02`)
- ✅ `make fuzz-build` completes cleanly (~13s incremental, only pre-existing warnings on deprecated secp wrapper calls in `src/libbitcoinpqc/src/lib.rs` — unchanged here)
- ✅ `make fuzz-smoke` end-to-end: 22 seconds total, all 9 targets exercised, zero panics or crashes

Smoke run summary (truncated):

```
===== smoke verify_robustness seeded invariant =====
Running: corpus/verify_robustness/secp_smoke
Executed corpus/verify_robustness/secp_smoke in 0 ms
***
*** NOTE: fuzzing was not performed, you have only
***       executed the target code on a fixed set of inputs.
***

===== smoke keypair_generation (1s) =====
[Done 156234 runs in 1 second(s)]

===== smoke key_parsing (1s) =====
[Done ~200k runs]

[... 6 more targets at 1s each ...]

===== smoke structured_parsing (1s) =====
Done 385945 runs in 2 second(s)

✓ fuzz-smoke complete — mirrors CI workflow recipe

real	0m22.141s
user	0m16.880s
sys	0m1.030s
```

Linux validation: `fuzz-deps-linux` target installs the same apt-get package list the workflow installs (`build-essential clang cmake libclang-dev libssl-dev pkg-config`); recipe is otherwise identical to the workflow's smoke recipe, which CI confirms green on Ubuntu 24.04.

## Out of scope (deliberately)

- **No changes to `run_all_fuzzers.sh`** — that's the long-run parallel-fuzz recipe (different purpose), already updated in #15 to use `cargo +nightly`. Leaving alone.
- **No changes to `CONTRIBUTING.md`** — keeping the fuzz-specific guidance in `src/libbitcoinpqc/fuzz/README.md` (downstream-specific) avoids merge friction with upstream Knots's `CONTRIBUTING.md`.
- **No top-level `Makefile`** — repo is CMake-based, no top-level Make. Putting the Makefile in the fuzz subdirectory keeps it co-located with the harness it serves.
- **No new fuzz targets / harness logic changes** — strictly tooling.