### PR TITLE
docs(build): host CPU requirements and multi-GPU mining for the CUDA backend

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -64,6 +64,57 @@ If CUDA runtime probing succeeds, the output will report:
 For current CUDA runtime defaults, pool behavior, and optimization notes, see
 `btx-cuda-matmul-optimization-notes-2026-04-13.md`.
 
+### Host CPU Requirements (Recommended)
+
+The BTX MatMul miner is launch-rate-driven: per-nonce CPU work (preparing the
+rank-`r` perturbation matrices, posting the CUDA dispatch, processing the
+SHA-256 transcript hash) is on the host pipeline's critical path. As a
+result, the host CPU's single-thread performance and memory bandwidth
+substantially affect throughput on a fast GPU. The same GPU on a modern
+CPU will deliver several times the throughput it does on an older
+datacenter Xeon.
+
+For full GPU saturation on Blackwell-class cards, **AMD Zen 4 / Intel
+Alder Lake or newer** is recommended. Older datacenter Xeons (Haswell /
+Broadwell-era) can run BTX correctly but will significantly underutilize a
+modern GPU and produce throughput well below the kernel's capability.
+
+Reference measurements (single RTX 5060 Ti, BTX 0.29.7 source build,
+mainnet `n=512 b=16 r=8`, optimal pipeline flags):
+
+| Host CPU                        | nonces/sec (mean) | GPU peak util |
+|---------------------------------|------------------:|--------------:|
+| Intel Xeon E5-2676 v3 (Haswell) |             4,020 |           24% |
+| AMD EPYC 9334 (Zen 4)           |            27,554 |          ~99% |
+
+If you observe a single-card throughput much lower than the modern-host
+number, suspect the host CPU before suspecting the kernel.
+
+### Multi-GPU Mining
+
+For multiple GPUs on a single host, the working pattern is **one miner
+process per GPU**, scoped via `CUDA_VISIBLE_DEVICES`:
+
+```bash
+for i in $(seq 0 $(( $(nvidia-smi -L | wc -l) - 1 ))); do
+  CUDA_VISIBLE_DEVICES=$i ./build/bin/btx-matmul-solve-bench \
+    --backend cuda --tries 4000 --batch-size 4096 --gpu-inputs 1 --async 1 \
+    --pool-slots 16 --prefetch-depth 16 --prepare-workers 16 \
+    --solver-threads 16 --parallel 8 \
+    > /tmp/btx-bench-gpu$i.out 2>&1 &
+done
+wait
+```
+
+Each process owns its own CUDA context and pipeline; cards do not contend.
+Verify both GPUs reach full utilization with `nvidia-smi` while running.
+Combined throughput scales near-linearly with GPU count, subject to host
+CPU and memory bandwidth headroom.
+
+For long-running mining via `btxd`, use the same pattern with separate
+`-datadir` arguments per process so the node instances don't share chain
+state on disk.
+
 ## Memory Requirements
 
 C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of


### PR DESCRIPTION
## Summary

Adds two subsections to the existing CUDA documentation in `doc/build-unix.md` covering operational facts that substantially affect retail miner experience but aren't yet documented: host-CPU dependency on throughput, and the multi-GPU launch pattern.

## Why

We benchmarked the same single RTX 5060 Ti, same source build, same bench command on two different vast.ai instances:

| Host CPU | nonces/sec (mean) | GPU peak util |
|---|---:|---:|
| Intel Xeon E5-2676 v3 (Haswell, 2014) | 4,020 | 24% |
| AMD EPYC 9334 (Zen 4, 2022) | 27,554 | ~99% |

The 6.85× delta is entirely from the host CPU. The miner is launch-rate-driven: per-nonce CPU work (preparing rank-`r` perturbation matrices, posting the CUDA dispatch, processing the SHA-256 transcript) sits on the pipeline's critical path. On older datacenter Xeons (typical for cheap cloud rentals) the GPU sits idle ~76% of the time waiting on the host. Without this in the docs, miners observing 24% GPU util will reasonably (but incorrectly) suspect the kernel — speaking from experience.

Separately, multi-GPU on a single host works cleanly via per-process `CUDA_VISIBLE_DEVICES`. We verified on a 2× 5060 Ti EPYC instance: both cards saturated independently at 100%, combined ~52,900 nonces/sec (near-linear scaling). Documenting the pattern explicitly will save miners reverse-engineering it.

## What changed

`doc/build-unix.md`: appended two subsections after the existing "Optional: Enable the CUDA MatMul Backend" section and before "## Memory Requirements":

- **Host CPU Requirements (Recommended)** — explains the launch-rate dependency, recommends Zen 4 / Alder Lake or newer, includes the reference table above with the warning to suspect the host CPU before the kernel.
- **Multi-GPU Mining** — `for` loop showing the `CUDA_VISIBLE_DEVICES=$i` pattern with the optimal pipeline flags, notes about per-process CUDA contexts not contending, and a pointer to use `-datadir` per process when running `btxd`.

51 lines added, no existing text removed.

## Test plan

- [x] Documentation-only change.
- [x] Reference numbers in the new table are from real bench runs (raw JSON / nvidia-smi logs available on request).

## Context

Happy to expand the reference table with additional `(GPU, host CPU, nonces/sec)` tuples as more hardware comes online (Apple Silicon Metal, owned 5060 Tis on Ryzen 9 hosts, etc.) — could grow into a `doc/expected-bench-numbers.md` if useful.