### PR TITLE
fix: route security reports to BTX team via GitHub Security Advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,12 +7,10 @@ security updates: https://btx.dev/
 
 ## Reporting a Vulnerability
 
-To report security issues send an email to luke+security+knots@dashjr.org (not for support).
+Please report security vulnerabilities privately via GitHub Security Advisories:
 
-The following OpenPGP key should be used to communicate sensitive information:
+**[Open a security advisory →](https://github.com/btxchain/btx/security/advisories/new)**
 
-| Name | Fingerprint |
-|------|-------------|
-| Luke Dashjr | FAC0 98FE 8DF9 975F 9024  1881 3666 E2B1 782A 18E1 |
+This creates a private discussion visible only to the BTX maintainers. Do not file a public GitHub issue for security-impacting bugs.
 
-You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.
+If you would prefer to communicate by encrypted email, contact the maintainers at the address listed in the latest release notes and request a PGP key for further correspondence.


### PR DESCRIPTION
## Summary

The `Reporting a Vulnerability` section in `SECURITY.md` was inherited verbatim from the Bitcoin Knots upstream and routed vulnerability reports to `luke+security+knots@dashjr.org` (Luke Dashjr's inbox) along with his PGP fingerprint. Reports made in good faith currently land with the upstream Bitcoin Knots maintainer rather than the BTX team.

## What changed

- Replaced the email contact + PGP key block with a pointer to **GitHub Security Advisories** (`https://github.com/btxchain/btx/security/advisories/new`). This is enabled by default on every public GitHub repo and provides private vulnerability disclosure visible only to maintainers.
- Left a placeholder paragraph noting that reporters preferring encrypted email can request a PGP key from the address listed in the latest release notes — so the team can add a specific email later without another PR.

## Test plan

- [x] Documentation-only change; no build or runtime impact.

## Context

Noticed while preparing a vulnerability-disclosure path during external benchmarking. Happy to adjust the wording (e.g. add a specific `security@btx.dev` address) if the team has a preferred contact channel.