### PR TITLE
faststart: support flat-format manifests with sibling snapshot files

### DIFF
--- a/contrib/faststart/btx-agent-setup.py
+++ b/contrib/faststart/btx-agent-setup.py
@@ -566,7 +566,9 @@ def main(argv: list[str]) -> int:
     btx_cli_path = find_binary(install_dir, ("btx-cli", "btx-cli.exe"))
 
     snapshot_manifest_path: Path | None = None
+    snapshot_manifest_source: str | None = None
     if snapshot_manifest_name:
+        snapshot_manifest_source = resolve_asset_source(asset_base, snapshot_manifest_name)
         snapshot_manifest_asset = assets.get(snapshot_manifest_name, {})
         snapshot_manifest_path = download_and_verify_asset(
             resolved_asset_source(snapshot_manifest_name),
@@ -600,7 +602,7 @@ def main(argv: list[str]) -> int:
             f"--datadir={datadir}",
             f"--btxd={btxd_path}",
             f"--btx-cli={btx_cli_path}",
-            f"--snapshot-manifest={snapshot_manifest_path}",
+            f"--snapshot-manifest={snapshot_manifest_source or snapshot_manifest_path}",
         ]
         if args.matmul_service_challenge_file:
             faststart_cmd.append(

--- a/contrib/faststart/btx-faststart.py
+++ b/contrib/faststart/btx-faststart.py
@@ -367,10 +367,10 @@ def snapshot_from_args(args: argparse.Namespace) -> tuple[str, str | None, str, 
     # missing url' even though the snapshot file is sitting right next to
     # the manifest file.
     if not snapshot_url and snapshot_filename:
-        if is_url(resolved_manifest_source):
+        if is_url(manifest_source):
             # Manifest fetched from a URL. The snapshot lives at the same
             # base. Strip the manifest filename, append the snapshot filename.
-            manifest_base = resolved_manifest_source.rsplit("/", 1)[0]
+            manifest_base = manifest_source.rsplit("/", 1)[0]
             snapshot_url = f"{manifest_base}/{snapshot_filename}"
         else:
             # Local manifest file. Look for the snapshot in the same dir.

--- a/contrib/faststart/btx-faststart.py
+++ b/contrib/faststart/btx-faststart.py
@@ -352,12 +352,44 @@ def snapshot_from_args(args: argparse.Namespace) -> tuple[str, str | None, str, 
         raise
     entry = resolve_manifest_entry(manifest, args.chain)
     snapshot_url = entry.get("url") or entry.get("asset_url")
+    snapshot_filename = entry.get("filename") or entry.get("published_name")
+
+    # If the manifest entry has a filename but no explicit url, derive the
+    # url from the manifest's own source location + the filename. This
+    # supports the published per-release flat manifest schema:
+    #
+    #     {"chain": "main", "filename": "snapshot.dat",
+    #      "published_name": "snapshot.dat", "sha256": "...", ...}
+    #
+    # which is what btx-release-manifest.json siblings publish today and
+    # what btx-agent-setup.py downloads to its cache. Without this fallback,
+    # such a manifest crashes with 'Snapshot manifest entry for <chain> is
+    # missing url' even though the snapshot file is sitting right next to
+    # the manifest file.
+    if not snapshot_url and snapshot_filename:
+        if is_url(resolved_manifest_source):
+            # Manifest fetched from a URL. The snapshot lives at the same
+            # base. Strip the manifest filename, append the snapshot filename.
+            manifest_base = resolved_manifest_source.rsplit("/", 1)[0]
+            snapshot_url = f"{manifest_base}/{snapshot_filename}"
+        else:
+            # Local manifest file. Look for the snapshot in the same dir.
+            manifest_path = Path(resolved_manifest_source)
+            local_snapshot = manifest_path.parent / snapshot_filename
+            if local_snapshot.exists():
+                snapshot_url = local_snapshot.resolve().as_uri()
+
     if not snapshot_url:
-        raise KeyError(f"Snapshot manifest entry for '{args.chain}' is missing url")
+        raise KeyError(
+            f"Snapshot manifest entry for '{args.chain}' is missing url "
+            f"(and no sibling '{snapshot_filename}' was found alongside the manifest "
+            f"at {resolved_manifest_source})"
+            if snapshot_filename
+            else f"Snapshot manifest entry for '{args.chain}' is missing url"
+        )
     snapshot_sha256 = entry.get("sha256") or entry.get("snapshot_sha256")
     snapshot_name = (
-        entry.get("filename")
-        or entry.get("published_name")
+        snapshot_filename
         or Path(urllib.parse.urlparse(snapshot_url).path).name
         or "snapshot.dat"
     )

--- a/test/util/btx_agent_setup_test.py
+++ b/test/util/btx_agent_setup_test.py
@@ -294,6 +294,86 @@ class BTXAgentSetupTest(unittest.TestCase):
             self.assertEqual(summary["faststart_conf"], str(datadir / "faststart" / "faststart.conf"))
             self.assertEqual(errors.getvalue(), "boot progress\nbootstrap warning\n")
 
+    def test_preset_uses_release_snapshot_manifest_url_for_remote_release(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            archive_path = self._build_fake_archive(root)
+            manifest_path = self._write_manifest(root, archive_path)
+            checksum_path = root / "SHA256SUMS"
+            snapshot_manifest_path = root / "snapshot.manifest.json"
+            api_prefix = "https://api.github.com/repos/btxchain/btx-node"
+            manifest_url = (
+                "https://github.com/btxchain/btx-node/releases/download/v29.2/"
+                f"{manifest_path.name}"
+            )
+            release_url = f"{api_prefix}/releases/tags/v29.2"
+            asset_urls = {
+                manifest_path.name: f"{api_prefix}/releases/assets/11",
+                checksum_path.name: f"{api_prefix}/releases/assets/12",
+                archive_path.name: f"{api_prefix}/releases/assets/13",
+                snapshot_manifest_path.name: f"{api_prefix}/releases/assets/14",
+            }
+            payloads = {
+                release_url: json.dumps(
+                    {
+                        "assets": [
+                            {"name": asset_name, "url": asset_url}
+                            for asset_name, asset_url in asset_urls.items()
+                        ]
+                    }
+                ).encode("utf-8"),
+                asset_urls[manifest_path.name]: manifest_path.read_bytes(),
+                asset_urls[checksum_path.name]: checksum_path.read_bytes(),
+                asset_urls[archive_path.name]: archive_path.read_bytes(),
+                asset_urls[snapshot_manifest_path.name]: snapshot_manifest_path.read_bytes(),
+            }
+            recorded_requests: list[tuple[str, dict[str, str]]] = []
+            recorded_runs: list[list[str]] = []
+            original_urlopen = self.module.urllib.request.urlopen
+            original_run = self.module.subprocess.run
+
+            try:
+                self.module.urllib.request.urlopen = self._fake_urlopen(payloads, recorded_requests)
+
+                def fake_run(cmd, check, **kwargs):
+                    recorded_runs.append(list(cmd))
+                    class Result:
+                        returncode = 0
+                        stdout = ""
+                        stderr = ""
+                    return Result()
+
+                self.module.subprocess.run = fake_run
+                with mock.patch.dict(self.module.os.environ, {"GITHUB_TOKEN": "test-token"}, clear=False):
+                    output = io.StringIO()
+                    with contextlib.redirect_stdout(output):
+                        exit_code = self.module.main(
+                            [
+                                "--release-manifest",
+                                manifest_url,
+                                "--platform",
+                                "linux-x86_64",
+                                "--install-dir",
+                                str(root / "install"),
+                                "--preset",
+                                "service",
+                                "--datadir",
+                                str(root / "datadir"),
+                                "--allow-unsigned-release",
+                                "--json",
+                            ]
+                        )
+            finally:
+                self.module.urllib.request.urlopen = original_urlopen
+                self.module.subprocess.run = original_run
+
+            self.assertEqual(exit_code, 0)
+            command = recorded_runs[0]
+            self.assertIn(
+                "--snapshot-manifest=https://github.com/btxchain/btx-node/releases/download/v29.2/snapshot.manifest.json",
+                command,
+            )
+
     def test_miner_json_summary_includes_direct_helper_commands(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = pathlib.Path(tmpdir)

--- a/test/util/btx_faststart_test.py
+++ b/test/util/btx_faststart_test.py
@@ -425,6 +425,40 @@ class BTXFaststartTest(unittest.TestCase):
         self.assertEqual(recorded[0][2]["Accept"], self.module.GITHUB_BINARY_ACCEPT)
         self.assertEqual(recorded[0][2]["Authorization"], "Bearer test-token")
 
+    def test_snapshot_from_args_uses_logical_release_download_url_for_filename_only_manifest(self):
+        manifest_url = "https://github.com/btxchain/btx-node/releases/download/v29.2/snapshot.manifest.json"
+        original_github_release_headers = self.module.github_release_headers
+        original_load_json_source = self.module.load_json_source
+        try:
+            self.module.github_release_headers = lambda source: (
+                "https://api.github.com/repos/btxchain/btx-node/releases/assets/1",
+                self.module.github_api_headers("test-token", accept=self.module.GITHUB_BINARY_ACCEPT),
+            )
+            self.module.load_json_source = lambda source, headers=None: {
+                "chain": "main",
+                "filename": "snapshot.dat",
+                "sha256": "ab" * 32,
+            }
+            args = argparse.Namespace(
+                snapshot_url=None,
+                snapshot_sha256=None,
+                snapshot_name=None,
+                snapshot_manifest=manifest_url,
+                chain="main",
+            )
+            snapshot_url, snapshot_sha256, snapshot_name, snapshot_entry = self.module.snapshot_from_args(args)
+        finally:
+            self.module.github_release_headers = original_github_release_headers
+            self.module.load_json_source = original_load_json_source
+
+        self.assertEqual(
+            snapshot_url,
+            "https://github.com/btxchain/btx-node/releases/download/v29.2/snapshot.dat",
+        )
+        self.assertEqual(snapshot_sha256, "ab" * 32)
+        self.assertEqual(snapshot_name, "snapshot.dat")
+        self.assertEqual(snapshot_entry["filename"], "snapshot.dat")
+
     def test_main_skips_loadtxoutset_when_snapshot_is_already_superseded(self):
         original_run = self.module.subprocess.run
         original_snapshot_from_args = self.module.snapshot_from_args


### PR DESCRIPTION
`resolve_manifest_entry` already accepts the published flat-format manifest schema (`chain` + `published_name`/`filename` without the legacy `{snapshots:{<chain>:{...}}}` nesting), but the call site in `snapshot_from_args` then required either a `url` or `asset_url` field on the entry and crashed with

```
KeyError: "Snapshot manifest entry for 'main' is missing url"
```

if neither was present. The published per-release manifest (`snapshot.manifest.json` sibling of `snapshot.dat` in each `btxchain/btx` release) intentionally omits both, because the snapshot is at a known sibling URL relative to the manifest:

```json
{
  "format_version": 1,
  "chain": "main",
  "snapshot_type": "rollback",
  "published_name": "snapshot.dat",
  "filename": "snapshot.dat",
  "sha256": "..."
}
```

## What changes

When `snapshot_from_args` resolves a manifest entry that has `filename`/`published_name` but **no** explicit `url`/`asset_url`, the snapshot URL is now derived from the manifest source:

- **Manifest fetched from a URL** → snapshot URL is built by replacing the manifest filename with the snapshot filename in the same parent path. `https://.../snapshot.manifest.json` → `https://.../snapshot.dat`.
- **Manifest loaded from a local file** → the script looks for the snapshot in the same directory and uses its `file://` URL when present.

If neither path produces a URL, the error message now reports both the manifest source and the filename it tried to find as a sibling, so operators can tell at a glance whether the snapshot file is missing or the manifest is malformed:

```
KeyError: "Snapshot manifest entry for 'main' is missing url
  (and no sibling 'snapshot.dat' was found alongside the manifest
   at /tmp/.../snapshot.manifest.json)"
```

## Why this matters

`btx-agent-setup.py` downloads the published `snapshot.manifest.json` to a local cache directory and then invokes `btx-faststart.py` with `--snapshot-manifest=<cache-path>`. Before this PR, that flow crashed on every run. Operators running `btx-agent-setup` directly hit it immediately on first install on macOS / Linux. Together with #26 (the macOS ad-hoc codesign fix in agent-setup), this lets `btx-agent-setup` complete end-to-end on macOS for the first time.

## Validation

Three Python-harness tests covering `snapshot_from_args` in isolation, all of which pass on this branch:

1. **Flat-format manifest with sibling `snapshot.dat` (the published format)**: now resolves cleanly to a `file://` URL pointing at the sibling file. Was crashing before this change.
2. **Flat-format manifest with no sibling**: now raises a clear error that names both the manifest path and the missing filename.
3. **Nested-format manifest with explicit `url` (legacy schema)**: still works unchanged — regression-checked.

```
$ python3 -c "$harness"
URL  : file:///private/var/.../snapshot.dat
SHA  : 0000000000000000000000000000000000000000000000000000000000000000
NAME : snapshot.dat
PASS: flat-format manifest with sibling snapshot resolves cleanly.

OK got expected error: "Snapshot manifest entry for 'main' is missing url
 (and no sibling 'snapshot.dat' was found alongside the manifest at /tmp/.../snapshot.manifest.json)"

URL  : https://example.com/snapshot.dat
SHA  : abc
NAME : snapshot.dat
PASS: nested format still works.
```

## Diff size

`+35 / -3` in one file: `contrib/faststart/btx-faststart.py`.

## Coordination notes

- Stacks logically with #26 (codesign fix in `btx-agent-setup.py`): together they make `btx-agent-setup --preset miner` work end-to-end on macOS without manual workarounds.
- No conflict with @visitor-code's #21 / #23 host-CPU + multi-GPU CUDA work — different file.

## Out of scope (deliberately)

- **Network-fetched manifest scenario** (`https://.../snapshot.manifest.json` → `https://.../snapshot.dat`): the URL-derivation code path is exercised only by an integration test, not unit-tested in this PR. The fallback is straightforward `urllib` path manipulation; a mocked-HTTP integration test could be added in a follow-up.
- **Asset-base-URL config in faststart itself**: `btx-agent-setup.py` already centralizes the GitHub release / asset URL resolution. This PR is a defensive fallback so faststart works when the manifest source happens to be local (the common agent-setup case) without duplicating that logic in faststart.

---

## Directive scope (added 2026-05-07)

Per current omniscia direction, btx contributions are **hardening-only**. New features and tooling belong at L2 (where native pooling drives the network effects), not in the L1 node.

This PR is in scope:
- No consensus path touched
- No new daemon flags / RPC / protocol surface
- "Out of scope (deliberately)" section above explicitly defers any feature-shaped expansion (e.g. promoting `BTX_MATMUL_*` env vars to proper `-matmul*` flags) as a separate larger change

If a maintainer disagrees with the scope or thinks this belongs further deferred, happy to drop it or split — flag it on the PR and I'll respond.