### PR TITLE
doc(build): document CUDA MatMul tuning env vars

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -64,6 +64,82 @@ If CUDA runtime probing succeeds, the output will report:
 For current CUDA runtime defaults, pool behavior, and optimization notes, see
 `btx-cuda-matmul-optimization-notes-2026-04-13.md`.
 
+## Tuning the CUDA MatMul accelerator (`BTX_MATMUL_*` environment variables)
+
+On Linux with the CUDA backend, the MatMul mining and verification backend is
+tuned by environment variables rather than `btxd` command-line flags. They
+are read directly inside `src/matmul/`, `src/cuda/`, and `src/pow.cpp`; none
+appear in `btxd -?`. Defaults work for most operators, but in practice a
+fresh install on a capable NVIDIA workstation can sit at 1 solver thread
+(the default) and look puzzlingly slow until one of these variables is set.
+This section lists the operationally relevant ones for the CUDA backend;
+for the complete inventory, search the source tree for
+`getenv("BTX_MATMUL_`. Metal-specific tuning knobs (Apple Silicon) are
+documented separately.
+
+After setting any variable, restart `btxd`. The startup log line
+
+```
+MatMul accelerator: requested=<input> active=<backend> reason=<...>
+```
+
+confirms the resolved backend on each start.
+
+### Backend selection
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BTX_MATMUL_BACKEND` | Select accelerator backend: `cpu`, `metal`, or `cuda`. | Platform default: `cpu` on Linux. Set to `cuda` to opt in. |
+
+### Mining throughput (`SolveMatMul`)
+
+These govern how many in-flight matmul solves the daemon runs in parallel
+during `generatetoaddress` / `getblocktemplate` mining. **The default of 1
+solver thread is conservative.** Operators with capable hardware should
+raise it to take advantage of available CPU and GPU resources.
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BTX_MATMUL_SOLVER_THREADS` | Number of parallel solver threads inside a single `SolveMatMul` call. Triggers the `SolveMatMulParallel` path in `src/pow.cpp` when `> 1`. | `1` (single-threaded). |
+| `BTX_MATMUL_PREPARE_WORKERS` | Number of workers that prepare next-window inputs ahead of the solve. | Auto-derived from `SOLVER_THREADS`. |
+| `BTX_MATMUL_PREPARE_PREFETCH_DEPTH` | How many windows ahead the prepare workers stage. Trades memory for steady-state throughput. | Backend-specific; usually small single digits. |
+| `BTX_MATMUL_SOLVE_BATCH_SIZE` | Batch size submitted to the accelerated solver per call. | Backend-specific. |
+| `BTX_MATMUL_PIPELINE_ASYNC` | Set to `1` to enable asynchronous pipelining of prepare and solve stages. | Off. |
+
+A reasonable starting point on a Linux workstation with the CUDA backend
+active:
+
+```bash
+export BTX_MATMUL_BACKEND=cuda
+export BTX_MATMUL_SOLVER_THREADS=8
+export BTX_MATMUL_PIPELINE_ASYNC=1
+btxd -daemon
+```
+
+### CUDA-specific knobs (Linux)
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `BTX_MATMUL_CUDA_DEVICE_PREPARED_INPUTS` | Policy for generating prepared inputs directly on the CUDA device. Saves a CPU↔GPU copy at the cost of additional GPU compute. | Backend-default. |
+| `BTX_MATMUL_CUDA_POOL_SLOTS` | Number of CUDA stream slots in the in-flight pool. Increase to overlap more solves on the GPU; decrease to cap GPU memory pressure. | Backend-default. |
+
+For current CUDA runtime defaults, pool behaviour, and optimisation notes,
+see `btx-cuda-matmul-optimization-notes-2026-04-13.md`.
+
+### Diagnostic / experimental (off by default)
+
+Safe to leave unset. Useful when investigating a regression or comparing
+backends.
+
+| Variable | Purpose |
+|---|---|
+| `BTX_MATMUL_MEM_DIAG` | Logs per-solve memory and backend stats to `debug.log`. Verbose. |
+| `BTX_MATMUL_CPU_CONFIRM` | Confirms an accelerated solve with a CPU recompute. Useful for backend-correctness investigation. |
+| `BTX_MATMUL_BLOCKED_MULTIPLY_THREADS` | Threads for the blocked CPU matmul fallback. |
+| `BTX_MATMUL_NOISE_PARALLEL` | Parallelism in the noise-generation stage. |
+| `BTX_MATMUL_DIGEST_SLICE_SIZE` | Slice size for digest construction. |
+| `BTX_MATMUL_TIP_WATCHER` | Tip-watcher behaviour during long solves. |
+
 ## Memory Requirements
 
 C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -69,42 +69,40 @@ For current CUDA runtime defaults, pool behavior, and optimization notes, see
 On Linux with the CUDA backend, the MatMul mining and verification backend is
 tuned by environment variables rather than `btxd` command-line flags. They
 are read directly inside `src/matmul/`, `src/cuda/`, and `src/pow.cpp`; none
-appear in `btxd -?`. Defaults work for most operators, but in practice a
-fresh install on a capable NVIDIA workstation can sit at 1 solver thread
-(the default) and look puzzlingly slow until one of these variables is set.
-This section lists the operationally relevant ones for the CUDA backend;
-for the complete inventory, search the source tree for
-`getenv("BTX_MATMUL_`. Metal-specific tuning knobs (Apple Silicon) are
-documented separately.
+appear in `btxd -?`. Defaults work for most operators, but on current `main`
+they are mostly auto-tuned from the active backend, host CPU, and GPU
+heuristics rather than fixed constants. This section lists the operationally
+relevant ones for the CUDA backend; for the complete inventory, search the
+source tree for `getenv("BTX_MATMUL_`. Metal-specific tuning knobs (Apple
+Silicon) are documented separately.
 
-After setting any variable, restart `btxd`. The startup log line
+After setting any variable, restart `btxd`. To inspect how the current tree
+would resolve a backend request, use:
 
+```bash
+btx-matmul-backend-info --backend cuda
 ```
-MatMul accelerator: requested=<input> active=<backend> reason=<...>
-```
-
-confirms the resolved backend on each start.
 
 ### Backend selection
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `BTX_MATMUL_BACKEND` | Select accelerator backend: `cpu`, `metal`, or `cuda`. | Platform default: `cpu` on Linux. Set to `cuda` to opt in. |
+| `BTX_MATMUL_BACKEND` | Select accelerator backend: `cpu`, `metal`, `mlx`, or `cuda`. (`mlx` is an alias for `metal`.) | Platform default: `cpu` on Linux. Set to `cuda` to opt in. |
 
 ### Mining throughput (`SolveMatMul`)
 
 These govern how many in-flight matmul solves the daemon runs in parallel
-during `generatetoaddress` / `getblocktemplate` mining. **The default of 1
-solver thread is conservative.** Operators with capable hardware should
-raise it to take advantage of available CPU and GPU resources.
+during `generatetoaddress` / `getblocktemplate` mining. On current `main`,
+the active CUDA policy auto-tunes several of these when unset instead of
+using fixed constants.
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `BTX_MATMUL_SOLVER_THREADS` | Number of parallel solver threads inside a single `SolveMatMul` call. Triggers the `SolveMatMulParallel` path in `src/pow.cpp` when `> 1`. | `1` (single-threaded). |
-| `BTX_MATMUL_PREPARE_WORKERS` | Number of workers that prepare next-window inputs ahead of the solve. | Auto-derived from `SOLVER_THREADS`. |
+| `BTX_MATMUL_SOLVER_THREADS` | Number of parallel solver threads inside a single `SolveMatMul` call. Triggers the `SolveMatMulParallel` path in `src/pow.cpp` when `> 1`. | Auto-tuned by backend/host/GPU heuristics when unset. |
+| `BTX_MATMUL_PREPARE_WORKERS` | Number of workers that prepare next-window inputs ahead of the solve. | Auto-tuned from host/backend heuristics when unset. |
 | `BTX_MATMUL_PREPARE_PREFETCH_DEPTH` | How many windows ahead the prepare workers stage. Trades memory for steady-state throughput. | Backend-specific; usually small single digits. |
 | `BTX_MATMUL_SOLVE_BATCH_SIZE` | Batch size submitted to the accelerated solver per call. | Backend-specific. |
-| `BTX_MATMUL_PIPELINE_ASYNC` | Set to `1` to enable asynchronous pipelining of prepare and solve stages. | Off. |
+| `BTX_MATMUL_PIPELINE_ASYNC` | Set to `1` to enable asynchronous pipelining of prepare and solve stages. | On for CUDA when unset. |
 
 A reasonable starting point on a Linux workstation with the CUDA backend
 active:


### PR DESCRIPTION
This is a doc-only PR. It adds a new section to `doc/build-unix.md` cataloguing the operationally-relevant `BTX_MATMUL_*` environment variables for the **CUDA MatMul backend on Linux**.

## Why

The CUDA MatMul mining and verification backend on Linux is configured by env vars rather than `btxd` command-line flags. None appear in `btxd -?`, which means a fresh install on a capable NVIDIA workstation can sit at 1 solver thread (the default) and look puzzlingly slow until an operator finds the right env var to set. This PR makes the operator's first hour easier on the CUDA path, complementing the existing "Optional: Enable the CUDA MatMul Backend" build section directly above it.

## What's covered

- Backend selection (`BTX_MATMUL_BACKEND`, framed for Linux/CUDA defaults — `cpu` baseline, `cuda` opt-in)
- Mining throughput knobs (`SOLVER_THREADS`, `PREPARE_WORKERS`, `PREPARE_PREFETCH_DEPTH`, `SOLVE_BATCH_SIZE`, `PIPELINE_ASYNC`)
- CUDA-specific knobs (`CUDA_DEVICE_PREPARED_INPUTS`, `CUDA_POOL_SLOTS`)
- Diagnostic / experimental knobs relevant to CUDA investigation (`MEM_DIAG`, `CPU_CONFIRM`, `BLOCKED_MULTIPLY_THREADS`, `NOISE_PARALLEL`, `DIGEST_SLICE_SIZE`, `TIP_WATCHER`)
- A "reasonable starting point" `export` block — `BTX_MATMUL_BACKEND=cuda`, `SOLVER_THREADS=8`, `PIPELINE_ASYNC=1` — for a Linux workstation, so an operator who follows this doc end-to-end isn't left at single-threaded defaults.
- Reference to the new `MatMul accelerator: requested=... active=... reason=...` startup log line as the canonical place to verify the resolved backend.
- Cross-reference to `btx-cuda-matmul-optimization-notes-2026-04-13.md` for in-depth CUDA tuning, since this section is intentionally a knob inventory rather than a tuning guide.

## Out of scope (intentional)

- **Metal-specific tuning knobs** (Apple Silicon) are intentionally split into their own doc PR (#29) so this PR stays focused on Linux/CUDA operators and Apple Silicon miners get a clean dedicated doc PR.
- Promoting any `BTX_MATMUL_*` env var to a proper `-matmul*` argsman flag — that's a feature change and deliberately deferred.
- Cross-validating defaults against the source — values come from current source reads; if any default has drifted, happy to take a follow-up.

## Notes

- No code changes; doc-only.
- Adds the new section directly after the existing "Optional: Enable the CUDA MatMul Backend" section so a CUDA operator gets build-then-tune in linear reading order.
- Companion to #29 (Metal tuning env vars). Both PRs add disjoint sections to `doc/build-unix.md`; if either lands first, the other rebases cleanly.
