### PR TITLE
Sync btx-node additional 0.32.7 updates

### DIFF
--- a/contrib/devtools/generate_assumeutxo.py
+++ b/contrib/devtools/generate_assumeutxo.py
@@ -29,6 +29,7 @@ class AssumeutxoSnapshot:
     path: str
     snapshot_sha256: str
     snapshot_version: int
+    shielded_state_pin: str | None = None
 
 
 def format_int_with_ticks(value: int) -> str:
@@ -59,20 +60,33 @@ def read_snapshot_file_version(path: pathlib.Path) -> int:
     return struct.unpack("<H", header[len(SNAPSHOT_MAGIC_BYTES) :])[0]
 
 
+def normalize_optional_hex64(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    normalized = value.strip().lower()
+    if len(normalized) != 64 or any(c not in "0123456789abcdef" for c in normalized):
+        raise ValueError(f"{field} must be a 64-character hex string")
+    return normalized
+
+
 def build_chainparams_entry(snapshot: AssumeutxoSnapshot, comment: str | None = None) -> str:
     lines = []
     if comment:
         lines.append(f"    // {comment}")
-    lines.extend(
-        [
-            "    {",
-            f"        .height = {format_int_with_ticks(snapshot.height)},",
-            f"        .hash_serialized = AssumeutxoHash{{uint256{{\"{snapshot.txoutset_hash}\"}}}},",
-            f"        .m_chain_tx_count = {snapshot.nchaintx},",
-            f"        .blockhash = consteval_ctor(uint256{{\"{snapshot.blockhash}\"}}),",
-            "    },",
-        ]
-    )
+    lines.extend([
+        "    {",
+        f"        .height = {format_int_with_ticks(snapshot.height)},",
+        f"        .hash_serialized = AssumeutxoHash{{uint256{{\"{snapshot.txoutset_hash}\"}}}},",
+        f"        .m_chain_tx_count = {snapshot.nchaintx},",
+        f"        .blockhash = consteval_ctor(uint256{{\"{snapshot.blockhash}\"}}),",
+    ])
+    if snapshot.shielded_state_pin:
+        lines.append(f"        .shielded_state_commitment = uint256{{\"{snapshot.shielded_state_pin}\"}},")
+    lines.extend([
+        "    },",
+    ])
     return "\n".join(lines)
 
 
@@ -106,6 +120,8 @@ def build_release_manifest(
     if asset_url:
         manifest["asset_url"] = asset_url
         manifest["url"] = asset_url
+    if snapshot.shielded_state_pin:
+        manifest["shielded_state_pin"] = snapshot.shielded_state_pin
     return manifest
 
 
@@ -147,6 +163,8 @@ def build_report(
             "url": asset_url,
             "sha256": snapshot.snapshot_sha256,
         }
+    if snapshot.shielded_state_pin:
+        report["snapshot"]["shielded_state_pin"] = snapshot.shielded_state_pin
     return report
 
 
@@ -177,6 +195,7 @@ def parse_snapshot_metadata(result: dict[str, Any], snapshot_path: pathlib.Path)
         path=str(snapshot_path.resolve()),
         snapshot_sha256=sha256_file(snapshot_path),
         snapshot_version=read_snapshot_file_version(snapshot_path),
+        shielded_state_pin=normalize_optional_hex64(result.get("shielded_state_pin"), "shielded_state_pin"),
     )
 
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -69,6 +69,17 @@ BTX is supported on Linux, macOS 13+, and Windows 10+.
   shielded snapshot appendix, currently version 8 or newer, or use a non-pruned
   datadir / full redownload when only older snapshot data is available.
 
+- Mainnet fast-start metadata has been refreshed to snapshot height 128,605
+  (`d95c8b565fefcda79efe47acad98648b0a24899f22facba9eedeb02c8bffd4d2`).
+  The published v8 snapshot has txoutset hash
+  `2cfa629907fbc18f3edc1dbb8b33fda651ad3655fb88a9dffe7a67ead580a102`,
+  SHA256
+  `28b49fc6b10fc1db69c39bfe78e1cccbb175c8e44055c3c95d6c814762f71335`,
+  and a compiled shielded-state pin
+  `827f8bf52ddf6de1e780a0917179dac715abeb428580744505dc30fbd6be5f9d`.
+  Clean fast-start nodes can load this snapshot in the default fail-closed
+  mode without `-allowunpinnedshieldedsnapshot`.
+
 - The operational lesson from this release is that recovery-exit safety checks
   also need explicit liveness controls: reuse admission-time mempool
   reservations, cache per-template state, track the in-progress block state, and

--- a/doc/release-notes/release-notes-0.32.7.md
+++ b/doc/release-notes/release-notes-0.32.7.md
@@ -69,6 +69,17 @@ BTX is supported on Linux, macOS 13+, and Windows 10+.
   shielded snapshot appendix, currently version 8 or newer, or use a non-pruned
   datadir / full redownload when only older snapshot data is available.
 
+- Mainnet fast-start metadata has been refreshed to snapshot height 128,605
+  (`d95c8b565fefcda79efe47acad98648b0a24899f22facba9eedeb02c8bffd4d2`).
+  The published v8 snapshot has txoutset hash
+  `2cfa629907fbc18f3edc1dbb8b33fda651ad3655fb88a9dffe7a67ead580a102`,
+  SHA256
+  `28b49fc6b10fc1db69c39bfe78e1cccbb175c8e44055c3c95d6c814762f71335`,
+  and a compiled shielded-state pin
+  `827f8bf52ddf6de1e780a0917179dac715abeb428580744505dc30fbd6be5f9d`.
+  Clean fast-start nodes can load this snapshot in the default fail-closed
+  mode without `-allowunpinnedshieldedsnapshot`.
+
 - The operational lesson from this release is that recovery-exit safety checks
   also need explicit liveness controls: reuse admission-time mempool
   reservations, cache per-template state, track the in-progress block state, and

--- a/scripts/apply_assumeutxo_report.py
+++ b/scripts/apply_assumeutxo_report.py
@@ -42,6 +42,10 @@ ENTRY_RE = re.compile(
         \s*
         \.blockhash \s* = \s* consteval_ctor\(uint256\{"(?P<blockhash>[0-9a-f]{64})"\}\) \s* ,
         \s*
+        (?:
+            \.shielded_state_commitment \s* = \s* uint256\{"(?P<shielded_state_pin>[0-9a-f]{64})"\} \s* ,
+            \s*
+        )?
     \}
     """,
     re.VERBOSE | re.S,
@@ -59,6 +63,7 @@ class AssumeutxoSnapshot:
     txoutset_hash: str
     nchaintx: int
     blockhash: str
+    shielded_state_pin: str | None = None
 
 
 def parse_args() -> argparse.Namespace:
@@ -110,6 +115,12 @@ def parse_hex64(value: Any, field: str) -> str:
     return normalized
 
 
+def parse_optional_hex64(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    return parse_hex64(value, field)
+
+
 def parse_report(path: Path) -> tuple[AssumeutxoSnapshot, str]:
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
@@ -129,6 +140,11 @@ def parse_report(path: Path) -> tuple[AssumeutxoSnapshot, str]:
     txoutset_hash = snapshot_data.get("txoutset_hash")
     nchaintx = snapshot_data.get("nchaintx")
     blockhash = snapshot_data.get("blockhash")
+    shielded_state_pin = snapshot_data.get("shielded_state_pin")
+    if shielded_state_pin is None:
+        release_manifest = data.get("release_asset_manifest")
+        if isinstance(release_manifest, dict):
+            shielded_state_pin = release_manifest.get("shielded_state_pin")
 
     if not isinstance(height, int) or height < 0:
         raise AssumeutxoApplyError("snapshot.height must be a non-negative integer")
@@ -141,6 +157,7 @@ def parse_report(path: Path) -> tuple[AssumeutxoSnapshot, str]:
         txoutset_hash=parse_hex64(txoutset_hash, "snapshot.txoutset_hash"),
         nchaintx=nchaintx,
         blockhash=parse_hex64(blockhash, "snapshot.blockhash"),
+        shielded_state_pin=parse_optional_hex64(shielded_state_pin, "snapshot.shielded_state_pin"),
     )
     return snapshot, chain
 
@@ -189,6 +206,7 @@ def parse_existing_assumeutxo_entries(assignment: str, chain: str) -> list[Assum
                 txoutset_hash=match.group("txoutset_hash"),
                 nchaintx=parse_int_with_ticks(match.group("nchaintx"), "existing m_chain_tx_count"),
                 blockhash=match.group("blockhash"),
+                shielded_state_pin=match.group("shielded_state_pin"),
             )
         )
 
@@ -203,17 +221,19 @@ def build_chainparams_assignment(chain: str, entries: list[AssumeutxoSnapshot]) 
 
     lines = ["m_assumeutxo_data = {"]
     for entry in sorted(entries, key=lambda item: item.height):
-        lines.extend(
-            [
-                "    {",
-                f"        // {chain} assumeutxo snapshot at height {format_int_with_ticks(entry.height)}",
-                f"        .height = {format_int_with_ticks(entry.height)},",
-                f"        .hash_serialized = AssumeutxoHash{{uint256{{\"{entry.txoutset_hash}\"}}}},",
-                f"        .m_chain_tx_count = {format_int_with_ticks(entry.nchaintx)},",
-                f"        .blockhash = consteval_ctor(uint256{{\"{entry.blockhash}\"}}),",
-                "    },",
-            ]
-        )
+        lines.extend([
+            "    {",
+            f"        // {chain} assumeutxo snapshot at height {format_int_with_ticks(entry.height)}",
+            f"        .height = {format_int_with_ticks(entry.height)},",
+            f"        .hash_serialized = AssumeutxoHash{{uint256{{\"{entry.txoutset_hash}\"}}}},",
+            f"        .m_chain_tx_count = {format_int_with_ticks(entry.nchaintx)},",
+            f"        .blockhash = consteval_ctor(uint256{{\"{entry.blockhash}\"}}),",
+        ])
+        if entry.shielded_state_pin:
+            lines.append(f"        .shielded_state_commitment = uint256{{\"{entry.shielded_state_pin}\"}},")
+        lines.extend([
+            "    },",
+        ])
     lines.append("};")
     return "\n".join(lines)
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -267,12 +267,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0;
 
-        // Mainnet anchor refreshed on 2026-06-10 at height 126'800 from a
+        // Mainnet anchor refreshed on 2026-06-12 at height 128'605 from a
         // synced canonical node so stale history below the current public
         // release floor is rejected quickly.
-        consensus.nMinimumChainWork = uint256{"000000000000000000000000000000000000000000000000000004df8d0e5f66"};
+        consensus.nMinimumChainWork = uint256{"000000000000000000000000000000000000000000000000000005323d5ff789"};
         // Assume signatures valid up to the same anchored block to speed sync.
-        consensus.defaultAssumeValid = uint256{"fb6dcf553916244d09ea1cf1f0c0dfc714f232ac17c94f8d0a73d21a75de9e34"};
+        consensus.defaultAssumeValid = uint256{"d95c8b565fefcda79efe47acad98648b0a24899f22facba9eedeb02c8bffd4d2"};
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -326,7 +326,7 @@ public:
         checkpointData = {
             {
                 {0, uint256{"75a998a39d2d6e25a9ca7de2cc659309c4105839c06cd435ba2b1aabf0fa4601"}},
-                {126800, uint256{"fb6dcf553916244d09ea1cf1f0c0dfc714f232ac17c94f8d0a73d21a75de9e34"}},
+                {128605, uint256{"d95c8b565fefcda79efe47acad98648b0a24899f22facba9eedeb02c8bffd4d2"}},
             }
         };
         m_assumeutxo_data = {
@@ -414,11 +414,19 @@ public:
                 .m_chain_tx_count = 155'621,
                 .blockhash = consteval_ctor(uint256{"fb6dcf553916244d09ea1cf1f0c0dfc714f232ac17c94f8d0a73d21a75de9e34"}),
             },
+            {
+                // main assumeutxo snapshot at height 128'605
+                .height = 128'605,
+                .hash_serialized = AssumeutxoHash{uint256{"2cfa629907fbc18f3edc1dbb8b33fda651ad3655fb88a9dffe7a67ead580a102"}},
+                .m_chain_tx_count = 158'299,
+                .blockhash = consteval_ctor(uint256{"d95c8b565fefcda79efe47acad98648b0a24899f22facba9eedeb02c8bffd4d2"}),
+                .shielded_state_commitment = uint256{"827f8bf52ddf6de1e780a0917179dac715abeb428580744505dc30fbd6be5f9d"},
+            },
         };
         chainTxData = ChainTxData{
-            .nTime = 1781111202,
-            .tx_count = 155623,
-            .dTxRate = 0.016516832131,
+            .nTime = 1781271685,
+            .tx_count = 158301,
+            .dTxRate = 0.017899035537,
         };
     }
 };

--- a/test/util/apply_assumeutxo_report_test.py
+++ b/test/util/apply_assumeutxo_report_test.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import pathlib
 import sys
+import tempfile
 import unittest
 
 
@@ -44,13 +46,21 @@ class ApplyAssumeutxoReportTest(unittest.TestCase):
     def setUp(self):
         self.module = load_module()
 
-    def snapshot(self, height: int, txoutset_hash: str, blockhash: str, nchaintx: int):
+    def snapshot(
+        self,
+        height: int,
+        txoutset_hash: str,
+        blockhash: str,
+        nchaintx: int,
+        shielded_state_pin: str | None = None,
+    ):
         return self.module.AssumeutxoSnapshot(
             chain="main",
             height=height,
             txoutset_hash=txoutset_hash,
             nchaintx=nchaintx,
             blockhash=blockhash,
+            shielded_state_pin=shielded_state_pin,
         )
 
     def test_replace_assumeutxo_block_appends_new_height(self):
@@ -69,6 +79,47 @@ class ApplyAssumeutxoReportTest(unittest.TestCase):
         self.assertIn(".height = 55'000,", updated)
         self.assertIn(".height = 60'760,", updated)
         self.assertLess(updated.index(".height = 55'000,"), updated.index(".height = 60'760,"))
+
+    def test_replace_assumeutxo_block_appends_shielded_state_pin(self):
+        shielded_state_pin = "44" * 32
+        updated = self.module.replace_assumeutxo_block(
+            BASE_SOURCE,
+            "main",
+            self.snapshot(
+                60760,
+                "1111111111111111111111111111111111111111111111111111111111111111",
+                "2222222222222222222222222222222222222222222222222222222222222222",
+                66221,
+                shielded_state_pin,
+            ),
+            replace_existing=False,
+        )
+
+        self.assertIn(f".shielded_state_commitment = uint256{{\"{shielded_state_pin}\"}}", updated)
+
+    def test_parse_report_reads_shielded_state_pin(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = pathlib.Path(tmpdir) / "snapshot.report.json"
+            report_path.write_text(
+                json.dumps(
+                    {
+                        "chain": "main",
+                        "snapshot": {
+                            "height": 60760,
+                            "txoutset_hash": "11" * 32,
+                            "nchaintx": 66221,
+                            "blockhash": "22" * 32,
+                            "shielded_state_pin": "44" * 32,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            snapshot, chain = self.module.parse_report(report_path)
+
+            self.assertEqual(chain, "main")
+            self.assertEqual(snapshot.shielded_state_pin, "44" * 32)
 
     def test_replace_assumeutxo_block_rejects_conflicting_height_without_replace(self):
         with self.assertRaises(self.module.AssumeutxoApplyError):

--- a/test/util/generate_assumeutxo_test.py
+++ b/test/util/generate_assumeutxo_test.py
@@ -30,6 +30,7 @@ class GenerateAssumeutxoTest(unittest.TestCase):
         self.module = load_module()
 
     def test_build_chainparams_entry_formats_cpp_snippet(self):
+        shielded_state_pin = "44" * 32
         metadata = self.module.AssumeutxoSnapshot(
             height=50000,
             txoutset_hash="0123456789abcdef" * 4,
@@ -38,6 +39,7 @@ class GenerateAssumeutxoTest(unittest.TestCase):
             path="/tmp/utxo.dat",
             snapshot_sha256="f0" * 32,
             snapshot_version=7,
+            shielded_state_pin=shielded_state_pin,
         )
 
         snippet = self.module.build_chainparams_entry(metadata, comment="mainnet snapshot")
@@ -46,12 +48,14 @@ class GenerateAssumeutxoTest(unittest.TestCase):
         self.assertIn(".hash_serialized = AssumeutxoHash{uint256{\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"}}", snippet)
         self.assertIn(".m_chain_tx_count = 777", snippet)
         self.assertIn(".blockhash = consteval_ctor(uint256{\"abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789\"})", snippet)
+        self.assertIn(f".shielded_state_commitment = uint256{{\"{shielded_state_pin}\"}}", snippet)
         self.assertIn("// mainnet snapshot", snippet)
 
     def test_build_report_includes_release_asset_hint(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             snapshot_path = pathlib.Path(tmpdir) / "utxo.dat"
             snapshot_path.write_bytes(b"snapshot")
+            shielded_state_pin = "44" * 32
             metadata = self.module.AssumeutxoSnapshot(
                 height=50000,
                 txoutset_hash="11" * 32,
@@ -60,6 +64,7 @@ class GenerateAssumeutxoTest(unittest.TestCase):
                 path=str(snapshot_path),
                 snapshot_sha256="33" * 32,
                 snapshot_version=7,
+                shielded_state_pin=shielded_state_pin,
             )
 
             report = self.module.build_report(
@@ -75,10 +80,33 @@ class GenerateAssumeutxoTest(unittest.TestCase):
             self.assertEqual(report["snapshot"]["height"], 50000)
             self.assertEqual(report["snapshot"]["sha256"], "33" * 32)
             self.assertEqual(report["snapshot"]["file_version"], 7)
+            self.assertEqual(report["snapshot"]["shielded_state_pin"], shielded_state_pin)
             self.assertIn("m_assumeutxo_data", report["chainparams_snippet"])
+            self.assertIn(".shielded_state_commitment", report["chainparams_snippet"])
             self.assertEqual(report["asset"]["url"], "https://node.btxchain.org/releases/utxo.dat")
             self.assertEqual(report["asset"]["sha256"], "33" * 32)
             self.assertEqual(report["release_asset_manifest"]["snapshot_file_version"], 7)
+            self.assertEqual(report["release_asset_manifest"]["shielded_state_pin"], shielded_state_pin)
+
+    def test_parse_snapshot_metadata_preserves_rpc_shielded_state_pin(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            snapshot_path = pathlib.Path(tmpdir) / "utxo.dat"
+            snapshot_path.write_bytes(b"utxo\xff" + struct.pack("<H", 8) + b"rest")
+            shielded_state_pin = "44" * 32
+
+            metadata = self.module.parse_snapshot_metadata(
+                {
+                    "base_height": 50000,
+                    "txoutset_hash": "11" * 32,
+                    "nchaintx": 888,
+                    "base_hash": "22" * 32,
+                    "shielded_state_pin": shielded_state_pin,
+                },
+                snapshot_path,
+            )
+
+            self.assertEqual(metadata.snapshot_version, 8)
+            self.assertEqual(metadata.shielded_state_pin, shielded_state_pin)
 
     def test_read_snapshot_file_version_reads_header(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- sync additional 0.32.7 updates from private btx-node main
- carry over assumeutxo shielded pin helper updates and tests
- preserve public-only release workflow, Windows clone guidance, and seed-server spec while excluding redteam/

## Verification
- git diff --check
- runbook targeted public-reference check
- filtered rsync dry-run shows only intended public-only divergences: release workflow and Windows handbook