### PR TITLE
doc(build): document Metal MatMul tuning env vars

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -66,7 +66,7 @@ For current CUDA runtime defaults, pool behavior, and optimization notes, see
 
 ## Tuning the Metal MatMul accelerator (`BTX_MATMUL_*` environment variables)
 
-On Apple Silicon, the MatMul mining and verification backend is tuned by
+On Apple Silicon, the MatMul mining / accelerated-solve paths are tuned by
 environment variables rather than `btxd` command-line flags. They are read
 directly inside `src/matmul/`, `src/metal/`, and `src/pow.cpp`; none appear
 in `btxd -?`. Defaults work for most operators, but they are mostly
@@ -77,8 +77,10 @@ This section lists the operationally relevant ones for the Metal backend; for
 the complete inventory, search the source tree for `getenv("BTX_MATMUL_`.
 CUDA-specific tuning knobs are documented separately.
 
-After setting any variable, restart `btxd`. To inspect how the current tree
-would resolve a backend request, use:
+These knobs affect mining throughput and accelerator diagnostics; consensus
+Phase 2 validation still falls back to the CPU-canonical path. After setting
+any variable, restart `btxd`. To inspect how the current tree would resolve a
+backend request, use:
 
 ```bash
 btx-matmul-backend-info --backend metal
@@ -119,26 +121,26 @@ btxd -daemon
 | Variable | Purpose | Default |
 |---|---|---|
 | `BTX_MATMUL_METAL_POOL_SLOTS` | Number of Metal command-buffer slots in the in-flight pool. Increase to overlap more solves on the GPU; decrease to cap GPU memory pressure. | Auto-tuned from solver-thread / Apple perf-level heuristics when unset. |
-| `BTX_MATMUL_METAL_PIPELINE` | Pipeline mode for Metal solves. | Backend-default. |
-| `BTX_MATMUL_METAL_FUNCTION_CONSTANTS` | Metal function-constant overrides for kernel tuning. | Backend-default. |
+| `BTX_MATMUL_METAL_PIPELINE` | Select the Metal transcript pipeline mode (`auto`, `legacy`, `fused`). | Backend-default. |
+| `BTX_MATMUL_METAL_FUNCTION_CONSTANTS` | Override Metal function-constant specialization for transcript kernels. | Backend-default. |
 | `BTX_MATMUL_GPU_INPUTS` | Set to `1` to generate matmul inputs on the GPU instead of the CPU before the solve. Saves a CPU↔GPU copy at the cost of additional GPU compute. | Backend-decided. |
 | `BTX_MATMUL_APPLE_PERFLEVEL0_LOGICALCPU_OVERRIDE` | Override Apple Silicon perf-level-0 logical CPU count used in launch-rate tuning heuristics. Useful for benchmarking on machines whose reported perf-level partitions differ from the host's actual sustained-throughput core count. | Auto-detected. |
 
-### Diagnostic / experimental (off by default)
+### Diagnostic / special-purpose knobs
 
-Safe to leave unset. Useful when investigating a regression or comparing
-backends.
+Safe to leave unset. Useful when investigating a regression, comparing
+backends, or changing guard-rail behavior on a dedicated mining host.
 
-| Variable | Purpose |
-|---|---|
-| `BTX_MATMUL_MEM_DIAG` | Logs per-solve memory and backend stats to `debug.log`. Verbose. |
-| `BTX_MATMUL_DIAG_COMPARE_CPU_METAL` | Cross-checks Metal results against a CPU recompute. Adds latency; useful for backend-correctness investigation. |
-| `BTX_MATMUL_CPU_CONFIRM` | Confirms an accelerated solve with a CPU recompute. |
-| `BTX_MATMUL_AMX_EXPERIMENT` | Apple AMX experimental matrix path (off by default; opt-in for benchmarking). |
-| `BTX_MATMUL_BLOCKED_MULTIPLY_THREADS` | Threads for the blocked CPU matmul fallback. |
-| `BTX_MATMUL_NOISE_PARALLEL` | Parallelism in the noise-generation stage. |
-| `BTX_MATMUL_DIGEST_SLICE_SIZE` | Slice size for digest construction. |
-| `BTX_MATMUL_TIP_WATCHER` | Tip-watcher behaviour during long solves. |
+| Variable | Purpose | Default |
+|---|---|---|
+| `BTX_MATMUL_MEM_DIAG` | Logs per-solve memory and backend stats to `debug.log`. Verbose. | Off unless set. |
+| `BTX_MATMUL_DIAG_COMPARE_CPU_METAL` | Cross-checks Metal results against a CPU recompute. Adds latency; useful for backend-correctness investigation. | Off unless set. |
+| `BTX_MATMUL_CPU_CONFIRM` | Confirms an accelerated solve with a CPU recompute before accepting it. | On for Metal/CUDA when unset. |
+| `BTX_MATMUL_AMX_EXPERIMENT` | Apple AMX experimental matrix path (opt-in for benchmarking). | Off unless set. |
+| `BTX_MATMUL_BLOCKED_MULTIPLY_THREADS` | Threads for the blocked CPU matmul fallback. | Backend / host default when unset. |
+| `BTX_MATMUL_NOISE_PARALLEL` | Parallelism in the noise-generation stage. | Backend / host default when unset. |
+| `BTX_MATMUL_DIGEST_SLICE_SIZE` | Slice size for digest construction. | Backend default when unset. |
+| `BTX_MATMUL_TIP_WATCHER` | Enables the tip watcher during long solves. | On when unset. |
 
 ## Initial Block Download
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -69,41 +69,41 @@ For current CUDA runtime defaults, pool behavior, and optimization notes, see
 On Apple Silicon, the MatMul mining and verification backend is tuned by
 environment variables rather than `btxd` command-line flags. They are read
 directly inside `src/matmul/`, `src/metal/`, and `src/pow.cpp`; none appear
-in `btxd -?`. Defaults work for most operators, but in practice a fresh
-install on a capable Mac (M1/M2/M3-class) can sit at 1 solver thread (the
-default) and look puzzlingly slow until one of these variables is set. This
-section lists the operationally relevant ones for the Metal backend; for
+in `btxd -?`. Defaults work for most operators, but they are mostly
+auto-tuned from backend and host heuristics rather than fixed constants. On
+Apple Silicon, conservative hosts can still resolve to a single solver
+thread by default, while higher-performance Macs fan out more aggressively.
+This section lists the operationally relevant ones for the Metal backend; for
 the complete inventory, search the source tree for `getenv("BTX_MATMUL_`.
 CUDA-specific tuning knobs are documented separately.
 
-After setting any variable, restart `btxd`. The startup log line
+After setting any variable, restart `btxd`. To inspect how the current tree
+would resolve a backend request, use:
 
+```bash
+btx-matmul-backend-info --backend metal
 ```
-MatMul accelerator: requested=<input> active=<backend> reason=<...>
-```
-
-confirms the resolved backend on each start.
 
 ### Backend selection
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `BTX_MATMUL_BACKEND` | Select accelerator backend: `cpu`, `metal`, or `cuda`. | Platform default: `metal` on Apple, `cpu` elsewhere. |
+| `BTX_MATMUL_BACKEND` | Select accelerator backend: `cpu`, `metal`, `mlx`, or `cuda`. (`mlx` is an alias for `metal`.) | Platform default: `metal` on Apple, `cpu` elsewhere. |
 
 ### Mining throughput (`SolveMatMul`)
 
 These govern how many in-flight matmul solves the daemon runs in parallel
-during `generatetoaddress` / `getblocktemplate` mining. **The default of 1
-solver thread is conservative.** Operators with capable hardware should raise
-it to take advantage of available CPU and GPU resources.
+during `generatetoaddress` / `getblocktemplate` mining. On current `main`,
+the active Metal policy auto-tunes several of these when unset instead of
+using fixed constants.
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `BTX_MATMUL_SOLVER_THREADS` | Number of parallel solver threads inside a single `SolveMatMul` call. Triggers the `SolveMatMulParallel` path in `src/pow.cpp` when `> 1`. | `1` (single-threaded). |
-| `BTX_MATMUL_PREPARE_WORKERS` | Number of workers that prepare next-window inputs ahead of the solve. | Auto-derived from `SOLVER_THREADS`. |
+| `BTX_MATMUL_SOLVER_THREADS` | Number of parallel solver threads inside a single `SolveMatMul` call. Triggers the `SolveMatMulParallel` path in `src/pow.cpp` when `> 1`. | Auto-tuned by backend/host heuristics when unset. |
+| `BTX_MATMUL_PREPARE_WORKERS` | Number of workers that prepare next-window inputs ahead of the solve. | Auto-tuned from host/backend heuristics when unset. |
 | `BTX_MATMUL_PREPARE_PREFETCH_DEPTH` | How many windows ahead the prepare workers stage. Trades memory for steady-state throughput. | Backend-specific; usually small single digits. |
 | `BTX_MATMUL_SOLVE_BATCH_SIZE` | Batch size submitted to the accelerated solver per call. | Backend-specific. |
-| `BTX_MATMUL_PIPELINE_ASYNC` | Set to `1` to enable asynchronous pipelining of prepare and solve stages. | Off. |
+| `BTX_MATMUL_PIPELINE_ASYNC` | Set to `1` to enable asynchronous pipelining of prepare and solve stages. | On for Metal when unset. |
 
 A reasonable starting point on an Apple Silicon workstation with the Metal
 backend active:
@@ -118,7 +118,7 @@ btxd -daemon
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `BTX_MATMUL_METAL_POOL_SLOTS` | Number of Metal command-buffer slots in the in-flight pool. Increase to overlap more solves on the GPU; decrease to cap GPU memory pressure. | `5` |
+| `BTX_MATMUL_METAL_POOL_SLOTS` | Number of Metal command-buffer slots in the in-flight pool. Increase to overlap more solves on the GPU; decrease to cap GPU memory pressure. | Auto-tuned from solver-thread / Apple perf-level heuristics when unset. |
 | `BTX_MATMUL_METAL_PIPELINE` | Pipeline mode for Metal solves. | Backend-default. |
 | `BTX_MATMUL_METAL_FUNCTION_CONSTANTS` | Metal function-constant overrides for kernel tuning. | Backend-default. |
 | `BTX_MATMUL_GPU_INPUTS` | Set to `1` to generate matmul inputs on the GPU instead of the CPU before the solve. Saves a CPU↔GPU copy at the cost of additional GPU compute. | Backend-decided. |

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -64,6 +64,82 @@ If CUDA runtime probing succeeds, the output will report:
 For current CUDA runtime defaults, pool behavior, and optimization notes, see
 `btx-cuda-matmul-optimization-notes-2026-04-13.md`.
 
+## Tuning the Metal MatMul accelerator (`BTX_MATMUL_*` environment variables)
+
+On Apple Silicon, the MatMul mining and verification backend is tuned by
+environment variables rather than `btxd` command-line flags. They are read
+directly inside `src/matmul/`, `src/metal/`, and `src/pow.cpp`; none appear
+in `btxd -?`. Defaults work for most operators, but in practice a fresh
+install on a capable Mac (M1/M2/M3-class) can sit at 1 solver thread (the
+default) and look puzzlingly slow until one of these variables is set. This
+section lists the operationally relevant ones for the Metal backend; for
+the complete inventory, search the source tree for `getenv("BTX_MATMUL_`.
+CUDA-specific tuning knobs are documented separately.
+
+After setting any variable, restart `btxd`. The startup log line
+
+```
+MatMul accelerator: requested=<input> active=<backend> reason=<...>
+```
+
+confirms the resolved backend on each start.
+
+### Backend selection
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BTX_MATMUL_BACKEND` | Select accelerator backend: `cpu`, `metal`, or `cuda`. | Platform default: `metal` on Apple, `cpu` elsewhere. |
+
+### Mining throughput (`SolveMatMul`)
+
+These govern how many in-flight matmul solves the daemon runs in parallel
+during `generatetoaddress` / `getblocktemplate` mining. **The default of 1
+solver thread is conservative.** Operators with capable hardware should raise
+it to take advantage of available CPU and GPU resources.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BTX_MATMUL_SOLVER_THREADS` | Number of parallel solver threads inside a single `SolveMatMul` call. Triggers the `SolveMatMulParallel` path in `src/pow.cpp` when `> 1`. | `1` (single-threaded). |
+| `BTX_MATMUL_PREPARE_WORKERS` | Number of workers that prepare next-window inputs ahead of the solve. | Auto-derived from `SOLVER_THREADS`. |
+| `BTX_MATMUL_PREPARE_PREFETCH_DEPTH` | How many windows ahead the prepare workers stage. Trades memory for steady-state throughput. | Backend-specific; usually small single digits. |
+| `BTX_MATMUL_SOLVE_BATCH_SIZE` | Batch size submitted to the accelerated solver per call. | Backend-specific. |
+| `BTX_MATMUL_PIPELINE_ASYNC` | Set to `1` to enable asynchronous pipelining of prepare and solve stages. | Off. |
+
+A reasonable starting point on an Apple Silicon workstation with the Metal
+backend active:
+
+```bash
+export BTX_MATMUL_SOLVER_THREADS=8
+export BTX_MATMUL_PIPELINE_ASYNC=1
+btxd -daemon
+```
+
+### Metal-specific knobs (Apple Silicon)
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BTX_MATMUL_METAL_POOL_SLOTS` | Number of Metal command-buffer slots in the in-flight pool. Increase to overlap more solves on the GPU; decrease to cap GPU memory pressure. | `5` |
+| `BTX_MATMUL_METAL_PIPELINE` | Pipeline mode for Metal solves. | Backend-default. |
+| `BTX_MATMUL_METAL_FUNCTION_CONSTANTS` | Metal function-constant overrides for kernel tuning. | Backend-default. |
+| `BTX_MATMUL_GPU_INPUTS` | Set to `1` to generate matmul inputs on the GPU instead of the CPU before the solve. Saves a CPU↔GPU copy at the cost of additional GPU compute. | Backend-decided. |
+| `BTX_MATMUL_APPLE_PERFLEVEL0_LOGICALCPU_OVERRIDE` | Override Apple Silicon perf-level-0 logical CPU count used in launch-rate tuning heuristics. Useful for benchmarking on machines whose reported perf-level partitions differ from the host's actual sustained-throughput core count. | Auto-detected. |
+
+### Diagnostic / experimental (off by default)
+
+Safe to leave unset. Useful when investigating a regression or comparing
+backends.
+
+| Variable | Purpose |
+|---|---|
+| `BTX_MATMUL_MEM_DIAG` | Logs per-solve memory and backend stats to `debug.log`. Verbose. |
+| `BTX_MATMUL_DIAG_COMPARE_CPU_METAL` | Cross-checks Metal results against a CPU recompute. Adds latency; useful for backend-correctness investigation. |
+| `BTX_MATMUL_CPU_CONFIRM` | Confirms an accelerated solve with a CPU recompute. |
+| `BTX_MATMUL_AMX_EXPERIMENT` | Apple AMX experimental matrix path (off by default; opt-in for benchmarking). |
+| `BTX_MATMUL_BLOCKED_MULTIPLY_THREADS` | Threads for the blocked CPU matmul fallback. |
+| `BTX_MATMUL_NOISE_PARALLEL` | Parallelism in the noise-generation stage. |
+| `BTX_MATMUL_DIGEST_SLICE_SIZE` | Slice size for digest construction. |
+| `BTX_MATMUL_TIP_WATCHER` | Tip-watcher behaviour during long solves. |
+
 ## Initial Block Download
 
 A new BTX node syncs the chain from peers via standard initial block download


### PR DESCRIPTION
This is a doc-only PR. It adds a new section to `doc/build-unix.md` cataloguing the operationally-relevant `BTX_MATMUL_*` environment variables for the **Metal MatMul backend on Apple Silicon**.

## Why

The MatMul mining and verification backend on Apple Silicon is configured by env vars rather than `btxd` command-line flags. None appear in `btxd -?`, which means a fresh install on a capable Mac (M1/M2/M3-class) can sit at 1 solver thread (the default) and look puzzlingly slow until an operator finds the right env var to set. This PR makes the operator's first hour easier.

## What's covered

- Backend selection (`BTX_MATMUL_BACKEND`)
- Mining throughput knobs that apply on Apple Silicon (`SOLVER_THREADS`, `PREPARE_WORKERS`, `PREPARE_PREFETCH_DEPTH`, `SOLVE_BATCH_SIZE`, `PIPELINE_ASYNC`)
- Metal-specific knobs (`METAL_POOL_SLOTS`, `METAL_PIPELINE`, `METAL_FUNCTION_CONSTANTS`, `GPU_INPUTS`, `APPLE_PERFLEVEL0_LOGICALCPU_OVERRIDE`)
- Diagnostic / experimental knobs relevant to Metal investigation (`MEM_DIAG`, `DIAG_COMPARE_CPU_METAL`, `CPU_CONFIRM`, `AMX_EXPERIMENT`, `BLOCKED_MULTIPLY_THREADS`, `NOISE_PARALLEL`, `DIGEST_SLICE_SIZE`, `TIP_WATCHER`)
- A "reasonable starting point" `export` block — `SOLVER_THREADS=8`, `PIPELINE_ASYNC=1` — for an Apple Silicon workstation, so an operator who follows this doc end-to-end isn't left at single-threaded defaults.
- Reference to the new `MatMul accelerator: requested=... active=... reason=...` startup log line as the canonical place to verify the resolved backend.

## Out of scope (intentional)

- **CUDA-specific tuning knobs** (`BTX_MATMUL_CUDA_DEVICE_PREPARED_INPUTS`, `BTX_MATMUL_CUDA_POOL_SLOTS`) are intentionally split into their own doc PR so this PR stays focused on Apple-Silicon operators and CUDA miners get a clean dedicated doc PR rather than getting orphaned in a Metal-focused section.
- Promoting any `BTX_MATMUL_*` env var to a proper `-matmul*` argsman flag — that's a feature change and deliberately deferred.
- Cross-validating defaults against the source — values come from current source reads; if any default has drifted, happy to take a follow-up.

## Notes

- No code changes; doc-only.
- Force-pushed once: this PR was previously titled "docs(build): document BTX_MATMUL_* environment variables for tuning" and covered both Metal and CUDA. The CUDA section moved to a separate PR to keep both narratives focused.
