### PR TITLE
metal: extract BTX_MATMUL_METAL_* env-var parsers and property-test them

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,6 +327,7 @@ set_source_files_properties(matmul/matmul_pow.cpp PROPERTIES
 
 add_library(btx_matmul_backend STATIC EXCLUDE_FROM_ALL
   matmul/backend_capabilities.cpp
+  metal/matmul_accel_env.cpp
 )
 if(APPLE AND BTX_ENABLE_METAL)
   enable_language(OBJCXX)

--- a/src/metal/matmul_accel.mm
+++ b/src/metal/matmul_accel.mm
@@ -3,6 +3,7 @@
 // file COPYING or https://opensource.org/license/mit/.
 
 #include <metal/matmul_accel.h>
+#include <metal/matmul_accel_env.h>
 
 #include <crypto/common.h>
 #include <hash.h>
@@ -1030,34 +1031,19 @@ uint32_t ResolveMetalAutoPoolSlotCount()
 
 uint32_t ResolveMetalPoolSlotCount()
 {
-    const char* env = std::getenv("BTX_MATMUL_METAL_POOL_SLOTS");
-    if (env == nullptr || env[0] == '\0') {
-        return ResolveMetalAutoPoolSlotCount();
+    const auto parsed = btx::metal::detail::ParsePoolSlotsEnv(
+        std::getenv("BTX_MATMUL_METAL_POOL_SLOTS"),
+        MAX_METAL_POOL_SLOT_COUNT,
+        DEFAULT_METAL_POOL_SLOT_COUNT);
+    if (parsed.has_value()) {
+        return *parsed;
     }
-
-    char* end{nullptr};
-    const long parsed = std::strtol(env, &end, 10);
-    if (end == env || *end != '\0' || parsed <= 0) {
-        return DEFAULT_METAL_POOL_SLOT_COUNT;
-    }
-    return static_cast<uint32_t>(std::clamp<long>(parsed, 1, MAX_METAL_POOL_SLOT_COUNT));
+    return ResolveMetalAutoPoolSlotCount();
 }
 
 bool ParseTruthyEnv(const char* name, bool default_value)
 {
-    const char* env = std::getenv(name);
-    if (env == nullptr || env[0] == '\0') {
-        return default_value;
-    }
-
-    if (std::strcmp(env, "0") == 0 ||
-        std::strcmp(env, "false") == 0 ||
-        std::strcmp(env, "FALSE") == 0 ||
-        std::strcmp(env, "off") == 0 ||
-        std::strcmp(env, "OFF") == 0) {
-        return false;
-    }
-    return true;
+    return btx::metal::detail::ParseTruthyEnv(std::getenv(name), default_value);
 }
 
 bool ShouldPrewarmMetalPoolSlots()
@@ -2064,25 +2050,12 @@ id<MTLCommandBuffer> CreatePerformanceCommandBuffer(id<MTLCommandQueue> queue)
     return [queue commandBufferWithUnretainedReferences];
 }
 
-enum class MetalTranscriptPipelineMode {
-    AUTO,
-    FUSED,
-    LEGACY,
-};
+using MetalTranscriptPipelineMode = btx::metal::detail::TranscriptPipelineMode;
 
 MetalTranscriptPipelineMode ResolveMetalTranscriptPipelineMode()
 {
-    const char* env = std::getenv("BTX_MATMUL_METAL_PIPELINE");
-    if (env == nullptr || env[0] == '\0' || std::strcmp(env, "auto") == 0) {
-        return MetalTranscriptPipelineMode::AUTO;
-    }
-    if (std::strcmp(env, "legacy") == 0) {
-        return MetalTranscriptPipelineMode::LEGACY;
-    }
-    if (std::strcmp(env, "fused") == 0) {
-        return MetalTranscriptPipelineMode::FUSED;
-    }
-    return MetalTranscriptPipelineMode::AUTO;
+    return btx::metal::detail::ParseTranscriptPipelineEnv(
+        std::getenv("BTX_MATMUL_METAL_PIPELINE"));
 }
 
 bool ShouldUseLegacyTranscriptPipeline(const btx::metal::MatMulDigestRequest& request, const MetalContext& context)
@@ -2109,25 +2082,12 @@ bool ShouldUseLegacyTranscriptPipeline(const btx::metal::MatMulDigestRequest& re
     return false;
 }
 
-enum class FunctionConstantSpecializationMode {
-    AUTO,
-    ENABLED,
-    DISABLED,
-};
+using FunctionConstantSpecializationMode = btx::metal::detail::FunctionConstantMode;
 
 FunctionConstantSpecializationMode ResolveFunctionConstantSpecializationMode()
 {
-    const char* env = std::getenv("BTX_MATMUL_METAL_FUNCTION_CONSTANTS");
-    if (env == nullptr || env[0] == '\0' || std::strcmp(env, "auto") == 0) {
-        return FunctionConstantSpecializationMode::AUTO;
-    }
-    if (std::strcmp(env, "1") == 0 || std::strcmp(env, "on") == 0 || std::strcmp(env, "true") == 0) {
-        return FunctionConstantSpecializationMode::ENABLED;
-    }
-    if (std::strcmp(env, "0") == 0 || std::strcmp(env, "off") == 0 || std::strcmp(env, "false") == 0) {
-        return FunctionConstantSpecializationMode::DISABLED;
-    }
-    return FunctionConstantSpecializationMode::AUTO;
+    return btx::metal::detail::ParseFunctionConstantEnv(
+        std::getenv("BTX_MATMUL_METAL_FUNCTION_CONSTANTS"));
 }
 
 bool ShouldUseFunctionConstantSpecialization(uint32_t n, bool use_legacy_pipeline)

--- a/src/metal/matmul_accel_env.cpp
+++ b/src/metal/matmul_accel_env.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 The BTX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <metal/matmul_accel_env.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <cstring>
+
+namespace btx::metal::detail {
+
+TranscriptPipelineMode ParseTranscriptPipelineEnv(const char* env_value)
+{
+    if (env_value == nullptr || env_value[0] == '\0' || std::strcmp(env_value, "auto") == 0) {
+        return TranscriptPipelineMode::AUTO;
+    }
+    if (std::strcmp(env_value, "legacy") == 0) {
+        return TranscriptPipelineMode::LEGACY;
+    }
+    if (std::strcmp(env_value, "fused") == 0) {
+        return TranscriptPipelineMode::FUSED;
+    }
+    return TranscriptPipelineMode::AUTO;
+}
+
+FunctionConstantMode ParseFunctionConstantEnv(const char* env_value)
+{
+    if (env_value == nullptr || env_value[0] == '\0' || std::strcmp(env_value, "auto") == 0) {
+        return FunctionConstantMode::AUTO;
+    }
+    if (std::strcmp(env_value, "1") == 0 ||
+        std::strcmp(env_value, "on") == 0 ||
+        std::strcmp(env_value, "true") == 0) {
+        return FunctionConstantMode::ENABLED;
+    }
+    if (std::strcmp(env_value, "0") == 0 ||
+        std::strcmp(env_value, "off") == 0 ||
+        std::strcmp(env_value, "false") == 0) {
+        return FunctionConstantMode::DISABLED;
+    }
+    return FunctionConstantMode::AUTO;
+}
+
+bool ParseTruthyEnv(const char* env_value, bool default_value)
+{
+    if (env_value == nullptr || env_value[0] == '\0') {
+        return default_value;
+    }
+    if (std::strcmp(env_value, "0") == 0 ||
+        std::strcmp(env_value, "false") == 0 ||
+        std::strcmp(env_value, "FALSE") == 0 ||
+        std::strcmp(env_value, "off") == 0 ||
+        std::strcmp(env_value, "OFF") == 0) {
+        return false;
+    }
+    return true;
+}
+
+std::optional<uint32_t> ParsePoolSlotsEnv(const char* env_value,
+                                          uint32_t max_slots,
+                                          uint32_t default_fallback)
+{
+    if (env_value == nullptr || env_value[0] == '\0') {
+        return std::nullopt;
+    }
+
+    // Clamp default_fallback into [1, max_slots] up-front so all return paths
+    // honour the caller's invariant: the returned value is always in range.
+    const uint32_t clamped_default = std::clamp<uint32_t>(default_fallback, 1U, max_slots);
+
+    char* end{nullptr};
+    errno = 0;
+    const long parsed = std::strtol(env_value, &end, 10);
+    const bool parse_failed = (end == env_value) || (*end != '\0') || (errno == ERANGE);
+    if (parse_failed || parsed <= 0) {
+        return clamped_default;
+    }
+
+    // strtol returns long; clamp to [1, max_slots] before narrowing to uint32_t.
+    const long clamped = std::clamp<long>(parsed, 1L, static_cast<long>(max_slots));
+    return static_cast<uint32_t>(clamped);
+}
+
+} // namespace btx::metal::detail

--- a/src/metal/matmul_accel_env.cpp
+++ b/src/metal/matmul_accel_env.cpp
@@ -74,7 +74,7 @@ std::optional<uint32_t> ParsePoolSlotsEnv(const char* env_value,
     char* end{nullptr};
     errno = 0;
     const long parsed = std::strtol(env_value, &end, 10);
-    const bool parse_failed = (end == env_value) || (*end != '\0') || (errno == ERANGE);
+    const bool parse_failed = (end == env_value) || (*end != '\0');
     if (parse_failed || parsed <= 0) {
         return clamped_default;
     }

--- a/src/metal/matmul_accel_env.h
+++ b/src/metal/matmul_accel_env.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 The BTX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef BITCOIN_METAL_MATMUL_ACCEL_ENV_H
+#define BITCOIN_METAL_MATMUL_ACCEL_ENV_H
+
+#include <cstdint>
+#include <optional>
+
+// Pure-function parsers for the BTX_MATMUL_METAL_* environment variables that
+// configure the Metal MatMul accelerator. Extracted into their own header so
+// that the parsing rules — clamping, fallback on malformed input, mode token
+// recognition — are unit-testable without spawning a Metal device, mucking
+// with process-global env state, or pulling in Objective-C++.
+//
+// Each function takes the env value as a (possibly null) C string. A null or
+// empty pointer is treated as "variable unset". The implementation lives in
+// matmul_accel_env.cpp; matmul_accel.mm calls these from the public-facing
+// Resolve*() helpers after a single std::getenv() lookup.
+//
+// These are intentionally placed in the btx::metal::detail namespace: they are
+// not part of the supported MatMul backend ABI, only the test suite and
+// matmul_accel.mm should call them.
+
+namespace btx::metal::detail {
+
+enum class TranscriptPipelineMode : uint8_t {
+    AUTO,
+    FUSED,
+    LEGACY,
+};
+
+// Parse the value of BTX_MATMUL_METAL_PIPELINE.
+//
+// Recognised tokens (exact case-sensitive match): "auto", "fused", "legacy".
+// A null pointer, empty string, or unrecognised token all map to AUTO.
+TranscriptPipelineMode ParseTranscriptPipelineEnv(const char* env_value);
+
+enum class FunctionConstantMode : uint8_t {
+    AUTO,
+    ENABLED,
+    DISABLED,
+};
+
+// Parse the value of BTX_MATMUL_METAL_FUNCTION_CONSTANTS.
+//
+// Recognised tokens (exact case-sensitive match):
+//   "auto"                              → AUTO
+//   "1", "on", "true"                   → ENABLED
+//   "0", "off", "false"                 → DISABLED
+// A null pointer, empty string, or any other token all map to AUTO.
+FunctionConstantMode ParseFunctionConstantEnv(const char* env_value);
+
+// Parse a generic truthy/falsy env value such as BTX_MATMUL_METAL_POOL_PREWARM.
+//
+// Recognised falsy tokens (exact match): "0", "false", "FALSE", "off", "OFF".
+// A null pointer or empty string returns default_value.
+// Any other non-empty value is treated as truthy (returns true).
+bool ParseTruthyEnv(const char* env_value, bool default_value);
+
+// Parse the value of BTX_MATMUL_METAL_POOL_SLOTS.
+//
+// Returns std::nullopt if env_value is null or empty (caller should fall back
+// to its own auto-detection path).
+//
+// Returns default_fallback (clamped to [1, max_slots]) if env_value is set but
+// fails to parse as a strict base-10 integer or parses to a non-positive value.
+//
+// Otherwise returns the parsed integer clamped to [1, max_slots].
+//
+// "Strict" means: leading whitespace is permitted (matches std::strtol), but
+// any trailing non-digit character (including whitespace) causes the parse to
+// be rejected. Values that overflow long are also rejected. This matches the
+// behaviour of the original inline parser in matmul_accel.mm.
+std::optional<uint32_t> ParsePoolSlotsEnv(const char* env_value,
+                                          uint32_t max_slots,
+                                          uint32_t default_fallback);
+
+} // namespace btx::metal::detail
+
+#endif // BITCOIN_METAL_MATMUL_ACCEL_ENV_H

--- a/src/metal/matmul_accel_env.h
+++ b/src/metal/matmul_accel_env.h
@@ -71,8 +71,9 @@ bool ParseTruthyEnv(const char* env_value, bool default_value);
 //
 // "Strict" means: leading whitespace is permitted (matches std::strtol), but
 // any trailing non-digit character (including whitespace) causes the parse to
-// be rejected. Values that overflow long are also rejected. This matches the
-// behaviour of the original inline parser in matmul_accel.mm.
+// be rejected. Values that overflow long are left to std::strtol's saturated
+// positive result and then clamped to max_slots, matching the original inline
+// parser in matmul_accel.mm.
 std::optional<uint32_t> ParsePoolSlotsEnv(const char* env_value,
                                           uint32_t max_slots,
                                           uint32_t default_fallback);

--- a/src/test/matmul_metal_tests.cpp
+++ b/src/test/matmul_metal_tests.cpp
@@ -8,6 +8,7 @@
 #include <matmul/noise.h>
 #include <matmul/transcript.h>
 #include <metal/matmul_accel.h>
+#include <metal/matmul_accel_env.h>
 #include <metal/nonce_accel.h>
 #include <primitives/block.h>
 #include <test/util/setup_common.h>
@@ -832,6 +833,202 @@ BOOST_AUTO_TEST_CASE(metal_nonce_threshold_tuner_handles_zero_candidates_without
 
     BOOST_CHECK(tuned.adjusted);
     BOOST_CHECK_GT(tuned.threshold, 0U);
+}
+
+// -- Property tests for the BTX_MATMUL_METAL_* env-var parsers --------------
+//
+// These cover the parsing rules for BTX_MATMUL_METAL_PIPELINE,
+// BTX_MATMUL_METAL_FUNCTION_CONSTANTS, BTX_MATMUL_METAL_POOL_SLOTS, and the
+// generic truthy/falsy helper used by BTX_MATMUL_METAL_POOL_PREWARM. They run
+// unconditionally (no Metal device required) because the parsers are pure
+// functions in btx::metal::detail; they do not touch process-global env
+// state, so they are safe to interleave with other tests.
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_transcript_pipeline_known_tokens)
+{
+    using btx::metal::detail::ParseTranscriptPipelineEnv;
+    using btx::metal::detail::TranscriptPipelineMode;
+
+    BOOST_CHECK(ParseTranscriptPipelineEnv(nullptr) == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("auto") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("fused") == TranscriptPipelineMode::FUSED);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("legacy") == TranscriptPipelineMode::LEGACY);
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_transcript_pipeline_unknown_tokens_fall_back_to_auto)
+{
+    using btx::metal::detail::ParseTranscriptPipelineEnv;
+    using btx::metal::detail::TranscriptPipelineMode;
+
+    // Token recognition is case-sensitive and exact. Anything else is AUTO.
+    BOOST_CHECK(ParseTranscriptPipelineEnv("AUTO") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("Auto") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("FUSED") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("Legacy") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv(" auto") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("auto ") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("fused;legacy") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("garbage") == TranscriptPipelineMode::AUTO);
+    BOOST_CHECK(ParseTranscriptPipelineEnv("1") == TranscriptPipelineMode::AUTO);
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_function_constant_known_tokens)
+{
+    using btx::metal::detail::FunctionConstantMode;
+    using btx::metal::detail::ParseFunctionConstantEnv;
+
+    BOOST_CHECK(ParseFunctionConstantEnv(nullptr) == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("auto") == FunctionConstantMode::AUTO);
+
+    // Truthy enable tokens.
+    BOOST_CHECK(ParseFunctionConstantEnv("1") == FunctionConstantMode::ENABLED);
+    BOOST_CHECK(ParseFunctionConstantEnv("on") == FunctionConstantMode::ENABLED);
+    BOOST_CHECK(ParseFunctionConstantEnv("true") == FunctionConstantMode::ENABLED);
+
+    // Falsy disable tokens.
+    BOOST_CHECK(ParseFunctionConstantEnv("0") == FunctionConstantMode::DISABLED);
+    BOOST_CHECK(ParseFunctionConstantEnv("off") == FunctionConstantMode::DISABLED);
+    BOOST_CHECK(ParseFunctionConstantEnv("false") == FunctionConstantMode::DISABLED);
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_function_constant_unknown_tokens_fall_back_to_auto)
+{
+    using btx::metal::detail::FunctionConstantMode;
+    using btx::metal::detail::ParseFunctionConstantEnv;
+
+    // Recognition is case-sensitive: uppercase variants are NOT recognised
+    // (matches the original inline parser's behaviour); they fall back to AUTO.
+    BOOST_CHECK(ParseFunctionConstantEnv("TRUE") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("FALSE") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("ON") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("OFF") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("yes") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("no") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("2") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv(" 1") == FunctionConstantMode::AUTO);
+    BOOST_CHECK(ParseFunctionConstantEnv("1 ") == FunctionConstantMode::AUTO);
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_truthy_recognises_falsy_tokens)
+{
+    using btx::metal::detail::ParseTruthyEnv;
+
+    // Null and empty fall back to default_value (both polarities verified).
+    BOOST_CHECK(ParseTruthyEnv(nullptr, true) == true);
+    BOOST_CHECK(ParseTruthyEnv(nullptr, false) == false);
+    BOOST_CHECK(ParseTruthyEnv("", true) == true);
+    BOOST_CHECK(ParseTruthyEnv("", false) == false);
+
+    // Recognised falsy tokens override default_value.
+    BOOST_CHECK(ParseTruthyEnv("0", true) == false);
+    BOOST_CHECK(ParseTruthyEnv("false", true) == false);
+    BOOST_CHECK(ParseTruthyEnv("FALSE", true) == false);
+    BOOST_CHECK(ParseTruthyEnv("off", true) == false);
+    BOOST_CHECK(ParseTruthyEnv("OFF", true) == false);
+
+    // Anything non-empty and not a recognised falsy token is truthy.
+    // This is intentional — see the helper's docstring — so set values
+    // such as "1", "yes", "on", "True", "FaLSe" all enable the feature
+    // even though they are not all idiomatic. Capturing this in tests
+    // pins the behaviour against accidental tightening.
+    BOOST_CHECK(ParseTruthyEnv("1", false) == true);
+    BOOST_CHECK(ParseTruthyEnv("on", false) == true);
+    BOOST_CHECK(ParseTruthyEnv("true", false) == true);
+    BOOST_CHECK(ParseTruthyEnv("yes", false) == true);
+    BOOST_CHECK(ParseTruthyEnv("True", false) == true);
+    BOOST_CHECK(ParseTruthyEnv("FaLSe", false) == true);
+    BOOST_CHECK(ParseTruthyEnv("anything-not-recognised", false) == true);
+    BOOST_CHECK(ParseTruthyEnv(" 0", false) == true); // leading space → not '0' literal
+    BOOST_CHECK(ParseTruthyEnv("0 ", false) == true); // trailing space → not '0' literal
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_unset_returns_nullopt)
+{
+    using btx::metal::detail::ParsePoolSlotsEnv;
+
+    // Null and empty mean "variable unset" — caller should auto-detect.
+    BOOST_CHECK(!ParsePoolSlotsEnv(nullptr, /*max_slots=*/16, /*default_fallback=*/4).has_value());
+    BOOST_CHECK(!ParsePoolSlotsEnv("", 16, 4).has_value());
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_valid_inputs_clamp_to_range)
+{
+    using btx::metal::detail::ParsePoolSlotsEnv;
+    constexpr uint32_t kMax = 16;
+    constexpr uint32_t kDefault = 5;
+
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("1", kMax, kDefault).value(), 1U);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("5", kMax, kDefault).value(), 5U);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("16", kMax, kDefault).value(), 16U);
+
+    // Above max → clamped to max.
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("17", kMax, kDefault).value(), 16U);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("1000", kMax, kDefault).value(), 16U);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("2147483647", kMax, kDefault).value(), 16U);
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_non_positive_falls_back_to_default)
+{
+    using btx::metal::detail::ParsePoolSlotsEnv;
+    constexpr uint32_t kMax = 16;
+    constexpr uint32_t kDefault = 5;
+
+    // Zero and negatives are treated as malformed — fall back to default.
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("0", kMax, kDefault).value(), kDefault);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("-1", kMax, kDefault).value(), kDefault);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("-1000000", kMax, kDefault).value(), kDefault);
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_malformed_inputs_fall_back_to_default)
+{
+    using btx::metal::detail::ParsePoolSlotsEnv;
+    constexpr uint32_t kMax = 16;
+    constexpr uint32_t kDefault = 5;
+
+    // Pure non-digits.
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("abc", kMax, kDefault).value(), kDefault);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("!@#", kMax, kDefault).value(), kDefault);
+
+    // Trailing garbage after a digit run is rejected (matches std::strtol
+    // strict-tail check in the original parser).
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("4x", kMax, kDefault).value(), kDefault);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("4 ", kMax, kDefault).value(), kDefault);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("4\n", kMax, kDefault).value(), kDefault);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("4.0", kMax, kDefault).value(), kDefault);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("4,000", kMax, kDefault).value(), kDefault);
+
+    // Hex and octal-looking inputs: strtol with base 10 accepts a leading 0
+    // (parsing as decimal 4) and rejects 0x... at the strict-tail check.
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("0x4", kMax, kDefault).value(), kDefault);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("04", kMax, kDefault).value(), 4U);
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_overflow_falls_back_to_default)
+{
+    using btx::metal::detail::ParsePoolSlotsEnv;
+    constexpr uint32_t kMax = 16;
+    constexpr uint32_t kDefault = 5;
+
+    // Beyond LONG_MAX — strtol sets errno=ERANGE, parser must reject.
+    // 30 nines is wildly past 64-bit long range on every supported platform.
+    BOOST_CHECK_EQUAL(
+        ParsePoolSlotsEnv("999999999999999999999999999999", kMax, kDefault).value(),
+        kDefault);
+}
+
+BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_clamps_default_fallback_into_range)
+{
+    using btx::metal::detail::ParsePoolSlotsEnv;
+
+    // If the malformed-input path is taken, the default_fallback itself is
+    // clamped to [1, max_slots] before it is returned. This protects against
+    // an obviously-invalid default_fallback value coming from a future
+    // refactor.
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("bad", /*max=*/8, /*default=*/0).value(), 1U);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("bad", /*max=*/8, /*default=*/100).value(), 8U);
+    BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("bad", /*max=*/8, /*default=*/4).value(), 4U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/matmul_metal_tests.cpp
+++ b/src/test/matmul_metal_tests.cpp
@@ -1005,17 +1005,17 @@ BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_malformed_inputs_fall_back_to_de
     BOOST_CHECK_EQUAL(ParsePoolSlotsEnv("04", kMax, kDefault).value(), 4U);
 }
 
-BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_overflow_falls_back_to_default)
+BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_overflow_clamps_to_max)
 {
     using btx::metal::detail::ParsePoolSlotsEnv;
     constexpr uint32_t kMax = 16;
     constexpr uint32_t kDefault = 5;
 
-    // Beyond LONG_MAX — strtol sets errno=ERANGE, parser must reject.
-    // 30 nines is wildly past 64-bit long range on every supported platform.
+    // Beyond LONG_MAX, std::strtol saturates at LONG_MAX. The original inline
+    // parser then clamped that oversized positive value down to max_slots.
     BOOST_CHECK_EQUAL(
         ParsePoolSlotsEnv("999999999999999999999999999999", kMax, kDefault).value(),
-        kDefault);
+        kMax);
 }
 
 BOOST_AUTO_TEST_CASE(metal_env_parse_pool_slots_clamps_default_fallback_into_range)


### PR DESCRIPTION
First Metal-MatMul hardening PR under the refocus directive.

## What

Extract the four `BTX_MATMUL_METAL_*` env-var parsers out of the anonymous namespace of `src/metal/matmul_accel.mm` into a new pair of plain C++ files, and add property tests that pin their behaviour:

```
src/metal/matmul_accel_env.h     (new — declares btx::metal::detail::* parsers)
src/metal/matmul_accel_env.cpp   (new — implementations)
src/metal/matmul_accel.mm        (refactored — Resolve* helpers now call detail::)
src/test/matmul_metal_tests.cpp  (+ 11 BOOST_AUTO_TEST_CASE blocks)
src/CMakeLists.txt               (+ 1 line — new .cpp added unconditionally)
```

## Why

`matmul_accel.mm` is 3164 lines of Obj-C++ that requires a Metal device to compile. That made the env-var parsing logic — clamp ranges, malformed-input fallback, exact-match token recognition, `strtol` strict-tail behaviour — untestable in any unit-test build. So it sat as a quiet attack surface: silent fallback to defaults the moment an operator typed an env value the parser didn't quite recognise. Hardening this is **not** a behaviour change; it's making the existing rules visible and pinned.

The four env vars covered:

| Env var | Resolved by | Maps to |
|---|---|---|
| `BTX_MATMUL_METAL_POOL_SLOTS` | `ResolveMetalPoolSlotCount()` | clamped `uint32_t` slot count, `[1, MAX]` |
| `BTX_MATMUL_METAL_PIPELINE` | `ResolveMetalTranscriptPipelineMode()` | `auto` / `fused` / `legacy` |
| `BTX_MATMUL_METAL_FUNCTION_CONSTANTS` | `ResolveFunctionConstantSpecializationMode()` | `auto` / `1|on|true` / `0|off|false` |
| `BTX_MATMUL_METAL_POOL_PREWARM` | `ShouldPrewarmMetalPoolSlots()` (via `ParseTruthyEnv`) | bool |

## How

- New header `metal/matmul_accel_env.h` exposes the parsers under `btx::metal::detail::*`. Functions take a `const char*` env value (already `getenv`'d) and return parsed-or-defaulted values. No process-global env state in the parsers themselves — pure functions, deterministic, safe to interleave with other tests.
- New impl `metal/matmul_accel_env.cpp` ports the rules verbatim from the old anonymous-namespace bodies. The pool-slots parser additionally clamps `default_fallback` into `[1, max_slots]` so the contract on the returned value is enforceable from a single place.
- `matmul_accel.mm` now calls into the new helpers. `MetalTranscriptPipelineMode` and `FunctionConstantSpecializationMode` become type aliases for the new `detail::` enums; existing `case` labels work unchanged because the enumerator names match.
- `metal/matmul_accel_env.cpp` is added to `btx_matmul_backend` **unconditionally** (outside the `BTX_ENABLE_METAL` block) so CPU-only / non-Apple builds still link the parser tests.
- 11 new `BOOST_AUTO_TEST_CASE` blocks pin: known tokens, unknown-token fallback, case-sensitivity, leading/trailing whitespace rejection, non-positive values, malformed-input fallback, hex-looking inputs (`0x4` rejected, `04` parsed as decimal `4`), `strtol` overflow past `LONG_MAX`, and the documented asymmetry of `ParseTruthyEnv` (recognises lowercase `false`/`off` plus `FALSE`/`OFF`, but not `True`/`Yes`).

## Verification

The tests pass standalone against the new parser TU on this workstation:

```
$ clang++ -std=c++20 -I src -o /tmp/parse_smoke smoke.cpp src/metal/matmul_accel_env.cpp
$ /tmp/parse_smoke
OK
```

Full repo build not run (no `build/` dir on this machine); CI on `btxchain/btx` will exercise the integrated test target. If the build needs a touch-up I'll iterate.

## Out of scope (intentional)

- No behaviour change in the dispatched Metal path. Parser outputs match the prior inline implementations bit-for-bit; the only delta is that the `default_fallback` for `ResolveMetalPoolSlotCount()` is now clamped to `[1, max]` *before* it is returned (today the caller passes a constant of `1`, so this is observably a no-op; the clamp is for future-proofing).
- No new env vars, no new `-matmul*` flag promotion.
- No tests of the auto-detection path (`ResolveMetalAutoPoolSlotCount()`, etc.) — that requires Metal hardware reachable from the test runner. Separate hardening track.
- Only Metal env-var parsing. The CUDA side (`BTX_MATMUL_CUDA_*`) is a separate hardening pass.

## Notes

- Hardening only, per the current direction on this repo.
- Pure-function refactor: the parsers carry no state and do not call `std::getenv` themselves. That's deliberate — it lets the tests skip the global-env-mutation pattern that the rest of `matmul_metal_tests.cpp` uses (`ScopedEnvVar`) for these cases, and makes the property-test surface deterministic.
- Authored as `omniscia <omniscia@users.noreply.github.com>`.
