### PR TITLE
Sync snapshot metadata height 118225

### DIFF
--- a/doc/man/btx-qt.1
+++ b/doc/man/btx-qt.1
@@ -33,7 +33,7 @@ If this block is in the chain assume that it and its ancestors are valid
 and potentially skip script verification for their transactions
 while still checking other consensus rules (0 to verify all,
 default:
-88a7b534ff66a863d45813668d9e53010a257af18b2d73154ec31a873bd36534,
+f4dfb86209f2f4f2c9ccfb960368cc334afea065916a82f38698f6391118cd8e,
 testnet3:
 f2bc3fb2eca6aa6059c4d0178b56efe038d46aa440d406905ef752179aa0e1a4,
 testnet4:

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -51,6 +51,9 @@ Notable changes
   Docker regtest, documentation, and CI-path-filter gates for the shielded
   bridge surfaces.
 
+- Mainnet snapshot, checkpoint, `minimumchainwork`, and `assumevalid` metadata
+  have been refreshed to height 118,225 for the 0.30.2 fast-start release.
+
 ## Credits
 
 Thanks to everyone who contributed code, testing, operational validation, and

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -235,12 +235,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0;
 
-        // Mainnet anchor refreshed on 2026-05-21 at height 106'875 from a
+        // Mainnet anchor refreshed on 2026-06-01 at height 118'225 from a
         // synced canonical node so stale history below the current public
         // release floor is rejected quickly.
-        consensus.nMinimumChainWork = uint256{"0000000000000000000000000000000000000000000000000000005649edfed5"};
+        consensus.nMinimumChainWork = uint256{"00000000000000000000000000000000000000000000000000000299d53aaf7d"};
         // Assume signatures valid up to the same anchored block to speed sync.
-        consensus.defaultAssumeValid = uint256{"88a7b534ff66a863d45813668d9e53010a257af18b2d73154ec31a873bd36534"};
+        consensus.defaultAssumeValid = uint256{"f4dfb86209f2f4f2c9ccfb960368cc334afea065916a82f38698f6391118cd8e"};
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -294,7 +294,7 @@ public:
         checkpointData = {
             {
                 {0, uint256{"75a998a39d2d6e25a9ca7de2cc659309c4105839c06cd435ba2b1aabf0fa4601"}},
-                {106875, uint256{"88a7b534ff66a863d45813668d9e53010a257af18b2d73154ec31a873bd36534"}},
+                {118225, uint256{"f4dfb86209f2f4f2c9ccfb960368cc334afea065916a82f38698f6391118cd8e"}},
             }
         };
         m_assumeutxo_data = {
@@ -354,11 +354,18 @@ public:
                 .m_chain_tx_count = 128'730,
                 .blockhash = consteval_ctor(uint256{"88a7b534ff66a863d45813668d9e53010a257af18b2d73154ec31a873bd36534"}),
             },
+            {
+                // main assumeutxo snapshot at height 118'225
+                .height = 118'225,
+                .hash_serialized = AssumeutxoHash{uint256{"69810930f3c4102c10bde6a5380059f6b9b59fc5a0f28c0805576c04a95cd8e1"}},
+                .m_chain_tx_count = 144'179,
+                .blockhash = consteval_ctor(uint256{"f4dfb86209f2f4f2c9ccfb960368cc334afea065916a82f38698f6391118cd8e"}),
+            },
         };
         chainTxData = ChainTxData{
-            .nTime = 1779323209,
-            .tx_count = 128732,
-            .dTxRate = 0.015144787163,
+            .nTime = 1780339110,
+            .tx_count = 144191,
+            .dTxRate = 0.017135588551,
         };
     }
 };

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -1204,10 +1204,10 @@ BOOST_AUTO_TEST_CASE(ChainParams_MAIN_hardening_anchor_consistency)
 
     BOOST_CHECK_EQUAL(
         consensus.nMinimumChainWork.GetHex(),
-        "0000000000000000000000000000000000000000000000000000005649edfed5");
+        "00000000000000000000000000000000000000000000000000000299d53aaf7d");
     BOOST_CHECK_EQUAL(
         consensus.defaultAssumeValid.GetHex(),
-        "88a7b534ff66a863d45813668d9e53010a257af18b2d73154ec31a873bd36534");
+        "f4dfb86209f2f4f2c9ccfb960368cc334afea065916a82f38698f6391118cd8e");
     BOOST_CHECK_EQUAL(params->AssumedBlockchainSize(), 16U);
     BOOST_CHECK_EQUAL(params->AssumedChainStateSize(), 1U);
 
@@ -1218,11 +1218,11 @@ BOOST_AUTO_TEST_CASE(ChainParams_MAIN_hardening_anchor_consistency)
     BOOST_CHECK_EQUAL(
         it_0->second.GetHex(),
         "75a998a39d2d6e25a9ca7de2cc659309c4105839c06cd435ba2b1aabf0fa4601");
-    const auto it_anchor = checkpoints.find(106875);
+    const auto it_anchor = checkpoints.find(118225);
     BOOST_REQUIRE(it_anchor != checkpoints.end());
     BOOST_CHECK_EQUAL(
         it_anchor->second.GetHex(),
-        "88a7b534ff66a863d45813668d9e53010a257af18b2d73154ec31a873bd36534");
+        "f4dfb86209f2f4f2c9ccfb960368cc334afea065916a82f38698f6391118cd8e");
 
     const auto assumeutxo_55000 = params->AssumeutxoForHeight(55000);
     BOOST_REQUIRE(assumeutxo_55000.has_value());
@@ -1312,11 +1312,22 @@ BOOST_AUTO_TEST_CASE(ChainParams_MAIN_hardening_anchor_consistency)
         assumeutxo_106875->blockhash.GetHex(),
         "88a7b534ff66a863d45813668d9e53010a257af18b2d73154ec31a873bd36534");
 
+    const auto assumeutxo_118225 = params->AssumeutxoForHeight(118225);
+    BOOST_REQUIRE(assumeutxo_118225.has_value());
+    BOOST_CHECK_EQUAL(assumeutxo_118225->height, 118225);
+    BOOST_CHECK_EQUAL(
+        assumeutxo_118225->hash_serialized.ToString(),
+        "69810930f3c4102c10bde6a5380059f6b9b59fc5a0f28c0805576c04a95cd8e1");
+    BOOST_CHECK_EQUAL(assumeutxo_118225->m_chain_tx_count, 144179U);
+    BOOST_CHECK_EQUAL(
+        assumeutxo_118225->blockhash.GetHex(),
+        "f4dfb86209f2f4f2c9ccfb960368cc334afea065916a82f38698f6391118cd8e");
+
     const auto snapshot_heights = params->GetAvailableSnapshotHeights();
-    BOOST_REQUIRE_EQUAL(snapshot_heights.size(), 8U);
+    BOOST_REQUIRE_EQUAL(snapshot_heights.size(), 9U);
     BOOST_CHECK(std::is_sorted(snapshot_heights.begin(), snapshot_heights.end()));
     BOOST_CHECK_EQUAL(snapshot_heights.front(), 55000);
-    BOOST_CHECK_EQUAL(snapshot_heights.back(), 106875);
+    BOOST_CHECK_EQUAL(snapshot_heights.back(), 118225);
     BOOST_CHECK_GE(snapshot_heights.back(), std::prev(checkpoints.end())->first);
 }
 

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -404,6 +404,7 @@ BOOST_AUTO_TEST_CASE(test_mainnet_assumeutxo_snapshot_metadata)
         85'850,
         105'550,
         106'875,
+        118'225,
     };
 
     BOOST_REQUIRE_EQUAL(snapshot_heights.size(), expected_snapshot_heights.size());
@@ -420,6 +421,7 @@ BOOST_AUTO_TEST_CASE(test_mainnet_assumeutxo_snapshot_metadata)
     BOOST_CHECK(params->AssumeutxoForHeight(85'850));
     BOOST_CHECK(params->AssumeutxoForHeight(105'550));
     BOOST_CHECK(params->AssumeutxoForHeight(106'875));
+    BOOST_CHECK(params->AssumeutxoForHeight(118'225));
     BOOST_CHECK(!params->AssumeutxoForHeight(50'000));
     BOOST_CHECK(!params->AssumeutxoForHeight(0));
 }


### PR DESCRIPTION
## Summary

Sync the public `btx` repo with the latest `btx-node` main snapshot metadata update.

Changes:
- Refresh mainnet `minimumchainwork`, `assumevalid`, checkpoint, chain tx data, and assumeutxo metadata to height 118,225.
- Add the 118,225 assumeutxo metadata to the chainparams tests.
- Update release notes and generated manpage default assumevalid text.

## Public-only handling

- Retained `infra/btx-seed-server-spec.md`.
- Restored public release workflow and Windows clone references after the tracked-file overlay.
- Kept release-note `Credits` headings normalized for `git diff --check`.

## Validation

- `git diff --check`
- Targeted public-facing search for private `btx-node` references

Build/test run was skipped per maintainer instruction.
