### PR TITLE
libbitcoinpqc: scope #[allow(dead_code)] to bindgen-generated bindings

### DIFF
--- a/src/libbitcoinpqc/src/bindings_include.rs
+++ b/src/libbitcoinpqc/src/bindings_include.rs
@@ -2,9 +2,23 @@
 // available in the IDE but required for builds.
 // The build script always generates bindings.rs in the OUT_DIR.
 
-// When compiling for real, include the real bindings
+// When compiling for real, include the real bindings.
+//
+// The bindings are wrapped in a private sub-module so that
+// `#[allow(dead_code)]` is scoped to the auto-generated FFI surface
+// only. Bindgen exposes every C function in the allowlist regex
+// (`bitcoin_pqc_.*`), some of which are intentionally not yet called
+// from Rust (e.g. `bitcoin_pqc_sign_with_randomness`); their
+// dead-code warnings are noise on every build of this crate. The
+// outer `pub use` keeps the existing call sites unchanged.
 #[cfg(all(not(feature = "ide"), not(doc)))]
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+#[allow(dead_code)]
+mod real_bindings {
+    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+}
+
+#[cfg(all(not(feature = "ide"), not(doc)))]
+pub use real_bindings::*;
 
 // For documentation, we need stubs to make doctests work
 #[cfg(doc)]


### PR DESCRIPTION
Closes the last `#[warn(dead_code)]` noise emitted on every build of the `libbitcoinpqc` crate. After #18 cleared the seven `secp256k1` deprecation warnings, the only remaining warning was on `bitcoin_pqc_sign_with_randomness` in `target/.../bindings.rs` — the bindgen-generated header binding for a C function that's part of the public ABI but not yet called from Rust.

## Why the warning exists

`src/libbitcoinpqc/build.rs`'s bindgen configuration uses an allowlist regex (`bitcoin_pqc_.*`) which exposes every matching C function as part of the FFI surface, regardless of whether each one is currently called from the Rust wrapper:

```rust
.allowlist_function("bitcoin_pqc_.*")
.allowlist_type("bitcoin_pqc_.*")
.allowlist_var("BITCOIN_PQC_.*")
```

That's the right setup for FFI bindings (it keeps the binding stable as Rust call sites come and go) but it makes per-function dead-code warnings spurious noise on every build of the crate.

## Fix

Wrap the `include!` in a private sub-module with `#[allow(dead_code)]` scoped to it, mirroring the existing `doc_bindings` / `ide_bindings` sub-module pattern already in the same file:

```rust
// before
#[cfg(all(not(feature = "ide"), not(doc)))]
include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

// after
#[cfg(all(not(feature = "ide"), not(doc)))]
#[allow(dead_code)]
mod real_bindings {
    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
}

#[cfg(all(not(feature = "ide"), not(doc)))]
pub use real_bindings::*;
```

The `#[allow(dead_code)]` is scoped strictly to the auto-generated FFI surface, not leaked across the rest of `bindings_include.rs` (where the `doc_bindings` / `ide_bindings` stubs are intentionally hand-written).

Public surface is unchanged: re-exporting via `pub use real_bindings::*` keeps every existing call site (`bindings_include::bitcoin_pqc_keygen`, etc.) compiling without modification.

## Build state after this PR

| | Warnings |
|---|---|
| Before #15 | 8 (7 deprecation + 1 dead_code) |
| After #18 | 1 (dead_code) |
| **After this PR** | **0** |

`cargo build --release` of `src/libbitcoinpqc/` is now warning-free.

## Validation

Tested on macOS aarch64-apple-darwin, M3 Ultra:

- `cargo build --release` of `src/libbitcoinpqc/` reports 0 warnings (was 1).
- `cargo +nightly-2026-05-01 fuzz build` of `src/libbitcoinpqc/fuzz/` builds unchanged.
- `make fuzz-smoke` (the recipe added in #17) runs cleanly with no new warnings or errors.

## Public API impact

None. The `pub use real_bindings::*;` keeps every existing C-binding symbol accessible at the same path it was at before (`bindings_include::bitcoin_pqc_keygen` etc.).

## Diff size

`+16 / -2` in one file: `src/libbitcoinpqc/src/bindings_include.rs`.

## Out of scope (deliberately)

- **Other clippy / `non_snake_case` etc. lint suppression** — bindgen output passes those today; no need to add allows pre-emptively. The pattern in this PR is easy to extend if a future bindgen output needs more allows scoped to the same `real_bindings` module.
- **Restricting the bindgen allowlist regex** — keeping the allowlist broad is correct for FFI stability; this PR fixes the symptom (warnings) without narrowing the binding surface.

---

## Directive scope (added 2026-05-07)

Per current omniscia direction, btx contributions are **hardening-only**. New features and tooling belong at L2 (where native pooling drives the network effects), not in the L1 node.

This PR is in scope:
- No consensus path touched
- No new daemon flags / RPC / protocol surface
- "Out of scope (deliberately)" section above explicitly defers any feature-shaped expansion (e.g. promoting `BTX_MATMUL_*` env vars to proper `-matmul*` flags) as a separate larger change

If a maintainer disagrees with the scope or thinks this belongs further deferred, happy to drop it or split — flag it on the PR and I'll respond.