### PR TITLE
wallet: honor -autoshieldcoinbase in walletpassphrase

### DIFF
--- a/src/wallet/rpc/encrypt.cpp
+++ b/src/wallet/rpc/encrypt.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <rpc/util.h>
 #include <wallet/rpc/util.h>
 #include <wallet/shielded_wallet.h>
@@ -105,7 +106,16 @@ RPCHelpMan walletpassphrase()
         // Unlock should be side-effect free when we just rehydrated historical
         // shielded state. Defer coinbase auto-shield until the next block or
         // an explicit z_shieldcoinbase call in that case.
-        if (!shielded_state_rehydrated) {
+        //
+        // Honor the operator-facing -autoshieldcoinbase flag here. Without
+        // this guard, every walletpassphrase call would shield mature
+        // coinbase outputs even when the operator has explicitly set
+        // -autoshieldcoinbase=0, which is surprising and burns relay-floor
+        // fees on every unlock. The block-connect call site
+        // (CWallet::blockConnected -> MaybeAutoShieldCoinbase) already
+        // checks the same flag with the same default; this brings the two
+        // entry points back into agreement.
+        if (!shielded_state_rehydrated && gArgs.GetBoolArg("-autoshieldcoinbase", true)) {
             pwallet->MaybeAutoShieldCoinbase();
         }
 


### PR DESCRIPTION
## Summary

Same fix as btxchain/btx-node#200 (merged), applied here for the public reference repo.

The block-connect path in `CWallet::blockConnected` checks `gArgs.GetBoolArg("-autoshieldcoinbase", true)` before invoking `MaybeAutoShieldCoinbase()`. The `walletpassphrase` RPC handler in `src/wallet/rpc/encrypt.cpp` does **not**. Result: every unlock auto-shields mature coinbase outputs even when the operator has explicitly set `-autoshieldcoinbase=0` in `btx.conf`. This is surprising, burns relay-floor fees per unlock, and silently moves transparent coinbase value into the shielded pool against operator intent.

## Fix

Extend the existing guard at the unlock site to also check the flag, with the same default (`true`) as the block-connect site.

```cpp
- if (!shielded_state_rehydrated) {
+ if (!shielded_state_rehydrated && gArgs.GetBoolArg("-autoshieldcoinbase", true)) {
      pwallet->MaybeAutoShieldCoinbase();
  }
```

Default behavior is unchanged. Only operators who set `-autoshieldcoinbase=0` see a difference (now: respected at unlock; previously: ignored at unlock).

## Verified live

Patched binary running on mainnet at block 94,910+ (v0.29.7 + this fix). Pre-patch: every `walletpassphrase` fired AutoShield, consuming ~0.00029 BTX in relay-floor fees per unlock. Post-patch: zero AutoShield events on unlock when `autoshieldcoinbase=0` is set. Confirmed via debug.log inspection and balance reconciliation across two independent unlocks.

## Test plan

- [ ] Build with the patch.
- [ ] On a regtest wallet with mature coinbase, set `autoshieldcoinbase=0`, encrypt, restart, `walletpassphrase` -> confirm no `AutoShieldCoinbase: found ... shielding` in `debug.log`.
- [ ] Unset (default), repeat -> confirm AutoShield runs as before.
- [ ] Existing functional tests still pass.

## Notes

- The block-connect path remains the canonical entry point; this is just bringing the unlock entry point into agreement with it.
- No consensus-affecting change. Pure operator-policy fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)