### PR TITLE
chore: post-fork hygiene + CUDA host-CPU docs + matmul build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ option(BUILD_BITCOINCONSENSUS_LIB "Build libbitcoinconsensus library." OFF)
 option(BUILD_TESTS "Build test_btx executable (legacy build target: test_bitcoin)." ON)
 option(BUILD_TX "Build btx-tx executable (legacy alias: bitcoin-tx)." ${BUILD_TESTS})
 option(BUILD_UTIL "Build btx-util executable (legacy alias: bitcoin-util)." ${BUILD_TESTS})
+option(BUILD_MATMUL_TOOLS "Build BTX MatMul tools (btx-matmul-backend-info, btx-matmul-metal-bench, btx-matmul-solve-bench)." ON)
 
 option(BUILD_UTIL_CHAINSTATE "Build experimental bitcoin-chainstate executable." OFF)
 option(BUILD_KERNEL_LIB "Build experimental bitcoinkernel library." ${BUILD_UTIL_CHAINSTATE})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,14 @@
-Contributing to Bitcoin Knots
-=============================
+Contributing to BTX
+===================
 
-The Bitcoin Knots project operates an open contributor model where anyone is
+The BTX project operates an open contributor model where anyone is
 welcome to contribute towards development in the form of peer review, testing
 and patches. This document explains the practical process and guidelines for
 contributing.
+
+BTX is derived from Bitcoin Knots / Bitcoin Core. Many of the conventions
+below — atomic commits, peer-review semantics, squash and rebase workflow —
+apply identically and are preserved verbatim from upstream.
 
 First, in terms of structure, there is no particular concept of "core
 developers" in the sense of privileged people. Open source often naturally
@@ -24,19 +28,16 @@ as a new contributor. It also will teach you much more about the code and
 process than opening pull requests. Please refer to the [peer review](#peer-review)
 section below.
 
-Before you start contributing, familiarize yourself with the Bitcoin Core build
-system and tests. Refer to the documentation in the repository on how to build
-Bitcoin Core and how to run the unit tests, functional tests, and fuzz tests.
+Before you start contributing, familiarize yourself with the BTX build
+system and tests (Bitcoin Core derived; see `doc/build-*.md`). Refer to the
+documentation in the repository on how to build BTX and how to run the unit
+tests, functional tests, and fuzz tests.
 
 There are many open issues of varying difficulty waiting to be fixed.
 If you're looking for somewhere to start contributing, check out the
-[good first issue](https://github.com/bitcoin/bitcoin/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-list or changes that are
-[up for grabs](https://github.com/bitcoin/bitcoin/issues?utf8=%E2%9C%93&q=label%3A%22Up+for+grabs%22).
-Some of them might no longer be applicable. So if you are interested, but
-unsure, you might want to leave a comment on the issue first.
-
-You may also participate in the [Bitcoin Core PR Review Club](https://bitcoincore.reviews/).
+[good first issue](https://github.com/btxchain/btx/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+list. Some of them might no longer be applicable, so if you are interested
+but unsure, you might want to leave a comment on the issue first.
 
 ### Good First Issue Label
 
@@ -54,21 +55,14 @@ and is also an effective way to request assistance if and when you need it.
 Communication Channels
 ----------------------
 
-Most communication about Bitcoin development happens on IRC, in the
-`#bitcoin-core-dev` channel on Libera Chat. The easiest way to participate on IRC is
-with the web client, [web.libera.chat](https://web.libera.chat/#bitcoin-core-dev). Chat
-history logs can be found
-on [https://www.erisian.com.au/bitcoin-core-dev/](https://www.erisian.com.au/bitcoin-core-dev/)
-and [https://gnusha.org/bitcoin-core-dev/](https://gnusha.org/bitcoin-core-dev/).
-
 Discussion about codebase improvements happens in GitHub issues and pull
-requests.
+requests on https://github.com/btxchain/btx. Watch the repository for release
+announcements.
 
-The developer
-[mailing list](https://groups.google.com/g/bitcoindev)
-should be used to discuss complicated or controversial consensus or P2P protocol changes before working on
-a patch set.
-Archives can be found on [https://gnusha.org/pi/bitcoindev/](https://gnusha.org/pi/bitcoindev/).
+For complicated or controversial consensus or P2P protocol changes, please
+open a GitHub issue or draft pull request describing the proposed change
+before working on a full patch set, so the BTX maintainers can weigh in
+early on direction.
 
 
 Contributor Workflow
@@ -84,25 +78,9 @@ To contribute a patch, the workflow is as follows:
   1. Create topic branch
   1. Commit patches
 
-For GUI-related issues or pull requests, the https://github.com/bitcoin-core/gui repository should be used.
-For all other issues and pull requests, the https://github.com/bitcoin/bitcoin node repository should be used.
-
-The master branch for all monotree repositories is identical.
-
-As a rule of thumb, everything that only modifies `src/qt` is a GUI-only pull
-request. However:
-
-* For global refactoring or other transversal changes the node repository
-  should be used.
-* For GUI-related build system changes, the node repository should be used
-  because the change needs review by the build systems reviewers.
-* Changes in `src/interfaces` need to go to the node repository because they
-  might affect other components like the wallet.
-
-For large GUI changes that include build system and interface changes, it is
-recommended to first open a pull request against the GUI repository. When there
-is agreement to proceed with the changes, a pull request with the build system
-and interfaces changes can be submitted to the node repository.
+All issues and pull requests — GUI and otherwise — go to the single BTX
+repository at https://github.com/btxchain/btx. As a rule of thumb,
+everything that only modifies `src/qt` is a GUI-only pull request.
 
 The project coding conventions in the [developer notes](doc/developer-notes.md)
 must be followed.
@@ -142,7 +120,7 @@ the pull request affects. Valid areas as:
 
   - `consensus` for changes to consensus critical code
   - `doc` for changes to the documentation
-  - `qt` or `gui` for changes to bitcoin-qt
+  - `qt` or `gui` for changes to btx-qt
   - `log` for changes to log messages
   - `mining` for changes to the mining code
   - `net` or `p2p` for changes to the peer-to-peer network code
@@ -170,14 +148,8 @@ mailing list discussions).
 The description for a new pull request should not contain any `@` mentions. The
 PR description will be included in the commit message when the PR is merged and
 any users mentioned in the description will be annoyingly notified each time a
-fork of Bitcoin Core copies the merge. Instead, make any username mentions in a
+fork of BTX copies the merge. Instead, make any username mentions in a
 subsequent comment to the PR.
-
-### Translation changes
-
-Note that translations should not be submitted as pull requests. Please see
-[Translation Process](https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md)
-for more information on helping with translations.
 
 ### Work in Progress Changes and Requests for Comments
 
@@ -232,7 +204,7 @@ pull request to pull request.
 
 When a pull request conflicts with the target branch, you may be asked to rebase it on top of the current target branch.
 
-    git fetch https://github.com/bitcoin/bitcoin  # Fetch the latest upstream commit
+    git fetch https://github.com/btxchain/btx  # Fetch the latest upstream commit
     git rebase FETCH_HEAD  # Rebuild commits on top of the new base
 
 This project aims to have a clean git history, where code changes are only made in non-merge commits. This simplifies
@@ -289,11 +261,12 @@ workload on reviewing.
 "Decision Making" Process
 -------------------------
 
-The following applies to code changes to the Bitcoin Knots project (and related
-projects such as libsecp256k1), and is not to be confused with overall Bitcoin
-Network Protocol consensus changes.
+The following applies to code changes to the BTX project (and the
+consensus-critical components inherited from Bitcoin Knots / Bitcoin Core),
+and is not to be confused with overall Bitcoin Network Protocol consensus
+changes.
 
-Whether a pull request is merged into Bitcoin Knots rests with the project merge
+Whether a pull request is merged into BTX rests with the project merge
 maintainers and ultimately the project lead.
 
 Maintainers will take into consideration if a patch is in line with the general
@@ -312,12 +285,13 @@ In general, all pull requests must:
     demonstrating the bug and also proving the fix. This helps prevent regression.
   - Change relevant comments and documentation when behaviour of code changes.
 
-Patches that change Bitcoin consensus rules are considerably more involved than
-normal because they affect the entire ecosystem and so must be preceded by
-extensive mailing list discussions and have a numbered BIP. While each case will
-be different, one should be prepared to expend more time and effort than for
-other kinds of patches because of increased peer review and consensus building
-requirements.
+Patches that change BTX consensus rules (MatMul PoW, post-quantum
+signatures, the shielded pool) are considerably more involved than normal
+because they affect the entire BTX network and so must be preceded by
+extensive discussion in GitHub issues / pull requests with a clear written
+proposal. While each case will be different, one should be prepared to
+expend more time and effort than for other kinds of patches because of
+increased peer review and consensus building requirements.
 
 
 ### Peer Review
@@ -373,9 +347,9 @@ higher in terms of discussion and peer review requirements, keeping in mind that
 mistakes could be very costly to the wider community. This includes refactoring
 of consensus-critical code.
 
-Where a patch set proposes to change the Bitcoin consensus, it must have been
-discussed extensively on the mailing list and IRC, be accompanied by a widely
-discussed BIP and have a generally widely perceived technical consensus of being
+Where a patch set proposes to change the BTX consensus, it must have been
+discussed extensively in GitHub issues / pull requests with a written
+proposal, and have a generally widely perceived technical consensus of being
 a worthwhile change based on the judgement of the maintainers.
 
 ### Finding Reviewers
@@ -396,16 +370,16 @@ about:
     that personally, though! Instead, take another critical look at what you are suggesting
     and see if it: changes too much, is too broad, doesn't adhere to the
     [developer notes](doc/developer-notes.md), is dangerous or insecure, is messily written, etc.
-    Identify and address any of the issues you find. Then ask e.g. on IRC if someone could give
-    their opinion on the concept itself.
+    Identify and address any of the issues you find. Then ask in a GitHub issue if someone
+    could give their opinion on the concept itself.
   - It may be because your code is too complex for all but a few people, and those people
     may not have realized your pull request even exists. A great way to find people who
     are qualified and care about the code you are touching is the
     [Git Blame feature](https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/tracking-changes-in-a-file). Simply
     look up who last modified the code you are changing and see if you can find
     them and give them a nudge. Don't be incessant about the nudging, though.
-  - Finally, if all else fails, ask on IRC or elsewhere for someone to give your pull request
-    a look. If you think you've been waiting for an unreasonably long time (say,
+  - Finally, if all else fails, comment on the PR or open a discussion to ask for
+    a review. If you think you've been waiting for an unreasonably long time (say,
     more than a month) for no particular reason (a few lines changed, etc.),
     this is totally fine. Try to return the favor when someone else is asking
     for feedback on their code, and the universe balances out.
@@ -427,12 +401,6 @@ A backport should contain the following metadata in the commit body:
 Github-Pull: #<PR number>
 Rebased-From: <commit hash of the original commit>
 ```
-
-Have a look at [an example backport PR](
-https://github.com/bitcoin/bitcoin/pull/16189).
-
-Also see the [backport.py script](
-https://github.com/bitcoin-core/bitcoin-maintainer-tools#backport).
 
 Copyright
 ---------

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,12 +7,10 @@ security updates: https://btx.dev/
 
 ## Reporting a Vulnerability
 
-To report security issues send an email to luke+security+knots@dashjr.org (not for support).
+Please report security vulnerabilities privately via GitHub Security Advisories:
 
-The following OpenPGP key should be used to communicate sensitive information:
+**[Open a security advisory →](https://github.com/btxchain/btx/security/advisories/new)**
 
-| Name | Fingerprint |
-|------|-------------|
-| Luke Dashjr | FAC0 98FE 8DF9 975F 9024  1881 3666 E2B1 782A 18E1 |
+This creates a private discussion visible only to the BTX maintainers. Do not file a public GitHub issue for security-impacting bugs.
 
-You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.
+If you would prefer to communicate by encrypted email, contact the maintainers at the address listed in the latest release notes and request a PGP key for further correspondence.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -64,6 +64,57 @@ If CUDA runtime probing succeeds, the output will report:
 For current CUDA runtime defaults, pool behavior, and optimization notes, see
 `btx-cuda-matmul-optimization-notes-2026-04-13.md`.
 
+### Host CPU Requirements (Recommended)
+
+The BTX MatMul miner is launch-rate-driven: per-nonce CPU work (preparing the
+rank-`r` perturbation matrices, posting the CUDA dispatch, processing the
+SHA-256 transcript hash) is on the host pipeline's critical path. As a
+result, the host CPU's single-thread performance and memory bandwidth
+substantially affect throughput on a fast GPU. The same GPU on a modern
+CPU will deliver several times the throughput it does on an older
+datacenter Xeon.
+
+For full GPU saturation on Blackwell-class cards, **AMD Zen 4 / Intel
+Alder Lake or newer** is recommended. Older datacenter Xeons (Haswell /
+Broadwell-era) can run BTX correctly but will significantly underutilize a
+modern GPU and produce throughput well below the kernel's capability.
+
+Reference measurements (single RTX 5060 Ti, BTX 0.29.7 source build,
+mainnet `n=512 b=16 r=8`, optimal pipeline flags):
+
+| Host CPU                        | nonces/sec (mean) | GPU peak util |
+|---------------------------------|------------------:|--------------:|
+| Intel Xeon E5-2676 v3 (Haswell) |             4,020 |           24% |
+| AMD EPYC 9334 (Zen 4)           |            27,554 |          ~99% |
+
+If you observe a single-card throughput much lower than the modern-host
+number, suspect the host CPU before suspecting the kernel.
+
+### Multi-GPU Mining
+
+For multiple GPUs on a single host, the working pattern is **one miner
+process per GPU**, scoped via `CUDA_VISIBLE_DEVICES`:
+
+```bash
+for i in $(seq 0 $(( $(nvidia-smi -L | wc -l) - 1 ))); do
+  CUDA_VISIBLE_DEVICES=$i ./build/bin/btx-matmul-solve-bench \
+    --backend cuda --tries 4000 --batch-size 4096 --gpu-inputs 1 --async 1 \
+    --pool-slots 16 --prefetch-depth 16 --prepare-workers 16 \
+    --solver-threads 16 --parallel 8 \
+    > /tmp/btx-bench-gpu$i.out 2>&1 &
+done
+wait
+```
+
+Each process owns its own CUDA context and pipeline; cards do not contend.
+Verify both GPUs reach full utilization with `nvidia-smi` while running.
+Combined throughput scales near-linearly with GPU count, subject to host
+CPU and memory bandwidth headroom.
+
+For long-running mining via `btxd`, use the same pattern with separate
+`-datadir` arguments per process so the node instances don't share chain
+state on disk.
+
 ## Memory Requirements
 
 C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -787,6 +787,25 @@ if(BUILD_UTIL)
   add_legacy_binary_alias(bitcoin-util bitcoin-util)
   add_btx_target_alias(btx-util bitcoin-util)
 
+  add_executable(btx-genesis btx-genesis.cpp)
+  target_link_libraries(btx-genesis
+    core_interface
+  )
+  if(UNIX AND NOT APPLE)
+    target_link_btx_linux_archive_group(btx-genesis ${BTX_BASE_ARCHIVES})
+  else()
+    target_link_libraries(btx-genesis
+      bitcoin_shielded
+    )
+  endif()
+  install_binary_component(btx-genesis)
+endif()
+
+
+# BTX MatMul bench/info tools — gated on BUILD_MATMUL_TOOLS rather than
+# BUILD_UTIL because miners commonly disable BUILD_UTIL but still need the
+# bench/info binaries to validate their CUDA setup.
+if(BUILD_MATMUL_TOOLS)
   add_executable(btx-matmul-backend-info btx-matmul-backend-info.cpp)
   target_link_libraries(btx-matmul-backend-info
     core_interface
@@ -824,19 +843,6 @@ if(BUILD_UTIL)
     )
   endif()
   install_binary_component(btx-matmul-solve-bench)
-
-  add_executable(btx-genesis btx-genesis.cpp)
-  target_link_libraries(btx-genesis
-    core_interface
-  )
-  if(UNIX AND NOT APPLE)
-    target_link_btx_linux_archive_group(btx-genesis ${BTX_BASE_ARCHIVES})
-  else()
-    target_link_libraries(btx-genesis
-      bitcoin_shielded
-    )
-  endif()
-  install_binary_component(btx-genesis)
 endif()
 
 


### PR DESCRIPTION
> **Note:** Combines #19, #20, #21, #22 into a single PR per maintainer request. Each of the four logical changes is preserved as its own commit so the diff stays reviewable per-topic.

## Summary

Four small, independent post-fork hygiene / CUDA-mining-UX fixes, bundled into one PR:

| Commit | Subject | Files |
|---|---|---|
| `762f7f3` | `fix: route security reports to BTX team via GitHub Security Advisories` | `SECURITY.md` |
| `135581b` | `docs(contrib): retitle CONTRIBUTING.md to BTX and update inherited references` | `CONTRIBUTING.md` |
| `039fe81` | `docs(build): host CPU requirements and multi-GPU mining for the CUDA backend` | `doc/build-unix.md` |
| `10823a6` | `build: split BTX MatMul tools out of BUILD_UTIL into BUILD_MATMUL_TOOLS option` | `CMakeLists.txt`, `src/CMakeLists.txt` |

Total: **5 files changed, 120 insertions, 96 deletions**.

None of these touch consensus paths (`src/matmul/`, `src/cuda/`, `src/shielded/`, `src/validation.cpp`, `src/kernel/`).

---

## 1. `SECURITY.md` — fix vulnerability routing (commit `762f7f3`)

**Why:** The `Reporting a Vulnerability` section was inherited verbatim from Bitcoin Knots and routed reports to `luke+security+knots@dashjr.org` (Luke Dashjr's inbox). Reports made in good faith were landing with the upstream Bitcoin Knots maintainer rather than the BTX team.

**What changed:** Replaced the email + PGP block with a pointer to GitHub Security Advisories (enabled by default on every public GitHub repo), with a placeholder noting that the team can add a preferred encrypted-email contact later.

## 2. `CONTRIBUTING.md` — retitle to BTX (commit `135581b`)

**Why:** The file was verbatim Bitcoin Knots' contributing guide. Title says *Contributing to Bitcoin Knots*, links go to `bitcoin/bitcoin`, communication channels reference `#bitcoin-core-dev` IRC + bitcoindev mailing list, GUI separation paragraphs describe a `bitcoin-core/gui` vs `bitcoin/bitcoin` repo split that doesn't apply to BTX (`btx-qt` lives in this repo).

**What changed:** Surgical identity/links fix, **not** a workflow rewrite. Workflow conventions, peer-review semantics (Concept ACK / NACK), commit-message guidance, squash and rebase notes are preserved verbatim — they apply identically to any Bitcoin-Core-derived project.

- Title and opening paragraph retitled to BTX
- `good first issue` link → `btxchain/btx`
- Dropped `bitcoin-core/gui` / `bitcoin/bitcoin` GUI separation, IRC channel, mailing list, Bitcoin Core PR Review Club, Translation section, `bitcoin/bitcoin#16189` example backport, `bitcoin-core/bitcoin-maintainer-tools` reference
- Decision-Making / consensus sections retargeted to BTX consensus rules (MatMul PoW, post-quantum signatures, shielded pool)

Two intentional references to "Bitcoin Knots / Bitcoin Core" are preserved as factual lineage statements (intro paragraph and Decision Making section).

## 3. `doc/build-unix.md` — host CPU + multi-GPU docs for CUDA mining (commit `039fe81`)

**Why:** The existing CUDA section documents the build flags. What's missing is two operational facts: host CPU performance dominates throughput, and the multi-GPU launch pattern works via per-process `CUDA_VISIBLE_DEVICES`. We measured both directly on rented vast.ai instances.

**What changed:** Added two subsections after the existing CUDA section, before `## Memory Requirements`:

- **Host CPU Requirements (Recommended)** — explains the launch-rate dependency, recommends Zen 4 / Alder Lake or newer, includes a reference table:

  | Host CPU | nonces/sec (mean) | GPU peak util |
  |---|---:|---:|
  | Intel Xeon E5-2676 v3 (Haswell) | 4,020 | 24% |
  | AMD EPYC 9334 (Zen 4) | 27,554 | ~99% |

  Same single RTX 5060 Ti, same source build, same bench command — 6.85× delta from the host CPU alone.

- **Multi-GPU Mining** — `for` loop showing the `CUDA_VISIBLE_DEVICES=$i` pattern with the optimal pipeline flags. We verified linear scaling (2× 5060 Ti at 100% util each → ~52,900 nonces/sec combined).

51 lines added, no existing text removed. Happy to soften the framing if the team prefers — per Numair's note that "if CPU matters, it's not properly optimized," this is a current-state documentation rather than an aspirational requirement.

## 4. `CMakeLists.txt` + `src/CMakeLists.txt` — `BUILD_MATMUL_TOOLS` option (commit `10823a6`)

**Why:** The matmul bench/info tools (`btx-matmul-backend-info`, `btx-matmul-metal-bench`, `btx-matmul-solve-bench`) live inside the `if(BUILD_UTIL)` block. A miner who sets `-DBUILD_UTIL=OFF` to skip building `bitcoin-util` / `btx-tx` gets **no bench binaries and no error** — silent disabling of the very tools every CUDA miner needs to validate their setup. We hit this on the first build attempt.

**What changed:**
- Added new top-level option `BUILD_MATMUL_TOOLS` defaulting to `ON`, declared adjacent to `BUILD_TX` / `BUILD_UTIL`.
- Moved the three `add_executable(btx-matmul-*)` definitions out of the `if(BUILD_UTIL)` block into a dedicated `if(BUILD_MATMUL_TOOLS)` block. `btx-genesis` stays inside `BUILD_UTIL` (one-time setup tool, not recurring miner-facing).
- Existing linking pattern (`if(UNIX AND NOT APPLE) target_link_btx_linux_archive_group(...) else() target_link_libraries(... bitcoin_common / bitcoin_shielded)`) preserved verbatim.

**Backwards compatibility:** Default `ON` means every existing build configuration continues to produce the matmul tools. Configurations that previously set `BUILD_UTIL=OFF` and silently lost the matmul tools will now correctly produce them. Configurations that explicitly want to opt out can set `-DBUILD_MATMUL_TOOLS=OFF`.

**Test plan:**
```bash
# 1. matmul tools build with BUILD_UTIL=OFF
cmake -B build-no-util -DBUILD_UTIL=OFF -DBUILD_MATMUL_TOOLS=ON \
  -DBTX_ENABLE_CUDA_EXPERIMENTAL=ON -DBTX_CUDA_ARCHITECTURES=120 \
  -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF -DBUILD_TESTS=OFF \
  -DBUILD_TX=OFF -DBUILD_KERNEL_LIB=OFF -DENABLE_WALLET=OFF -DBUILD_BENCH=OFF
cmake --build build-no-util --target btx-matmul-backend-info --target btx-matmul-solve-bench -j$(nproc)
test -x build-no-util/bin/btx-matmul-solve-bench   # should pass

# 2. opt-out works
cmake -B build-opt-out -DBUILD_UTIL=ON -DBUILD_MATMUL_TOOLS=OFF [...]
! test -e build-opt-out/bin/btx-matmul-solve-bench   # should not exist

# 3. legacy default (BUILD_UTIL=ON, no flag) still produces matmul tools
cmake -B build-legacy -DBUILD_UTIL=ON [...]
test -x build-legacy/bin/btx-matmul-solve-bench   # should pass
```

---

## Risk

Very low. Documentation, hygiene, and one new build option (default-ON, backwards-compatible). No consensus-path code touched.

## Context

External miner here — these came up while building from source and benchmarking on a Blackwell rig. Happy to split back into 4 PRs or adjust scope on any of them. Closes / supersedes #19, #20, #21, #22.