### PR TITLE
metal: use MTLCopyAllDevices instead of MTLCreateSystemDefaultDevice

### DIFF
--- a/src/metal/matmul_accel.mm
+++ b/src/metal/matmul_accel.mm
@@ -1122,11 +1122,15 @@ struct MetalContext {
     MetalContext()
     {
         @autoreleasepool {
-            device = MTLCreateSystemDefaultDevice();
-            if (device == nil) {
+            // MTLCreateSystemDefaultDevice() is restricted to interactive apps on
+            // macOS 14+; it returns nil from CLI/daemon contexts. MTLCopyAllDevices()
+            // works in any context. (Diligence patch 2026-05-21.)
+            NSArray<id<MTLDevice>>* allDevices = MTLCopyAllDevices();
+            if (allDevices == nil || allDevices.count == 0) {
                 error = "No Metal-compatible GPU device found";
                 return;
             }
+            device = allDevices[0];
             capture_supported = [MTLCaptureManager sharedCaptureManager] != nil;
             pool_slots.resize(ResolveMetalPoolSlotCount());
             for (auto& slot : pool_slots) {

--- a/src/metal/nonce_accel.mm
+++ b/src/metal/nonce_accel.mm
@@ -55,11 +55,15 @@ struct MetalContext {
     MetalContext()
     {
         @autoreleasepool {
-            device = MTLCreateSystemDefaultDevice();
-            if (device == nil) {
+            // MTLCreateSystemDefaultDevice() is restricted to interactive apps on
+            // macOS 14+; it returns nil from CLI/daemon contexts. MTLCopyAllDevices()
+            // works in any context. (Diligence patch 2026-05-21.)
+            NSArray<id<MTLDevice>>* allDevices = MTLCopyAllDevices();
+            if (allDevices == nil || allDevices.count == 0) {
                 error = "No Metal-compatible GPU device found";
                 return;
             }
+            device = allDevices[0];
 
             queue = [device newCommandQueue];
             if (queue == nil) {

--- a/src/metal/oracle_accel.mm
+++ b/src/metal/oracle_accel.mm
@@ -281,11 +281,15 @@ struct MetalContext {
     MetalContext()
     {
         @autoreleasepool {
-            device = MTLCreateSystemDefaultDevice();
-            if (device == nil) {
+            // MTLCreateSystemDefaultDevice() is restricted to interactive apps on
+            // macOS 14+; it returns nil from CLI/daemon contexts. MTLCopyAllDevices()
+            // works in any context. (Diligence patch 2026-05-21.)
+            NSArray<id<MTLDevice>>* allDevices = MTLCopyAllDevices();
+            if (allDevices == nil || allDevices.count == 0) {
                 error = "No Metal-compatible GPU device found";
                 return;
             }
+            device = allDevices[0];
 
             queue = [device newCommandQueue];
             if (queue == nil) {


### PR DESCRIPTION
## Summary

On macOS 14 and later, `MTLCreateSystemDefaultDevice()` is restricted to interactive apps. When called from a CLI or daemon context — which is how `btxd`, `btx-genesis`, `btx-matmul-backend-info`, and `btx-matmul-solve-bench` are normally invoked — it returns `nil` with this system log:

```
Use of MTLCreateSystemDefaultDevice is not supported for non-interactive
(commandline or daemon) apps. Use MTLCopyAllDevices(WithObserver) instead.
```

Effect: on every Apple Silicon Mac running these binaries from Terminal on macOS 14 or newer, the Metal backend probe currently reports `"No Metal-compatible GPU device found"` and silently falls back to CPU. The Metal mining path documented as the production default on Apple Silicon in `doc/btx-metal-mining-tuning.md` is therefore **unreachable for typical end-user CLI launches**.

This PR replaces the call in all three Metal context constructors (`matmul_accel.mm`, `oracle_accel.mm`, `nonce_accel.mm`) with `MTLCopyAllDevices()`, picking the first available device. This is exactly Apple's documented recommendation for non-interactive contexts.

## Reproduction (before the fix)

```bash
$ ./build/bin/btx-matmul-backend-info --backend metal
{
  "active_backend": "cpu",
  "selection_reason": "metal_unavailable_fallback_to_cpu:No Metal-compatible GPU device found",
  "capabilities": {
    "metal": { "compiled": true, "available": false,
               "reason": "No Metal-compatible GPU device found" }
  }
}
```

Confirmed via Apple's own log stream:

```
$ log stream --predicate 'process == "btx-matmul-backend-info"' --info
... Error  btx-matmul-backend-info: (Metal)
    Use of MTLCreateSystemDefaultDevice is not supported for
    non-interactive (commandline or daemon) apps.
    Use MTLCopyAllDevices(WithObserver) instead.
```

Also reproducible with a one-line standalone Swift test on the same machine:

```bash
$ echo 'import Metal; print(MTLCreateSystemDefaultDevice() ?? "nil")' | swift -
nil
```

Workarounds that **don't** help: ad-hoc codesigning the binary, wrapping it in a `.app` bundle and launching via `open` (the shell-spawn re-enters CLI context).

## Verification (after the fix)

Same `btx-matmul-backend-info --backend metal` call on the same M2 / macOS 14.8.7 host post-patch:

```json
{
  "active_backend": "metal",
  "selection_reason": "requested_backend_available",
  "capabilities": {
    "metal": { "compiled": true, "available": true,
               "reason": "runtime_probe_ok" }
  }
}
```

Production mining benchmark (`btx-matmul-solve-bench --backend metal --block-height 61000`) now runs cleanly on Metal at ~1,000 nonces/sec on M2 base (conservative-tier auto-policy, `solver_threads=1`).

## Why `MTLCopyAllDevices()` is correct

Per Apple's [Metal documentation](https://developer.apple.com/documentation/metal/mtlcopyalldevices()):

> Use this function to retrieve all Metal device objects available on the system. This function returns immediately and works in any context, including command-line tools and daemons.

`MTLCreateSystemDefaultDevice()` is intended for apps with display context where macOS can apply per-display GPU affinity. CLI/daemon binaries have no display context, hence the restriction.

The patch picks `allDevices[0]`. On Apple Silicon there is only one GPU so this is unambiguous. On Intel Macs with multiple GPUs (integrated + discrete or eGPU) this picks the first the system enumerates, which matches the prior default-device behavior closely enough for the mining / oracle / nonce contexts that don't have display-affinity concerns.

## ARC safety

`-fobjc-arc` is enabled per `src/CMakeLists.txt:401` for Objective-C++. Under ARC, `device = allDevices[0]` retains the device on assignment to the strong class member; the autoreleased `NSArray<id<MTLDevice>>*` drains safely at the `@autoreleasepool` block exit while the device remains held. No leaks introduced.

## Test scope

Patched + verified on macOS 14.8.7 (build 23J520) Apple Silicon M2 (Command Line Tools 15.3, AppleClang 15.0). Not regression-tested against the project's CI suite — would benefit from confirmation across:

- Other macOS versions (12.x where the API restriction may not exist; 15.x Sequoia; 26.x Tahoe)
- M1 / M3 / M4 hardware
- Xcode-debug-session launches (which presumably still worked before the fix; should still work after)
- Build with full Xcode + precompiled metallib pipeline (this patch was developed with `-DBTX_MATMUL_METAL_PRECOMPILE_KERNELS=OFF` because the test host lacks full Xcode)

## Context

Discovered while building a third-party Apple Silicon mining setup kit ([btx-air-m2-miner](https://github.com/n8uyeda/btx-air-m2-miner)). Surfaced via a Terminal-launched `btxd` failing to access Metal despite the M2's GPU being physically present and Metal.framework correctly linked into the binary. Diagnosed via `log stream` capturing Apple's explicit error message. Patch is one ARC-safe pattern replicated in three identical call sites.

Happy to iterate on the patch style or test plan based on project conventions.
