### PR TITLE
fix: default Metal transcript pipeline to legacy finalize

### DIFF
--- a/src/metal/matmul_accel.mm
+++ b/src/metal/matmul_accel.mm
@@ -2073,10 +2073,11 @@ bool ShouldUseLegacyTranscriptPipeline(const btx::metal::MatMulDigestRequest& re
     case MetalTranscriptPipelineMode::FUSED:
         return !fused_available && legacy_available;
     case MetalTranscriptPipelineMode::AUTO:
-        if (!legacy_available) return false;
-        if (!fused_available) return true;
-        // Large production dimensions regress on fused+GPU hash on M1 class devices.
-        return request.n >= 128;
+        // Prefer the legacy GPU-compute + CPU-finalize path for consensus safety.
+        // The fused GPU-hash transcript path is retained behind the explicit
+        // BTX_MATMUL_METAL_PIPELINE=fused override, but it is not byte-exact on
+        // this Apple Silicon host for small transcript fixtures.
+        return legacy_available;
     }
 
     return false;

--- a/src/test/matmul_backend_capabilities_tests.cpp
+++ b/src/test/matmul_backend_capabilities_tests.cpp
@@ -1057,7 +1057,7 @@ BOOST_AUTO_TEST_CASE(metal_profiling_samples_increment_after_digest)
     BOOST_CHECK_GT(after.samples, before.samples);
     BOOST_CHECK_GT(after.last_encode_build_perturbed_us, 0.0);
     BOOST_CHECK_GT(after.last_encode_fused_prefix_compress_us, 0.0);
-    BOOST_CHECK_GT(after.last_encode_transcript_sha256_us, 0.0);
+    BOOST_CHECK(after.last_encode_transcript_sha256_us > 0.0 || after.last_cpu_finalize_us > 0.0);
     BOOST_CHECK_GT(after.last_submit_wait_us, 0.0);
 }
 


### PR DESCRIPTION
## Summary
- Defaults Metal AUTO transcript selection to the legacy GPU-compute + CPU-finalize path for consensus safety
- Keeps fused GPU-hash transcript path available behind explicit BTX_MATMUL_METAL_PIPELINE=fused override
- Updates Metal profiling test to accept either fused SHA256 timing or CPU-finalize timing

## Test Plan
- cmake --build build-btx-metal-runtime --target test_btx -j 8
- ./build-btx-metal-runtime/bin/test_btx --run_test=matmul_backend_capabilities_tests --catch_system_errors=no

## Notes
This follows the Apple Silicon MLX/Metal host finding that fused GPU-hash transcript fixtures were not byte-exact for small transcript cases.