### PR TITLE
cuda: widen ultra-GPU mining defaults for RTX 5090 class hardware

### DIFF
--- a/contrib/mining/cuda-mining-env.sh
+++ b/contrib/mining/cuda-mining-env.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# RTX 5090 / Blackwell (sm_120, 128+ SM) MatMul CUDA mining defaults.
+# Source before starting btxd or the live-mining supervisor.
+#
+# Usage:
+#   source contrib/mining/cuda-mining-env.sh
+#   ./build-cuda/bin/btxd -daemon ...
+#
+# Consensus-safe: these knobs only change scheduling/overlap, not digest math.
+# BTX_MATMUL_CPU_CONFIRM stays enabled so GPU hits are re-verified on CPU.
+
+export BTX_MATMUL_BACKEND=cuda
+export BTX_MATMUL_PIPELINE_ASYNC=1
+export BTX_MATMUL_CPU_CONFIRM=1
+export BTX_MATMUL_GPU_INPUTS=1
+export CUDA_DEVICE_ORDER=PCI_BUS_ID
+
+# Ultra-tier AUTO heuristics (sm >= 128) widen batch/prefetch/pool slots in pow.cpp
+# and matmul_accel.cu. Override one knob at a time when benchmarking:
+#
+# export BTX_MATMUL_SOLVE_BATCH_SIZE=12
+# export BTX_MATMUL_CUDA_POOL_SLOTS=12
+# export BTX_MATMUL_PREPARE_PREFETCH_DEPTH=6
+# export BTX_MATMUL_SOLVER_THREADS=8
+# export BTX_MATMUL_PREPARE_WORKERS=8
+#
+# Single-GPU product-digest mining (mainnet height >= 61000) auto-enables
+# device-prepared inputs. Do not force that path on multi-GPU rigs.
+#
+# Verify the build and runtime:
+#   ./build-cuda/bin/btx-matmul-backend-info --backend cuda
+#   ./build-cuda/bin/btx-matmul-solve-bench --backend cuda --block-height 61000 \
+#     --n 512 --b 16 --r 8 --iterations 20 --tries 4096

--- a/contrib/mining/live-mining-loop.sh
+++ b/contrib/mining/live-mining-loop.sh
@@ -965,7 +965,7 @@ last_peer_refresh_epoch=0
 printf '%s\n' "$$" > "${PIDFILE}"
 trap 'rm -f "${PIDFILE}"' EXIT
 
-log_health "loop-start datadir=${DATADIR:-default} wallet=${WALLET} rpc_restart_threshold=${RPC_RESTART_THRESHOLD} health_restart_threshold=${HEALTH_RESTART_THRESHOLD} peer_remediation_threshold=${PEER_REMEDIATION_THRESHOLD} peer_cache_limit=${PEER_CACHE_LIMIT} peer_refresh_limit=${PEER_REFRESH_LIMIT} healthy_public_peer_target=${HEALTHY_PUBLIC_PEER_TARGET} healthy_full_relay_peer_target=${HEALTHY_FULL_RELAY_PEER_TARGET} sync_stall_restart_secs=${SYNC_STALL_RESTART_SECS} maxconnections=${MAXCONNECTIONS} startup_grace=${STARTUP_GRACE_SECS} node_pidfile=${NODE_PIDFILE}"
+log_health "loop-start datadir=${DATADIR:-default} wallet=${WALLET} matmul_backend=${BTX_MATMUL_BACKEND:-cpu} rpc_restart_threshold=${RPC_RESTART_THRESHOLD} health_restart_threshold=${HEALTH_RESTART_THRESHOLD} peer_remediation_threshold=${PEER_REMEDIATION_THRESHOLD} peer_cache_limit=${PEER_CACHE_LIMIT} peer_refresh_limit=${PEER_REFRESH_LIMIT} healthy_public_peer_target=${HEALTHY_PUBLIC_PEER_TARGET} healthy_full_relay_peer_target=${HEALTHY_FULL_RELAY_PEER_TARGET} sync_stall_restart_secs=${SYNC_STALL_RESTART_SECS} maxconnections=${MAXCONNECTIONS} startup_grace=${STARTUP_GRACE_SECS} node_pidfile=${NODE_PIDFILE}"
 
 while true; do
   ((loop_count += 1))

--- a/contrib/mining/start-cuda-mining.sh
+++ b/contrib/mining/start-cuda-mining.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Load CUDA mining defaults (BTX_MATMUL_BACKEND=cuda, async pipeline, CPU confirm).
+# shellcheck source=contrib/mining/cuda-mining-env.sh
+source "${SCRIPT_DIR}/cuda-mining-env.sh"
+
+DATADIR="${BTX_MINING_DATADIR:-${HOME}/.btx}"
+BUILD_DIR="${BTX_CUDA_BUILD_DIR:-${BTX_MINING_BUILD_DIR:-}}"
+CLI="${BTX_MINING_CLI:-}"
+DAEMON="${BTX_MINING_DAEMON:-}"
+
+print_usage() {
+  cat <<EOF
+Usage: $(basename "$0") [start-live-mining options]
+
+Start BTX solo mining with CUDA MatMul defaults tuned for RTX 5090-class GPUs.
+
+This script:
+  1. exports BTX_MATMUL_BACKEND=cuda and related safe throughput knobs
+  2. prefers binaries from a CUDA build directory when present
+  3. delegates to contrib/mining/start-live-mining.sh
+
+Environment:
+  BTX_CUDA_BUILD_DIR   Directory containing build-cuda/bin/btxd (optional)
+  BTX_MINING_BUILD_DIR Fallback build directory
+  BTX_MINING_DATADIR   BTX datadir (default: ~/.btx)
+
+Build first (Linux + NVIDIA):
+  cmake -S . -B build-cuda \\
+    -DBTX_ENABLE_CUDA_EXPERIMENTAL=ON \\
+    -DBTX_CUDA_ARCHITECTURES=120 \\
+    -DCUDAToolkit_ROOT=/usr/local/cuda
+  cmake --build build-cuda -j"\$(nproc)"
+
+All other flags are forwarded to start-live-mining.sh (--datadir, --wallet, ...).
+EOF
+}
+
+for arg in "$@"; do
+  case "${arg}" in
+    --help|-h)
+      print_usage
+      exit 0
+      ;;
+  esac
+done
+
+resolve_cuda_binary() {
+  local name="$1"
+  local candidate=""
+
+  if [[ -n "${BUILD_DIR}" && -x "${BUILD_DIR}/bin/${name}" ]]; then
+    candidate="${BUILD_DIR}/bin/${name}"
+  elif [[ -x "${SCRIPT_DIR}/../../build-cuda/bin/${name}" ]]; then
+    candidate="$(cd "${SCRIPT_DIR}/../.." && pwd)/build-cuda/bin/${name}"
+  elif [[ -n "${BTX_MINING_BUILD_DIR}" && -x "${BTX_MINING_BUILD_DIR}/bin/${name}" ]]; then
+    candidate="${BTX_MINING_BUILD_DIR}/bin/${name}"
+  fi
+
+  if [[ -n "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+  return 1
+}
+
+if [[ -z "${DAEMON}" ]]; then
+  if resolved="$(resolve_cuda_binary btxd)"; then
+    DAEMON="${resolved}"
+  else
+    DAEMON="${BTX_MINING_DAEMON:-btxd}"
+  fi
+fi
+
+if [[ -z "${CLI}" ]]; then
+  if resolved="$(resolve_cuda_binary btx-cli)"; then
+    CLI="${resolved}"
+  else
+    CLI="${BTX_MINING_CLI:-btx-cli}"
+  fi
+fi
+
+if [[ -x "${DAEMON}" ]]; then
+  backend_info="${DAEMON%/btxd}/btx-matmul-backend-info"
+  if [[ ! -x "${backend_info}" ]]; then
+    backend_info="$(dirname "${DAEMON}")/btx-matmul-backend-info"
+  fi
+  if [[ -x "${backend_info}" ]]; then
+    if ! "${backend_info}" --backend cuda 2>/dev/null | grep -q '"available"[[:space:]]*:[[:space:]]*true'; then
+      echo "Warning: CUDA backend probe failed for ${backend_info}." >&2
+      echo "Build with -DBTX_ENABLE_CUDA_EXPERIMENTAL=ON -DBTX_CUDA_ARCHITECTURES=120" >&2
+    fi
+  fi
+fi
+
+export BTX_MINING_CLI="${CLI}"
+export BTX_MINING_DAEMON="${DAEMON}"
+
+exec "${SCRIPT_DIR}/start-live-mining.sh" "$@"

--- a/src/cuda/matmul_accel.cu
+++ b/src/cuda/matmul_accel.cu
@@ -395,14 +395,15 @@ uint32_t ResolveCudaPoolSlotCount(int device_index)
 
     const uint32_t hw = std::thread::hardware_concurrency();
     const uint32_t cpu_limit =
+        hw >= 32 ? 12U :
         hw >= 24 ? 8U :
         hw >= 16 ? 6U :
         hw >= 12 ? 4U :
         hw >= 8 ? 3U :
         hw >= 4 ? 2U : 1U;
     const uint32_t gpu_limit =
-        multiprocessor_count >= 128 ? 8U :
-        multiprocessor_count >= 96 ? 7U :
+        multiprocessor_count >= 128 ? 12U :
+        multiprocessor_count >= 96 ? 8U :
         multiprocessor_count >= 64 ? 6U :
         multiprocessor_count >= 48 ? 5U :
         multiprocessor_count >= 24 ? 4U :

--- a/src/matmul/accelerated_solver.cpp
+++ b/src/matmul/accelerated_solver.cpp
@@ -22,6 +22,8 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace matmul::accelerated {
 namespace {
@@ -499,23 +501,43 @@ std::vector<DigestResult> ComputeCudaDigestsPreparedBatch(const std::vector<CBlo
 
         std::vector<DigestResult> results;
         results.reserve(prepared_batch.size());
-        for (size_t i = 0; i < prepared_batch.size(); ++i) {
+
+        const auto finalize_batch_entry = [&](size_t index) -> DigestResult {
             const auto words = Span<const field::Element>{
-                cuda_result.words.data() + i * expected_words_per_request,
+                cuda_result.words.data() + index * expected_words_per_request,
                 expected_words_per_request,
             };
-            DigestResult result;
-            result.digest = digest_scheme == DigestScheme::PRODUCT_COMMITTED
+            DigestResult entry;
+            entry.digest = digest_scheme == DigestScheme::PRODUCT_COMMITTED
                 ? transcript::ComputeProductCommittedDigestFromWords(
                       words,
-                      prepared_batch[i].sigma,
-                      blocks[i].matmul_dim,
+                      prepared_batch[index].sigma,
+                      blocks[index].matmul_dim,
                       transcript_block_size)
                 : transcript::FinalizeTranscriptDigestFromWords(words);
-            result.backend = backend::Kind::CUDA;
-            result.accelerated = true;
-            result.ok = true;
-            results.push_back(std::move(result));
+            entry.backend = backend::Kind::CUDA;
+            entry.accelerated = true;
+            entry.ok = true;
+            return entry;
+        };
+
+        const size_t batch_count = prepared_batch.size();
+        const bool parallel_host_finalize =
+            batch_count >= 4 &&
+            std::thread::hardware_concurrency() >= 8;
+        if (parallel_host_finalize) {
+            std::vector<std::future<DigestResult>> futures;
+            futures.reserve(batch_count);
+            for (size_t i = 0; i < batch_count; ++i) {
+                futures.push_back(std::async(std::launch::async, finalize_batch_entry, i));
+            }
+            for (auto& future : futures) {
+                results.push_back(future.get());
+            }
+        } else {
+            for (size_t i = 0; i < batch_count; ++i) {
+                results.push_back(finalize_batch_entry(i));
+            }
         }
         g_cuda_successes.fetch_add(results.size(), std::memory_order_relaxed);
         return results;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -285,6 +285,9 @@ int32_t ResolveDefaultMatMulPrepareWorkerCount()
     const auto backend_selection = matmul::accelerated::ResolveMiningBackendFromEnvironment();
     if (backend_selection.active == matmul::backend::Kind::CUDA) {
         const uint32_t cuda_sm_count = ResolveCudaMultiprocessorCountForHeuristics();
+        if (cuda_sm_count >= 128 && hw >= 16) {
+            return std::clamp<int32_t>(static_cast<int32_t>(hw / 2), 4, 12);
+        }
         if (cuda_sm_count >= 96 && hw >= 16) {
             return std::clamp<int32_t>(static_cast<int32_t>(hw / 2), 2, 8);
         }
@@ -373,6 +376,17 @@ int32_t ResolveMatMulSolverThreadCount()
     if (backend_selection.active == matmul::backend::Kind::CUDA) {
         const uint32_t cuda_sm_count = ResolveCudaMultiprocessorCountForHeuristics();
         const uint32_t hw = std::thread::hardware_concurrency();
+        if (cuda_sm_count >= 128) {
+            if (hw >= 16) {
+                return 8;
+            }
+            if (hw >= 12) {
+                return 6;
+            }
+            if (hw >= 8) {
+                return 5;
+            }
+        }
         if (cuda_sm_count >= 96) {
             if (hw >= 24) {
                 return 8;
@@ -871,6 +885,15 @@ uint32_t ResolvePreparePrefetchDepth(matmul::backend::Kind backend, uint32_t con
         if (configured_batch_size <= 1) {
             return 1;
         }
+        if (cuda_sm_count >= 128) {
+            if (configured_batch_size >= 8) {
+                return 6;
+            }
+            if (configured_batch_size >= 4) {
+                return 5;
+            }
+            return 3;
+        }
         if (cuda_sm_count >= 96) {
             return configured_batch_size >= 6 ? 5 : 4;
         }
@@ -916,7 +939,9 @@ uint32_t ResolveSolveBatchSize(matmul::backend::Kind backend,
         uint32_t batch_size{1};
         if (n >= 512 && transcript_block_size >= 16 && noise_rank >= 8) {
             if (product_digest_active) {
-                if (cuda_sm_count >= 96) {
+                if (cuda_sm_count >= 128) {
+                    batch_size = solver_threads >= 6 ? 12 : 6;
+                } else if (cuda_sm_count >= 96) {
                     batch_size = solver_threads >= 6 ? 8 : 4;
                 } else if (cuda_sm_count >= 64) {
                     batch_size = solver_threads >= 5 ? 6 : 4;


### PR DESCRIPTION
Add an sm>=128 AUTO tier with larger batch/prefetch/pool depth, parallelize CUDA batch host digest finalization, and ship operator scripts for CUDA mining.

<!--
*** Please remove the following help text before submitting: ***

Before opening a pull request to Bitcoin Knots, please first consider if it
is appropriate for Bitcoin Core and, if so, rebase it and [open a pull request](https://github.com/bitcoin/bitcoin/compare)
there first! Bitcoin Core has a strict and slow review process, but since
Knots is more relaxed, feel free to request a merge of your Core PR into
Knots even while it's waiting on Core.

-->

## Validation

- [ ] I listed the tests that cover this change.
- [ ] If this PR touches `src/libbitcoinpqc/**`, I ran `cd src/libbitcoinpqc/fuzz && make fuzz-smoke` and summarized the result below or in a follow-up comment.

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Knots user experience or Bitcoin Knots developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are typically welcome.
* Refactoring changes are never accepted in Knots, and must be performed in
  Bitcoin Core.
-->
