### PR TITLE
build: split BTX MatMul tools out of BUILD_UTIL into BUILD_MATMUL_TOOLS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ option(BUILD_BITCOINCONSENSUS_LIB "Build libbitcoinconsensus library." OFF)
 option(BUILD_TESTS "Build test_btx executable (legacy build target: test_bitcoin)." ON)
 option(BUILD_TX "Build btx-tx executable (legacy alias: bitcoin-tx)." ${BUILD_TESTS})
 option(BUILD_UTIL "Build btx-util executable (legacy alias: bitcoin-util)." ${BUILD_TESTS})
+option(BUILD_MATMUL_TOOLS "Build BTX MatMul tools (btx-matmul-backend-info, btx-matmul-metal-bench, btx-matmul-solve-bench)." ON)
 
 option(BUILD_UTIL_CHAINSTATE "Build experimental bitcoin-chainstate executable." OFF)
 option(BUILD_KERNEL_LIB "Build experimental bitcoinkernel library." ${BUILD_UTIL_CHAINSTATE})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -787,6 +787,25 @@ if(BUILD_UTIL)
   add_legacy_binary_alias(bitcoin-util bitcoin-util)
   add_btx_target_alias(btx-util bitcoin-util)
 
+  add_executable(btx-genesis btx-genesis.cpp)
+  target_link_libraries(btx-genesis
+    core_interface
+  )
+  if(UNIX AND NOT APPLE)
+    target_link_btx_linux_archive_group(btx-genesis ${BTX_BASE_ARCHIVES})
+  else()
+    target_link_libraries(btx-genesis
+      bitcoin_shielded
+    )
+  endif()
+  install_binary_component(btx-genesis)
+endif()
+
+
+# BTX MatMul bench/info tools — gated on BUILD_MATMUL_TOOLS rather than
+# BUILD_UTIL because miners commonly disable BUILD_UTIL but still need the
+# bench/info binaries to validate their CUDA setup.
+if(BUILD_MATMUL_TOOLS)
   add_executable(btx-matmul-backend-info btx-matmul-backend-info.cpp)
   target_link_libraries(btx-matmul-backend-info
     core_interface
@@ -824,19 +843,6 @@ if(BUILD_UTIL)
     )
   endif()
   install_binary_component(btx-matmul-solve-bench)
-
-  add_executable(btx-genesis btx-genesis.cpp)
-  target_link_libraries(btx-genesis
-    core_interface
-  )
-  if(UNIX AND NOT APPLE)
-    target_link_btx_linux_archive_group(btx-genesis ${BTX_BASE_ARCHIVES})
-  else()
-    target_link_libraries(btx-genesis
-      bitcoin_shielded
-    )
-  endif()
-  install_binary_component(btx-genesis)
 endif()
 
 


### PR DESCRIPTION
## Summary

The matmul bench/info tools (`btx-matmul-backend-info`, `btx-matmul-metal-bench`, `btx-matmul-solve-bench`) currently live inside the `if(BUILD_UTIL)` block in `src/CMakeLists.txt`. A miner who sets `-DBUILD_UTIL=OFF` to skip building `bitcoin-util` / `btx-tx` (a reasonable choice if those tools aren't needed) gets **no bench binaries and no error** — silent disabling of the very tools every CUDA miner needs to validate their setup.

I hit this on the first build attempt while preparing benchmark data for the team.

## What changed

- `CMakeLists.txt`: added new top-level option `BUILD_MATMUL_TOOLS` defaulting to `ON`, declared adjacent to `BUILD_TX` / `BUILD_UTIL`.
- `src/CMakeLists.txt`: moved the three `add_executable(btx-matmul-*)` definitions out of the `if(BUILD_UTIL)` block into a dedicated `if(BUILD_MATMUL_TOOLS)` block immediately after, with a brief explanatory comment. `btx-genesis` stays inside `BUILD_UTIL` since it's a one-time setup tool, not a recurring miner-facing tool.

The existing `if(UNIX AND NOT APPLE) target_link_btx_linux_archive_group(...) else() target_link_libraries(... bitcoin_common / bitcoin_shielded) endif()` pattern is preserved verbatim for each binary — no changes to linking logic.

## Backwards compatibility

- `BUILD_MATMUL_TOOLS=ON` by default, so every existing build configuration that previously set `BUILD_UTIL=ON` continues to produce the matmul tools as before — no behavior change.
- Configurations that previously set `BUILD_UTIL=OFF` and silently lost the matmul tools will now correctly produce them (the previous behavior was clearly unintentional given the docs reference `btx-matmul-backend-info` for verification).
- Configurations that explicitly want to opt out (e.g. minimal CI builds) can set `-DBUILD_MATMUL_TOOLS=OFF`.

## Test plan

```bash
# 1. matmul tools build with BUILD_UTIL=OFF
cmake -B build-no-util -DBUILD_UTIL=OFF -DBUILD_MATMUL_TOOLS=ON \
  -DBTX_ENABLE_CUDA_EXPERIMENTAL=ON -DBTX_CUDA_ARCHITECTURES=120 \
  -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF -DBUILD_TESTS=OFF \
  -DBUILD_TX=OFF -DBUILD_KERNEL_LIB=OFF -DENABLE_WALLET=OFF -DBUILD_BENCH=OFF
cmake --build build-no-util --target btx-matmul-backend-info --target btx-matmul-solve-bench -j$(nproc)
test -x build-no-util/bin/btx-matmul-solve-bench   # should pass

# 2. opt-out works
cmake -B build-opt-out -DBUILD_UTIL=ON -DBUILD_MATMUL_TOOLS=OFF [...]
cmake --build build-opt-out --target btx-cli -j$(nproc)
! test -e build-opt-out/bin/btx-matmul-solve-bench   # should not exist

# 3. legacy default (BUILD_UTIL=ON, no flag) still produces matmul tools
cmake -B build-legacy -DBUILD_UTIL=ON [...]
cmake --build build-legacy --target btx-matmul-solve-bench -j$(nproc)
test -x build-legacy/bin/btx-matmul-solve-bench   # should pass
```

I haven't run these locally on the Mac (no CUDA there), but the cmake logic mirrors the existing `BUILD_UTIL` / `BUILD_TX` patterns 1:1.

## Risk

Very low. No consensus impact, no source-file changes, no link-pattern changes. Trivially reversible.