### PR TITLE
libbitcoinpqc: migrate secp256k1 wrappers from from_slice to from_byte_array

### DIFF
--- a/src/libbitcoinpqc/src/lib.rs
+++ b/src/libbitcoinpqc/src/lib.rs
@@ -213,7 +213,10 @@ impl PublicKey {
 
         // Additional validation for Secp256k1 keys
         if algorithm == Algorithm::SECP256K1_SCHNORR {
-            XOnlyPublicKey::from_slice(bytes).map_err(|_| PqcError::BadKey)?;
+            let array: [u8; 32] = bytes
+                .try_into()
+                .map_err(|_| PqcError::BadKey)?;
+            XOnlyPublicKey::from_byte_array(array).map_err(|_| PqcError::BadKey)?;
         }
 
         Ok(PublicKey {
@@ -231,8 +234,13 @@ impl PublicKey {
     /// Returns the underlying secp256k1 XOnlyPublicKey if applicable.
     pub fn secp256k1_key(&self) -> Result<XOnlyPublicKey, PqcError> {
         if self.algorithm == Algorithm::SECP256K1_SCHNORR {
-            XOnlyPublicKey::from_slice(&self.bytes).map_err(|_| PqcError::BadKey)
-        // Should be valid if constructed correctly
+            // Should be valid if constructed correctly.
+            let array: [u8; 32] = self
+                .bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| PqcError::BadKey)?;
+            XOnlyPublicKey::from_byte_array(array).map_err(|_| PqcError::BadKey)
         } else {
             Err(PqcError::AlgorithmMismatch)
         }
@@ -270,8 +278,11 @@ impl SecretKey {
 
         // Additional validation for Secp256k1 keys
         if algorithm == Algorithm::SECP256K1_SCHNORR {
-            // SecpSecretKey::from_slice does verification, checking if the key is valid (non-zero)
-            SecpSecretKey::from_slice(bytes).map_err(|_| PqcError::BadKey)?;
+            // SecpSecretKey::from_byte_array does verification, checking if the key is valid (non-zero).
+            let array: [u8; 32] = bytes
+                .try_into()
+                .map_err(|_| PqcError::BadKey)?;
+            SecpSecretKey::from_byte_array(array).map_err(|_| PqcError::BadKey)?;
         }
 
         Ok(SecretKey {
@@ -283,8 +294,13 @@ impl SecretKey {
     /// Returns the underlying secp256k1 SecretKey if applicable.
     pub fn secp256k1_key(&self) -> Result<SecpSecretKey, PqcError> {
         if self.algorithm == Algorithm::SECP256K1_SCHNORR {
-            SecpSecretKey::from_slice(&self.bytes).map_err(|_| PqcError::BadKey)
-        // Should be valid if constructed correctly
+            // Should be valid if constructed correctly.
+            let array: [u8; 32] = self
+                .bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| PqcError::BadKey)?;
+            SecpSecretKey::from_byte_array(array).map_err(|_| PqcError::BadKey)
         } else {
             Err(PqcError::AlgorithmMismatch)
         }
@@ -324,11 +340,15 @@ impl Signature {
             return Err(PqcError::BadSignature);
         }
 
-        // Additional validation for Secp256k1 signatures
+        // Schnorr signatures don't have a cheap per-byte validity check like
+        // keys; length is already validated above, and the layered
+        // schnorr::Signature::from_byte_array constructor is a no-op wrapper.
+        // We still confirm the slice converts cleanly to a 64-byte array,
+        // so length-mismatch bugs introduced above would surface here.
         if algorithm == Algorithm::SECP256K1_SCHNORR {
-            // Schnorr signatures don't have a cheap validity check like keys,
-            // but from_slice checks the length (already done above).
-            schnorr::Signature::from_slice(bytes).map_err(|_| PqcError::BadSignature)?;
+            let _array: [u8; 64] = bytes
+                .try_into()
+                .map_err(|_| PqcError::BadSignature)?;
         }
 
         Ok(Signature {
@@ -346,8 +366,13 @@ impl Signature {
     /// Returns the underlying secp256k1 Schnorr Signature if applicable.
     pub fn secp256k1_signature(&self) -> Result<schnorr::Signature, PqcError> {
         if self.algorithm == Algorithm::SECP256K1_SCHNORR {
-            schnorr::Signature::from_slice(&self.bytes).map_err(|_| PqcError::BadSignature)
-        // Should be valid if constructed correctly
+            // Should be valid if constructed correctly.
+            let array: [u8; 64] = self
+                .bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| PqcError::BadSignature)?;
+            Ok(schnorr::Signature::from_byte_array(array))
         } else {
             Err(PqcError::AlgorithmMismatch)
         }
@@ -393,8 +418,10 @@ pub fn generate_keypair(algorithm: Algorithm, random_data: &[u8]) -> Result<KeyP
         let secp = Secp256k1::<All>::new(); // Context needed for key derivation
 
         // Attempt to create secret key from the provided data
-        let sk_result = SecpSecretKey::from_slice(key_data);
-        let sk = sk_result.map_err(|_| PqcError::BadKey)?;
+        let key_array: [u8; 32] = key_data
+            .try_into()
+            .map_err(|_| PqcError::BadKey)?;
+        let sk = SecpSecretKey::from_byte_array(key_array).map_err(|_| PqcError::BadKey)?;
 
         // Create KeyPair from secret key
         let keypair = SecpKeypair::from_secret_key(&secp, &sk);


### PR DESCRIPTION
Independent of #17 (different files, different scope — that one's tooling, this one's a cleanup of warnings).

## What this is

Replaces seven uses of `secp256k1::*::from_slice` (deprecated since secp256k1 0.30.0) with the equivalent `from_byte_array` constructors. Clears the seven `#[warn(deprecated)]` warnings the libbitcoinpqc crate has been emitting since the secp256k1 0.31 dependency upgrade.

These warnings appear on every `cargo build` / `cargo +nightly fuzz build` of the crate today; they're surface noise in CI logs and the `make fuzz-smoke` runs from #17. Clearing them now means future deprecation warnings (which there will be — the secp256k1 maintainers are systematically migrating to fixed-size byte arrays) will surface against a clean baseline rather than mixed with these.

## Sites migrated

All in `src/libbitcoinpqc/src/lib.rs`:

| Site | Type |
|---|---|
| `PublicKey::try_from_slice` | `XOnlyPublicKey` |
| `PublicKey::secp256k1_key` | `XOnlyPublicKey` |
| `SecretKey::try_from_slice` | `SecpSecretKey` |
| `SecretKey::secp256k1_key` | `SecpSecretKey` |
| `Signature::try_from_slice` | `schnorr::Signature` |
| `Signature::secp256k1_signature` | `schnorr::Signature` |
| `generate_keypair` (SECP256K1_SCHNORR branch) | `SecpSecretKey` |

## Migration pattern

Each call site converts the input slice to the expected fixed-size array via `TryInto`, then passes it to `from_byte_array`. The slice length is validated before the conversion in every case (either by an explicit length check earlier in the function, or by the wrapping struct's construction invariants). The `try_into` is given a defensive `map_err` to the same `PqcError` variant the previous code returned, so a future refactor that broke a prior length check cannot reach `from_byte_array` with a wrong-sized input — it would surface as the same error as before.

## One semantic note worth flagging

`Signature::try_from_slice` previously called `schnorr::Signature::from_slice(bytes)` as a cheap length-only check, with a comment noting that `from_slice` checks the length (already done above by the explicit `bytes.len() != expected_len` guard).

`schnorr::Signature::from_byte_array` does no validation at all (it's literally `Self(sig)`), so calling it would be a true no-op. The new code keeps a defensive `[u8; 64]` `try_into` to preserve the same length-mismatch detection the previous code provided. Comment updated to explain.

## Build state

Before:
```
warning: `bitcoinpqc` (lib) generated 8 warnings
```

After:
```
warning: `bitcoinpqc` (lib) generated 1 warning
```

The remaining warning is on `bitcoin_pqc_sign_with_randomness` in `target/.../bindings.rs`, which is auto-generated by `bindgen` at build time, not source code in this crate. Resolving that would be a separate change in `build.rs` or in the wrapping module's `#[allow(dead_code)]`. Out of scope here.

## Validation

`cargo build --release` on aarch64-apple-darwin:
- Clean (1 warning, 0 errors)
- 8 → 1 warnings as documented above

All 9 fuzz harnesses build and exercise cleanly under the pinned `nightly-2026-05-01` + `cargo-fuzz 0.13.1` toolchain (matches the workflow in #16 and the `make fuzz-smoke` recipe in #17):

```
verify_robustness (seeded):     replay clean
keypair_generation:                885 runs in 2 second(s)
key_parsing:                 2,219,571 runs in 2 second(s)
signature_parsing:           2,228,915 runs in 2 second(s)
sign_verify:                        68 runs in 2 second(s)
cross_algorithm:                10,838 runs in 2 second(s)
determinism:                     5,745 runs in 2 second(s)
sig_substitution:                   24 runs in 2 second(s)
structured_parsing:            478,485 runs in 2 second(s)
```

~5M total iterations across the suite, zero panics, zero crashes. Same behaviour as `main` modulo the warnings.

## Public API impact

None. `PublicKey`, `SecretKey`, `Signature`, `KeyPair` structs and their methods are unchanged in signature, semantics, and observable behaviour. Every error mapping returns the same `PqcError` variant the previous code returned.

## Out of scope (deliberately)

- **No `bindings.rs` warning fix** — that warning is on auto-generated code (the `bitcoin_pqc_sign_with_randomness` C function from `bindgen`); fixing it requires either an `#[allow(dead_code)]` on the generated module or a `build.rs` adjustment. Different change, different review.
- **No further secp256k1 API migrations** — only the `from_slice` → `from_byte_array` deprecation. The crate may have other deprecated calls in adjacent versions; surfacing those would happen if/when they appear in the warning stream.
- **No fuzz-harness changes** — the harness is unchanged. Validation just confirms it still passes after the migration.