### PR TITLE
Sync public btx with btx-node main for BTX 0.32.1

### DIFF
--- a/src/test/shielded_wallet_chunk_discovery_tests.cpp
+++ b/src/test/shielded_wallet_chunk_discovery_tests.cpp
@@ -25,10 +25,12 @@
 #include <test/util/shielded_account_registry_test_util.h>
 #include <test/util/smile2_placeholder_utils.h>
 #include <test/util/shielded_v2_egress_fixture.h>
+#include <wallet/crypter.h>
 #include <wallet/shielded_coins.h>
 #include <wallet/shielded_wallet.h>
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -947,6 +949,148 @@ BOOST_AUTO_TEST_CASE(locked_scan_owned_note_rehydrates_to_spendable_on_unlock)
         BOOST_CHECK_EQUAL(summary.watchonly, 0);
         BOOST_CHECK_EQUAL(shielded_wallet->GetShieldedBalance(/*min_depth=*/0), value);
         BOOST_REQUIRE_EQUAL(shielded_wallet->GetSpendableNotes(/*min_depth=*/0).size(), 1U);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(unreadable_encrypted_shielded_state_cache_is_rebuilt_on_unlock)
+{
+    const std::vector<unsigned char> truncated_state{0x04};
+    wallet::CKeyingMaterial plaintext(truncated_state.begin(), truncated_state.end());
+    uint256 iv;
+    iv.begin()[0] = 0x42;
+
+    std::vector<unsigned char> legacy_ciphertext;
+    BOOST_REQUIRE(wallet.WithEncryptionKey([&](const wallet::CKeyingMaterial& master_key) {
+        return wallet::EncryptSecret(master_key, plaintext, iv, legacy_ciphertext);
+    }));
+
+    {
+        wallet::WalletBatch batch(wallet.GetDatabase());
+        BOOST_REQUIRE(batch.WriteCryptedShieldedState(iv, legacy_ciphertext));
+        BOOST_REQUIRE(batch.WriteShieldedState(truncated_state));
+    }
+
+    std::shared_ptr<wallet::CShieldedWallet> recovered_wallet;
+    BOOST_CHECK_NO_THROW(recovered_wallet = std::make_shared<wallet::CShieldedWallet>(wallet));
+    BOOST_REQUIRE(recovered_wallet);
+    wallet.m_shielded_wallet = recovered_wallet;
+    shielded_wallet = recovered_wallet;
+
+    {
+        wallet::WalletBatch batch(wallet.GetDatabase());
+        uint256 stored_iv;
+        std::vector<unsigned char> stored_state;
+        BOOST_CHECK(!batch.ReadCryptedShieldedState(stored_iv, stored_state));
+        BOOST_CHECK(!batch.ReadShieldedState(stored_state));
+    }
+
+    {
+        LOCK2(wallet.cs_wallet, shielded_wallet->cs_shielded);
+        BOOST_CHECK(shielded_wallet->MaybeRehydrateSpendingKeys());
+    }
+
+    {
+        wallet::WalletBatch batch(wallet.GetDatabase());
+        uint256 stored_iv;
+        std::vector<unsigned char> stored_state;
+        BOOST_CHECK(batch.ReadCryptedShieldedState(stored_iv, stored_state));
+        BOOST_CHECK(!stored_state.empty());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(unreadable_encrypted_shielded_state_salvages_generated_address)
+{
+    const CAmount value = 23 * COIN / 100;
+    const CTransaction tx =
+        BuildMinimalV2SendTransaction(owned_addr.pk_hash, owned_kem_pk, value, 0xfa);
+
+    CBlock block;
+    block.vtx.push_back(MakeTransactionRef(tx));
+    {
+        LOCK2(wallet.cs_wallet, shielded_wallet->cs_shielded);
+        shielded_wallet->ScanBlock(block, /*height=*/1);
+        const auto notes = shielded_wallet->GetUnspentNotes(/*min_depth=*/0);
+        BOOST_REQUIRE_EQUAL(notes.size(), 1U);
+        BOOST_REQUIRE(notes.front().account_leaf_hint.has_value());
+    }
+
+    uint256 state_iv;
+    std::vector<unsigned char> encrypted_state;
+    {
+        wallet::WalletBatch batch(wallet.GetDatabase());
+        BOOST_REQUIRE(batch.ReadCryptedShieldedState(state_iv, encrypted_state));
+        BOOST_REQUIRE(!encrypted_state.empty());
+    }
+
+    std::vector<unsigned char> plaintext_state;
+    BOOST_REQUIRE(wallet.WithEncryptionKey([&](const wallet::CKeyingMaterial& master_key) {
+        bool was_authenticated{false};
+        return wallet::DecryptAuthenticatedSecret(master_key,
+                                                  encrypted_state,
+                                                  state_iv,
+                                                  plaintext_state,
+                                                  "shieldedstate",
+                                                  &was_authenticated) &&
+               was_authenticated;
+    }));
+
+    std::vector<unsigned char> direct_send_hint_pattern(1 + 1 + 1 + 64, 0);
+    direct_send_hint_pattern[0] = 1; // ShieldedCoin::account_leaf_hint has_value flag.
+    direct_send_hint_pattern[1] = shielded::registry::REGISTRY_WIRE_VERSION;
+    direct_send_hint_pattern[2] = static_cast<uint8_t>(shielded::registry::AccountDomain::DIRECT_SEND);
+    auto hint_it = plaintext_state.end();
+    for (auto it = std::search(plaintext_state.begin(),
+                               plaintext_state.end(),
+                               direct_send_hint_pattern.begin(),
+                               direct_send_hint_pattern.end());
+         it != plaintext_state.end();
+         it = std::search(std::next(it),
+                          plaintext_state.end(),
+                          direct_send_hint_pattern.begin(),
+                          direct_send_hint_pattern.end())) {
+        hint_it = it;
+    }
+    BOOST_REQUIRE(hint_it != plaintext_state.end());
+    *(hint_it + 1) = 0x7f;
+
+    uint256 corrupt_iv;
+    corrupt_iv.begin()[0] = 0x51;
+    wallet::CKeyingMaterial corrupt_plaintext(plaintext_state.begin(), plaintext_state.end());
+    std::vector<unsigned char> corrupt_ciphertext;
+    BOOST_REQUIRE(wallet.WithEncryptionKey([&](const wallet::CKeyingMaterial& master_key) {
+        return wallet::EncryptAuthenticatedSecret(master_key,
+                                                  corrupt_plaintext,
+                                                  corrupt_iv,
+                                                  corrupt_ciphertext,
+                                                  "shieldedstate");
+    }));
+
+    {
+        wallet::WalletBatch batch(wallet.GetDatabase());
+        BOOST_REQUIRE(batch.WriteCryptedShieldedState(corrupt_iv, corrupt_ciphertext));
+    }
+
+    std::shared_ptr<wallet::CShieldedWallet> recovered_wallet;
+    BOOST_CHECK_NO_THROW(recovered_wallet = std::make_shared<wallet::CShieldedWallet>(wallet));
+    BOOST_REQUIRE(recovered_wallet);
+    wallet.m_shielded_wallet = recovered_wallet;
+    shielded_wallet = recovered_wallet;
+
+    {
+        LOCK2(wallet.cs_wallet, shielded_wallet->cs_shielded);
+        mlkem::PublicKey rehydrated_pk{};
+        BOOST_REQUIRE(shielded_wallet->GetKEMPublicKey(owned_addr, rehydrated_pk));
+        BOOST_CHECK_EQUAL_COLLECTIONS(rehydrated_pk.begin(), rehydrated_pk.end(),
+                                      owned_kem_pk.begin(), owned_kem_pk.end());
+    }
+
+    {
+        wallet::WalletBatch batch(wallet.GetDatabase());
+        uint256 stored_iv;
+        std::vector<unsigned char> stored_state;
+        BOOST_CHECK(batch.ReadCryptedShieldedState(stored_iv, stored_state));
+        BOOST_CHECK(!stored_state.empty());
+        BOOST_CHECK(!batch.ReadShieldedState(stored_state));
     }
 }
 

--- a/src/wallet/shielded_wallet.cpp
+++ b/src/wallet/shielded_wallet.cpp
@@ -1132,6 +1132,20 @@ bool AppendOutputChunkViews(ShieldedTxView& tx_view,
     return ok;
 }
 
+[[nodiscard]] bool ErasePersistedShieldedStateCache(WalletBatch& batch, const char* context)
+{
+    bool ok{true};
+    if (!batch.EraseCryptedShieldedState()) {
+        LogPrintf("%s: failed to erase encrypted shielded state cache\n", context);
+        ok = false;
+    }
+    if (!batch.EraseShieldedState()) {
+        LogPrintf("%s: failed to erase plaintext shielded state cache\n", context);
+        ok = false;
+    }
+    return ok;
+}
+
 [[nodiscard]] bool DecryptWithWalletKey(const CWallet& wallet,
                                         Span<const unsigned char> ciphertext,
                                         const uint256& iv,
@@ -1275,6 +1289,112 @@ struct PersistedShieldedState
         }
     }
 };
+
+struct TolerantShieldedCoinSkip
+{
+    SERIALIZE_METHODS(TolerantShieldedCoinSkip, obj)
+    {
+        ShieldedNote note;
+        uint256 commitment;
+        Nullifier nullifier;
+        uint64_t tree_position{0};
+        int confirmation_height{-1};
+        int spent_height{-1};
+        bool is_spent{false};
+        bool is_mine_spend{false};
+        uint256 block_hash;
+        READWRITE(note,
+                  commitment,
+                  nullifier,
+                  tree_position,
+                  confirmation_height,
+                  spent_height,
+                  is_spent,
+                  is_mine_spend,
+                  block_hash);
+        bool has_account_leaf_hint{false};
+        READWRITE(has_account_leaf_hint);
+        if (has_account_leaf_hint) {
+            uint8_t hint_version{0};
+            uint8_t hint_domain{0};
+            uint256 settlement_binding_digest;
+            uint256 output_binding_digest;
+            READWRITE(hint_version,
+                      hint_domain,
+                      settlement_binding_digest,
+                      output_binding_digest);
+        }
+    }
+};
+
+void DropPersistedShieldedScanCache(PersistedShieldedState& state)
+{
+    state.last_scanned_height = -1;
+    state.last_scanned_hash.SetNull();
+    state.tree = shielded::ShieldedMerkleTree{shielded::ShieldedMerkleTree::IndexStorageMode::MEMORY_ONLY};
+    state.notes.clear();
+    state.note_classes.clear();
+    state.witnesses.clear();
+    state.recent_ring_exclusions.clear();
+}
+
+void LogPersistedShieldedIdentitySalvage(const PersistedShieldedState& state,
+                                         const char* trigger,
+                                         const std::string& reason)
+{
+    LogPrintf("CShieldedWallet::LoadPersistedState: shielded_state_recovery=salvaged_identity "
+              "trigger=%s reason=\"%s\" keysets=%u lifecycles=%u next_spend_idx=%u next_kem_idx=%u; "
+              "discarded scan cache will be rebuilt from active chain\n",
+              trigger,
+              reason,
+              static_cast<unsigned int>(state.key_sets.size()),
+              static_cast<unsigned int>(state.address_lifecycles.size()),
+              state.next_spending_index,
+              state.next_kem_index);
+}
+
+[[nodiscard]] std::optional<PersistedShieldedState> TrySalvagePersistedShieldedIdentity(
+    const std::vector<unsigned char>& blob,
+    std::string& diagnostic)
+{
+    PersistedShieldedState salvaged;
+    try {
+        DataStream ss{blob};
+        shielded::ShieldedMerkleTree ignored_tree{shielded::ShieldedMerkleTree::IndexStorageMode::MEMORY_ONLY};
+        ss >> salvaged.version
+           >> salvaged.next_spending_index
+           >> salvaged.next_kem_index
+           >> salvaged.last_scanned_height
+           >> salvaged.last_scanned_hash
+           >> ignored_tree
+           >> salvaged.key_sets;
+        if (salvaged.version == 0 || salvaged.version > SHIELDED_STATE_VERSION) {
+            diagnostic = strprintf("unsupported salvaged state version %u", salvaged.version);
+            return std::nullopt;
+        }
+        DropPersistedShieldedScanCache(salvaged);
+
+        try {
+            std::vector<TolerantShieldedCoinSkip> ignored_notes;
+            std::vector<std::pair<uint256, shielded::ShieldedMerkleWitness>> ignored_witnesses;
+            ss >> ignored_notes >> ignored_witnesses;
+            if (salvaged.version >= 2) {
+                std::vector<uint64_t> ignored_recent_ring_exclusions;
+                ss >> ignored_recent_ring_exclusions;
+            }
+            if (salvaged.version >= 3) {
+                ss >> salvaged.address_lifecycles;
+            }
+        } catch (const std::exception& e) {
+            diagnostic = strprintf("salvaged key metadata only; failed to skip scan cache: %s", e.what());
+            salvaged.address_lifecycles.clear();
+        }
+        return salvaged;
+    } catch (const std::exception& e) {
+        diagnostic = strprintf("failed to salvage shielded wallet identity: %s", e.what());
+        return std::nullopt;
+    }
+}
 
 } // namespace
 
@@ -6613,25 +6733,58 @@ void CShieldedWallet::LoadPersistedState()
 
     PersistedShieldedState state;
     bool rewrite_unencrypted_tree_only{false};
+    bool salvaged_unreadable_encrypted_state{false};
     try {
         DataStream ss{blob};
         ss >> state;
         if (!ss.empty()) {
             if (have_encrypted_state && !using_locked_plaintext_fallback) {
-                throw std::runtime_error("Persisted encrypted shielded state has trailing bytes");
+                const std::string error{"Persisted encrypted shielded state has trailing bytes"};
+                if (!ErasePersistedShieldedStateCache(batch, "CShieldedWallet::LoadPersistedState")) {
+                    throw std::runtime_error(strprintf("%s; failed to erase shielded state cache", error));
+                }
+                DropPersistedShieldedScanCache(state);
+                LogPersistedShieldedIdentitySalvage(state, "trailing-bytes", error);
+                salvaged_unreadable_encrypted_state = true;
+                m_locked_state_incomplete = false;
             }
-            LogPrintf("CShieldedWallet: persisted state decode had trailing bytes; ignoring persisted state\n");
-            return;
+            if (!salvaged_unreadable_encrypted_state) {
+                LogPrintf("CShieldedWallet: persisted state decode had trailing bytes; ignoring persisted state\n");
+                return;
+            }
         }
     } catch (const std::exception& e) {
         if (have_encrypted_state && !using_locked_plaintext_fallback) {
-            throw std::runtime_error(strprintf("Persisted encrypted shielded state is unreadable: %s", e.what()));
+            const std::string error = strprintf("Persisted encrypted shielded state is unreadable: %s", e.what());
+            std::string salvage_diagnostic;
+            auto salvaged_state = TrySalvagePersistedShieldedIdentity(blob, salvage_diagnostic);
+            if (!ErasePersistedShieldedStateCache(batch, "CShieldedWallet::LoadPersistedState")) {
+                throw std::runtime_error(strprintf("%s; failed to erase shielded state cache", error));
+            }
+            if (!salvaged_state.has_value()) {
+                LogPrintf("CShieldedWallet::LoadPersistedState: shielded_state_recovery=cache_cleared_seed_rederive "
+                          "reason=\"%s\" salvage=\"%s\"; generated shielded addresses will be rederived from master seed when possible\n",
+                          error,
+                          salvage_diagnostic.empty() ? "no salvage details" : salvage_diagnostic);
+                m_locked_state_incomplete = false;
+                return;
+            }
+            state = std::move(*salvaged_state);
+            LogPersistedShieldedIdentitySalvage(state, "decode-error", error);
+            if (!salvage_diagnostic.empty()) {
+                LogPrintf("CShieldedWallet::LoadPersistedState: shielded_state_recovery_detail=%s\n",
+                          salvage_diagnostic);
+            }
+            salvaged_unreadable_encrypted_state = true;
+            m_locked_state_incomplete = false;
+        } else {
+            LogPrintf("CShieldedWallet: failed to decode persisted state: %s\n", e.what());
+            return;
         }
-        LogPrintf("CShieldedWallet: failed to decode persisted state: %s\n", e.what());
-        return;
     }
 
-    if (have_encrypted_state && !using_locked_plaintext_fallback && !encrypted_state_was_authenticated &&
+    if (have_encrypted_state && !using_locked_plaintext_fallback && !salvaged_unreadable_encrypted_state &&
+        !encrypted_state_was_authenticated &&
         m_parent_wallet.IsCrypted() && !m_parent_wallet.IsLocked()) {
         uint256 migrated_iv;
         std::vector<unsigned char> migrated_blob;


### PR DESCRIPTION
## Source ref

- `btx-node`: `main` at `0d28a1f2`

## Version

- BTX `0.32.1`

## Highlights

- Syncs the wallet shielded-state cache recovery update from `btx-node` main.
- Updates `src/wallet/shielded_wallet.cpp` to salvage shielded identity metadata and clear unreadable persisted scan caches.
- Brings over the expanded shielded wallet chunk discovery test coverage.

## Public-only checks

- Confirmed `.github/workflows/btx-release-assets.yml` still publishes to `btxchain/btx`.
- Confirmed public docs still point users at `btxchain/btx`.
- Confirmed `infra/btx-seed-server-spec.md` was retained.
- Confirmed no tracked `redteam/**` files remain public.

## Validation

- `git diff --check main...HEAD`
- `git status --short --branch`
- `git diff --stat main...HEAD`
