### PR TITLE
Refresh v0.32.11 MatMul seed hardening

### DIFF
--- a/doc/btx-matmul-v3-v03211-edr.md
+++ b/doc/btx-matmul-v3-v03211-edr.md
@@ -1,0 +1,173 @@
+# MatMul v3 / v0.32.11 Engineering Decision Record
+
+Status: accepted for the v0.32.11 posture. This is a decision record, not a
+replacement for the consensus specification in `doc/btx-matmul-pow-spec.md`.
+
+## Decision
+
+BTX keeps MatMul v3 as the canonical proof-of-work posture for v0.32.11. The
+accepted `.11` hardening is narrow: preserve the existing MatMul v3 field,
+dimension, transcript, product-digest, pre-hash gate, and validation model, while
+closing the remaining template-precomputation gap with parent-MTP-bound seed v3.
+
+At and above `nMatMulParentMtpSeedHeight` (mainline height `130500`), deterministic
+matrix seeds are:
+
+```text
+sha256("BTX_MATMUL_SEED_V3" ||
+       prev_block_hash ||
+       parent_median_time_past ||
+       height ||
+       version ||
+       merkle_root ||
+       time ||
+       bits ||
+       nonce64 ||
+       matmul_dim ||
+       which)
+```
+
+Seed v3 supersedes seed v2 only from its activation height forward. Historical
+blocks and pre-activation replay keep their already-defined derivation rules.
+Mining and verification paths must fail closed when seed v3 is active but the
+parent MTP context is unavailable.
+
+## Accepted .11 Changes
+
+- Parent-MTP seed binding is accepted as the canonical `.11` consensus hardening.
+  It prevents one prepared template from being reused across alternate withheld
+  parents while keeping the rule deterministic from committed parent context.
+- CUDA and Metal nonce-seed pre-hash scans may support seed versions 2 and 3, but
+  consensus remains the CPU-defined seed/digest contract. GPU paths must match
+  CPU gate results or fall back/fail visibly.
+- `getmatmulchallenge` work-profile metadata should report the active seed scope
+  as `per_nonce_header_parent_mtp`, with no fixed instance reuse and no "winner
+  knows next seeds first" assumption once seed v3 is active. It should separately
+  disclose that a miner who withholds a valid parent can privately mine
+  descendants until publication, which is standard proof-of-work selfish-mining
+  surface rather than a public/template precomputation channel.
+- Benchmark tooling may expose seed-v3 inputs, including parent MTP, so accepted
+  measurements can be reproduced under the same height, seed version, epsilon,
+  backend, and device conditions.
+- MatMul service-challenge RPCs are accepted as application-side admission-control
+  tools with local/shared replay registries. They are not block consensus, not
+  fork-choice policy, and not a settlement-finality mechanism.
+
+## Deferred Or Rejected v4 Ideas
+
+No MatMul v4 consensus change is accepted in v0.32.11. The following remain
+experimental until a later EDR and activation plan accept them explicitly:
+
+- changing the MatMul field, dimension, transcript ordering, noise rank, digest
+  rule, or validation model;
+- arbitrary external-work / data-availability PoUW inputs;
+- CUDA-only, Metal-only, or other hardware-specific consensus behavior;
+- service-challenge proofs as mining shares, identity proofs, P2P admission, or
+  chain finality;
+- external finality feeds or service-specific anchors that influence BTX
+  consensus or automatic fork choice;
+- CUDA graphs, aggressive kernel layout rewrites, or larger-GPU heuristics as
+  mandatory behavior rather than measured backend optimizations.
+
+Experimental alternatives may be benchmarked and documented, but they do not
+change what nodes accept as valid blocks.
+
+## CUDA CI Requirement
+
+CUDA changes that affect MatMul v3 mining, seed-v3 pre-hash scanning, or CUDA
+benchmark claims require a real NVIDIA Linux lane, not CPU-only CI. The lane must:
+
+- run on a self-hosted NVIDIA host with `nvidia-smi`, `nvcc`, and
+  `BTX_CUDA_ARCHITECTURES` set;
+- configure with `BTX_ENABLE_CUDA_EXPERIMENTAL=ON`, `BUILD_TESTS=ON`,
+  `BUILD_UTIL=ON`, and `BUILD_BENCH=ON`;
+- force CUDA selection during validation with `BTX_MATMUL_BACKEND=cuda`,
+  `BTX_MATMUL_REQUIRE_BACKEND=cuda`, and the intended `BTX_MATMUL_CUDA_DEVICES`;
+- run `scripts/ci/run_cuda_matmul_v3.sh` or an equivalent lane that captures
+  backend info, `MatMulNonceSeed_cuda_prehash_scan_matches_cpu_gate`,
+  `MatMulParentMtpSeed_cuda_prehash_scan_matches_cpu_gate`, strict CUDA solver
+  regressions, `matmul_accelerated_solver_tests`, and seed-v3 solve/cost bench
+  artifacts.
+
+CPU and Metal tests remain required for general validation, but they do not
+establish CUDA correctness or performance.
+
+## Service-Challenge Decision
+
+Service challenges use MatMul as a reusable cost primitive for API gating,
+rate-limiting, agent admission, and similar application workflows. The accepted
+posture is operational:
+
+- challenges are domain-bound and replay-protected by redemption state;
+- shared registry files may be used by service clusters;
+- verification may be local, shared-registry-backed, or stateless depending on
+  the caller's policy;
+- successful redemption proves only that the submitted challenge met its target.
+
+They must not be described as BTX finality, miner authorization, Sybil immunity,
+identity, account ownership, or consensus participation.
+
+`matmul_service_challenge_v1` remains compatible in `.11`, but it is not the
+final adversarial service-gate shape. Its seeds are fixed per challenge, so a
+solver can amortize A/B generation across nonce attempts inside one service
+challenge. That is an off-chain admission-control economics gap, not a block
+consensus flaw.
+
+A later additive `matmul_service_challenge_v2` should use a new domain such as
+`BTX_MATMUL_SERVICE_V2`, keep the challenge id nonce-independent for registry
+and redemption identity, and derive proof seeds as:
+
+```text
+sha256("BTX_MATMUL_SERVICE_V2" ||
+       "seed" ||
+       challenge_id ||
+       anchor_hash ||
+       nonce64 ||
+       label)
+```
+
+The v2 envelope should report `seed_derivation_scope =
+per_service_challenge_nonce` and `fixed_instance_reuse_possible = false`. It
+should be opt-in first; flipping the default would break existing service
+solvers, examples, and issued v1 challenge semantics.
+
+## Benchmark Interpretation
+
+MatMul v3 benchmarks are hardware- and profile-specific engineering evidence.
+Interpret them with the exact parameters attached: `n`, `b`, `r`, height, seed
+version, parent MTP, epsilon bits, backend, device, attempts, thermal state, and
+fallback policy.
+
+Small median differences are not product claims. A CUDA or Metal number is not a
+universal GPU number. A service-challenge solve target is an operator budget, not
+network hashrate. The pre-hash gate reduces expensive MatMul invocations before
+the final digest check; it does not replace the final proof-of-work target.
+
+The repeatable red-team cost matrix is:
+
+```sh
+scripts/ci/run_matmul_v3_experiment_matrix.sh
+```
+
+That matrix records canonical v3 plus deferred variants such as smaller
+dimensions, larger transcript block sizes, disabled pre-hash gating, and higher
+noise rank. Only the canonical v3 case is a release guardrail; the other cases
+exist to show which experimental knobs shift cost toward SHA/matrix expansion or
+away from product-digest work.
+
+## Claims We Must Not Make
+
+Do not claim:
+
+- "final ASIC-resistant";
+- "ASIC-proof";
+- "supersedes all public research";
+- "proves useful work for arbitrary external workloads" for the canonical v3
+  chain rule;
+- "CUDA validated" unless the CUDA hardware lane passed;
+- "service challenges provide finality" or "service challenges are consensus";
+- "v4 is accepted" without a later EDR and activation plan.
+
+The defensible claim is narrower: v0.32.11 keeps MatMul v3 canonical, adds
+parent-MTP seed binding as forward-only hardening, and leaves broader v4 ideas
+experimental.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -3,10 +3,10 @@ BTX version 0.32.11 is now available from:
   <https://github.com/btxchain/btx/releases/tag/v0.32.11>
 
 This v0.32.11 point release rolls in the latest btx-node production hardening
-for shielded-exit velocity accounting, assumeutxo snapshot compatibility, and
-the block-130,000 empty-block subsidy transition. It is intended for nodes,
-miners, pools, exchanges, services, explorers, and wallet operators running the
-0.32.x block-125,000 shielded sunset series.
+for shielded-exit velocity accounting, assumeutxo snapshot compatibility,
+MatMul v3 seed handling, and the block-130,000 empty-block subsidy transition.
+It is intended for nodes, miners, pools, exchanges, services, explorers, and
+wallet operators running the 0.32.x block-125,000 shielded sunset series.
 
 Please report bugs using the issue tracker at GitHub:
 
@@ -38,6 +38,18 @@ nodes should use a v9+ snapshot or reindex/redownload from a non-pruned source.
 BTX is supported on Linux, macOS 13+, and Windows 10+.
 
 # Notable changes
+
+- MatMul v3 parent-MTP seed handling is hardened across CPU, Metal, and CUDA
+  paths. GPU nonce prehash scanning now carries the active seed version and
+  parent median-time-past context so accelerated miners verify the same seed
+  scope as consensus.
+
+- `getmatmulchallenge` work-profile metadata reports the active parent-MTP
+  seed-v3 scope when it is active, distinguishing public template
+  precomputation from ordinary private parent withholding.
+
+- MatMul v3 benchmark and CI helper scripts were added for CPU, Metal, and
+  CUDA validation of seed-v3 behavior and cost measurements.
 
 - Shielded unshield-velocity state is now part of the persisted shielded state
   and v9 assumeutxo snapshot section. This lets snapshot-started nodes evaluate

--- a/doc/release-notes/release-notes-0.32.11.md
+++ b/doc/release-notes/release-notes-0.32.11.md
@@ -3,10 +3,10 @@ BTX version 0.32.11 is now available from:
   <https://github.com/btxchain/btx/releases/tag/v0.32.11>
 
 This v0.32.11 point release rolls in the latest btx-node production hardening
-for shielded-exit velocity accounting, assumeutxo snapshot compatibility, and
-the block-130,000 empty-block subsidy transition. It is intended for nodes,
-miners, pools, exchanges, services, explorers, and wallet operators running the
-0.32.x block-125,000 shielded sunset series.
+for shielded-exit velocity accounting, assumeutxo snapshot compatibility,
+MatMul v3 seed handling, and the block-130,000 empty-block subsidy transition.
+It is intended for nodes, miners, pools, exchanges, services, explorers, and
+wallet operators running the 0.32.x block-125,000 shielded sunset series.
 
 Please report bugs using the issue tracker at GitHub:
 
@@ -38,6 +38,18 @@ nodes should use a v9+ snapshot or reindex/redownload from a non-pruned source.
 BTX is supported on Linux, macOS 13+, and Windows 10+.
 
 # Notable changes
+
+- MatMul v3 parent-MTP seed handling is hardened across CPU, Metal, and CUDA
+  paths. GPU nonce prehash scanning now carries the active seed version and
+  parent median-time-past context so accelerated miners verify the same seed
+  scope as consensus.
+
+- `getmatmulchallenge` work-profile metadata reports the active parent-MTP
+  seed-v3 scope when it is active, distinguishing public template
+  precomputation from ordinary private parent withholding.
+
+- MatMul v3 benchmark and CI helper scripts were added for CPU, Metal, and
+  CUDA validation of seed-v3 behavior and cost measurements.
 
 - Shielded unshield-velocity state is now part of the persisted shielded state
   and v9 assumeutxo snapshot section. This lets snapshot-started nodes evaluate

--- a/scripts/ci/run_cuda_matmul_v3.sh
+++ b/scripts/ci/run_cuda_matmul_v3.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ci/run_cuda_matmul_v3.sh
+
+Configure, build, and run the CUDA MatMul v3 verification lane on a self-hosted
+NVIDIA Linux machine.
+
+Required environment:
+  BTX_CUDA_ARCHITECTURES   Semicolon-separated CUDA SM architectures, e.g. "86;89;120"
+
+Optional environment:
+  BUILD_DIR                Build directory (default: build-cuda)
+  CUDA_DEVICE              CUDA device index for benchmarks (default: 0)
+  CUDAToolkit_ROOT         CUDA toolkit root, e.g. /usr/local/cuda
+  CMAKE_CUDA_COMPILER      nvcc path, e.g. /usr/local/cuda/bin/nvcc
+  CMAKE_GENERATOR          CMake generator (default: Ninja)
+  CMAKE_BUILD_TYPE         Build type (default: RelWithDebInfo)
+  CUDA_ARTIFACT_DIR        JSON/log output directory (default: <BUILD_DIR>/cuda-matmul-v3-artifacts)
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "${BTX_CUDA_ARCHITECTURES:-}" ]]; then
+  echo "error: BTX_CUDA_ARCHITECTURES is required, e.g. BTX_CUDA_ARCHITECTURES='86;89;120'" >&2
+  exit 1
+fi
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  echo "error: nvidia-smi not found; this lane requires an NVIDIA host" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq not found; this lane requires jq for JSON assertions" >&2
+  exit 1
+fi
+
+if [[ -n "${CMAKE_CUDA_COMPILER:-}" ]]; then
+  NVCC="${CMAKE_CUDA_COMPILER}"
+elif command -v nvcc >/dev/null 2>&1; then
+  NVCC="$(command -v nvcc)"
+else
+  echo "error: nvcc not found; set CMAKE_CUDA_COMPILER or install CUDA toolkit" >&2
+  exit 1
+fi
+
+nproc_detect() {
+  if command -v nproc >/dev/null 2>&1; then
+    nproc
+  elif command -v getconf >/dev/null 2>&1; then
+    getconf _NPROCESSORS_ONLN
+  else
+    echo 4
+  fi
+}
+
+BUILD_DIR="${BUILD_DIR:-build-cuda}"
+CUDA_DEVICE="${CUDA_DEVICE:-0}"
+CMAKE_GENERATOR="${CMAKE_GENERATOR:-Ninja}"
+CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}"
+CUDA_ARTIFACT_DIR="${CUDA_ARTIFACT_DIR:-${BUILD_DIR}/cuda-matmul-v3-artifacts}"
+mkdir -p "${CUDA_ARTIFACT_DIR}"
+
+cmake_args=(
+  -S .
+  -B "${BUILD_DIR}"
+  -G "${CMAKE_GENERATOR}"
+  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
+  -DBUILD_TESTS=ON
+  -DBUILD_UTIL=ON
+  -DBUILD_BENCH=ON
+  -DBTX_ENABLE_CUDA_EXPERIMENTAL=ON
+  -DBTX_CUDA_ARCHITECTURES="${BTX_CUDA_ARCHITECTURES}"
+  -DCMAKE_CUDA_COMPILER="${NVCC}"
+)
+
+if [[ -n "${CUDAToolkit_ROOT:-}" ]]; then
+  cmake_args+=("-DCUDAToolkit_ROOT=${CUDAToolkit_ROOT}")
+fi
+
+cmake "${cmake_args[@]}"
+
+cmake --build "${BUILD_DIR}" \
+  --target btx-matmul-backend-info btx-matmul-solve-bench btx-matmul-cost-bench test_btx bench_btx \
+  -j"$(nproc_detect)"
+
+echo "CUDA host:" | tee "${CUDA_ARTIFACT_DIR}/nvidia-smi.log"
+nvidia-smi | tee -a "${CUDA_ARTIFACT_DIR}/nvidia-smi.log"
+"${NVCC}" --version | tee "${CUDA_ARTIFACT_DIR}/nvcc-version.log"
+
+BTX_MATMUL_BACKEND=cuda \
+BTX_MATMUL_REQUIRE_BACKEND=cuda \
+BTX_MATMUL_CUDA_DEVICES="${CUDA_DEVICE}" \
+  "${BUILD_DIR}/bin/btx-matmul-backend-info" --backend cuda \
+  | tee "${CUDA_ARTIFACT_DIR}/backend-info.json"
+
+jq -e '
+  .active_backend == "cuda" and
+  .capabilities.cuda.compiled == true and
+  .capabilities.cuda.available == true and
+  .cuda_runtime.available == true and
+  .cuda_runtime.selected_device_count > 0
+' "${CUDA_ARTIFACT_DIR}/backend-info.json" >/dev/null
+
+run_test() {
+  local name="$1"
+  BTX_MATMUL_BACKEND=cuda \
+  BTX_MATMUL_REQUIRE_BACKEND=cuda \
+  BTX_MATMUL_GPU_INPUTS=1 \
+  BTX_MATMUL_CUDA_DEVICES="${CUDA_DEVICE}" \
+    "${BUILD_DIR}/bin/test_btx" --run_test="${name}" --catch_system_errors=no \
+    | tee "${CUDA_ARTIFACT_DIR}/test-${name//\//-}.log"
+}
+
+run_test 'pow_tests/MatMulNonceSeed_cuda_prehash_scan_matches_cpu_gate'
+run_test 'pow_tests/MatMulParentMtpSeed_cuda_prehash_scan_matches_cpu_gate'
+run_test 'pow_tests/MatMulParentMtpSeed_cuda_solver_uses_gpu_scan_and_variable_base_batch'
+run_test 'pow_tests/MatMulNonceSeed_cuda_batch_override_accepts_large_batch'
+run_test 'pow_tests/matmul_solve_uses_cuda_batch_defaults_when_backend_is_available'
+run_test 'pow_tests/matmul_solve_enables_cpu_confirm_for_cuda_in_strict_mode'
+run_test 'pow_tests/cuda_strict_regtest_warning_repro_solves_without_digest_divergence'
+run_test 'matmul_accelerated_solver_tests'
+
+BTX_MATMUL_BACKEND=cuda \
+BTX_MATMUL_REQUIRE_BACKEND=cuda \
+BTX_MATMUL_GPU_INPUTS=1 \
+BTX_MATMUL_CUDA_DEVICES="${CUDA_DEVICE}" \
+  "${BUILD_DIR}/bin/btx-matmul-solve-bench" \
+    --backend cuda \
+    --iterations 3 \
+    --tries 4194304 \
+    --n 512 --b 16 --r 8 \
+    --epsilon-bits 18 \
+    --block-height 130500 \
+    --nonce-seed-height 125000 \
+    --parent-mtp-seed-height 130500 \
+    --parent-mtp 1780000000 \
+    --product-digest-height 61000 \
+  | tee "${CUDA_ARTIFACT_DIR}/solve-v3-mainnet-like.json"
+
+jq -e '
+  .active_backend == "cuda" and
+  .options.parent_mtp_seed_active == true and
+  .last_backend_runtime_stats.requested_cuda > 0 and
+  .last_backend_runtime_stats.cuda_successes > 0 and
+  .last_backend_runtime_stats.cuda_fallbacks_to_cpu == 0 and
+  .last_pipeline_stats.batched_digest_requests > 0 and
+  .last_pipeline_stats.batched_nonce_attempts > 0
+' "${CUDA_ARTIFACT_DIR}/solve-v3-mainnet-like.json" >/dev/null
+
+"${BUILD_DIR}/bin/btx-matmul-cost-bench" \
+  --iterations 3 \
+  --n 512 --b 16 --r 8 \
+  --epsilon-bits 18 \
+  --seed-version 3 \
+  --block-height 130500 \
+  --parent-mtp 1780000000 \
+  | tee "${CUDA_ARTIFACT_DIR}/cost-v3-mainnet-like.json"
+
+echo "CUDA MatMul v3 lane complete. Artifacts: ${CUDA_ARTIFACT_DIR}"

--- a/scripts/ci/run_matmul_v3_experiment_matrix.sh
+++ b/scripts/ci/run_matmul_v3_experiment_matrix.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+export LC_ALL=C
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/ci/run_matmul_v3_experiment_matrix.sh
+
+Runs a repeatable MatMul v3 cost matrix for canonical and experimental parameter
+sets. The script records the measurements and fails only on canonical v3 guardrail
+regressions that would indicate the work has shifted away from the intended
+GEMM/product-digest dominated profile.
+
+Optional environment:
+  BUILD_DIR                                      Build directory (default: build-btx)
+  BTX_MATMUL_EXPERIMENT_ARTIFACT_DIR             Output directory (default: <BUILD_DIR>/matmul-v3-experiment-artifacts)
+  BTX_MATMUL_EXPERIMENT_ITERATIONS               Iterations per normal case (default: 2)
+  BTX_MATMUL_EXPERIMENT_FULL                     Include heavier n=1024 case when set to 1 (default: 0)
+  BTX_MATMUL_MIN_CANONICAL_PRODUCT_SHARE         Minimum canonical product share (default: 0.45)
+  BTX_MATMUL_MAX_CANONICAL_GATE_SHARE            Maximum canonical SHA/gate share (default: 0.02)
+  BTX_MATMUL_MAX_CANONICAL_MATRIX_VS_PRODUCT     Maximum canonical matrix/product ratio (default: 1.0)
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required for MatMul experiment matrix summaries" >&2
+  exit 1
+fi
+
+BUILD_DIR="${BUILD_DIR:-build-btx}"
+ARTIFACT_DIR="${BTX_MATMUL_EXPERIMENT_ARTIFACT_DIR:-${BUILD_DIR}/matmul-v3-experiment-artifacts}"
+ITERATIONS="${BTX_MATMUL_EXPERIMENT_ITERATIONS:-2}"
+FULL="${BTX_MATMUL_EXPERIMENT_FULL:-0}"
+MIN_CANONICAL_PRODUCT_SHARE="${BTX_MATMUL_MIN_CANONICAL_PRODUCT_SHARE:-0.45}"
+MAX_CANONICAL_GATE_SHARE="${BTX_MATMUL_MAX_CANONICAL_GATE_SHARE:-0.02}"
+MAX_CANONICAL_MATRIX_VS_PRODUCT="${BTX_MATMUL_MAX_CANONICAL_MATRIX_VS_PRODUCT:-1.0}"
+
+BENCH="${BUILD_DIR}/bin/btx-matmul-cost-bench"
+if [[ ! -x "${BENCH}" ]]; then
+  echo "error: missing benchmark binary: ${BENCH}" >&2
+  echo "hint: build with BUILD_UTIL=ON and target btx-matmul-cost-bench" >&2
+  exit 1
+fi
+
+mkdir -p "${ARTIFACT_DIR}"
+SUMMARY_NDJSON="${ARTIFACT_DIR}/summary.ndjson"
+SUMMARY_JSON="${ARTIFACT_DIR}/summary.json"
+: > "${SUMMARY_NDJSON}"
+
+run_case() {
+  local name="$1"
+  local classification="$2"
+  shift 2
+  local out="${ARTIFACT_DIR}/cost-${name}.json"
+
+  echo "MatMul experiment: ${name} (${classification})"
+  "${BENCH}" "$@" | tee "${out}" >/dev/null
+  jq -c --arg name "${name}" --arg classification "${classification}" \
+    '{
+      case: $name,
+      classification: $classification,
+      n: .options.n,
+      b: .options.b,
+      r: .options.r,
+      epsilon_bits: .options.epsilon_bits,
+      seed_version: .options.seed_version,
+      pass_probability: .amortized_per_scanned_nonce.pre_hash_gate_pass_probability_estimate,
+      gate_share: .amortized_per_scanned_nonce.gate_hash_share,
+      matrix_share: .amortized_per_scanned_nonce.matrix_generation_share,
+      product_share: .amortized_per_scanned_nonce.product_digest_share,
+      matrix_vs_product: .ratios.matrix_generation_vs_product_digest,
+      accepted_total_us: .timings.accepted_candidate_total.mean_us,
+      matrix_us: .timings.matrix_generation_ab.mean_us,
+      product_us: .timings.product_digest_dense.mean_us
+    }' "${out}" | tee -a "${SUMMARY_NDJSON}"
+}
+
+common_v3_args=(
+  --seed-version 3
+  --block-height 130500
+  --parent-mtp 1780000000
+)
+
+run_case canonical_mainnet_v3 accepted \
+  --iterations "${ITERATIONS}" \
+  --n 512 --b 16 --r 8 \
+  --epsilon-bits 18 \
+  "${common_v3_args[@]}"
+
+run_case no_gate_v3 diagnostic \
+  --iterations "${ITERATIONS}" \
+  --n 512 --b 16 --r 8 \
+  --epsilon-bits 0 \
+  "${common_v3_args[@]}"
+
+run_case small_n256_v3 deferred_cpu_bias_risk \
+  --iterations "${ITERATIONS}" \
+  --n 256 --b 8 --r 4 \
+  --epsilon-bits 18 \
+  "${common_v3_args[@]}"
+
+run_case high_noise_r16 diagnostic \
+  --iterations "${ITERATIONS}" \
+  --n 512 --b 16 --r 16 \
+  --epsilon-bits 18 \
+  "${common_v3_args[@]}"
+
+run_case block32_v3 deferred_digest_reduction_risk \
+  --iterations "${ITERATIONS}" \
+  --n 512 --b 32 --r 8 \
+  --epsilon-bits 18 \
+  "${common_v3_args[@]}"
+
+if [[ "${FULL}" == "1" ]]; then
+  run_case large_n1024_v3 deferred_cost_increase \
+    --iterations 1 \
+    --n 1024 --b 16 --r 8 \
+    --epsilon-bits 18 \
+    "${common_v3_args[@]}"
+fi
+
+jq -s '.' "${SUMMARY_NDJSON}" > "${SUMMARY_JSON}"
+
+CANONICAL_JSON="${ARTIFACT_DIR}/cost-canonical_mainnet_v3.json"
+jq -e \
+  --argjson min_product "${MIN_CANONICAL_PRODUCT_SHARE}" \
+  --argjson max_gate "${MAX_CANONICAL_GATE_SHARE}" \
+  --argjson max_matrix_vs_product "${MAX_CANONICAL_MATRIX_VS_PRODUCT}" \
+  '.amortized_per_scanned_nonce.product_digest_share >= $min_product and
+   .amortized_per_scanned_nonce.gate_hash_share <= $max_gate and
+   .ratios.matrix_generation_vs_product <= $max_matrix_vs_product' \
+  "${CANONICAL_JSON}" >/dev/null
+
+echo "MatMul v3 experiment matrix complete. Summary: ${SUMMARY_JSON}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -903,6 +903,22 @@ if(BUILD_UTIL)
   endif()
   install_binary_component(btx-matmul-solve-bench)
 
+  add_executable(btx-matmul-cost-bench btx-matmul-cost-bench.cpp)
+  target_include_directories(btx-matmul-cost-bench PRIVATE
+    $<TARGET_PROPERTY:univalue,INTERFACE_INCLUDE_DIRECTORIES>
+  )
+  target_link_libraries(btx-matmul-cost-bench
+    core_interface
+  )
+  if(UNIX AND NOT APPLE)
+    target_link_btx_linux_archive_group(btx-matmul-cost-bench ${BTX_BASE_ARCHIVES})
+  else()
+    target_link_libraries(btx-matmul-cost-bench
+      bitcoin_shielded
+    )
+  endif()
+  install_binary_component(btx-matmul-cost-bench)
+
   add_executable(btx-genesis btx-genesis.cpp)
   target_link_libraries(btx-genesis
     core_interface

--- a/src/btx-matmul-cost-bench.cpp
+++ b/src/btx-matmul-cost-bench.cpp
@@ -1,0 +1,471 @@
+// Copyright (c) 2026 The BTX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <arith_uint256.h>
+#include <chainparams.h>
+#include <common/args.h>
+#include <matmul/matmul_pow.h>
+#include <matmul/matrix.h>
+#include <matmul/noise.h>
+#include <matmul/transcript.h>
+#include <pow.h>
+#include <primitives/block.h>
+#include <uint256.h>
+#include <util/chaintype.h>
+#include <util/translation.h>
+
+#include <univalue.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+const TranslateFn G_TRANSLATION_FUN{nullptr};
+
+namespace {
+
+struct Options {
+    uint32_t iterations{3};
+    uint32_t n{512};
+    uint32_t b{16};
+    uint32_t r{8};
+    uint32_t nbits{0x1e063c74U};
+    uint32_t epsilon_bits{18};
+    uint32_t seed_version{3};
+    int32_t block_height{130'500};
+    int64_t parent_mtp{1'780'000'000};
+};
+
+struct Timings {
+    double seed_derivation_us{0.0};
+    double matrix_generation_us{0.0};
+    double sigma_us{0.0};
+    double noise_generation_us{0.0};
+    double perturbation_us{0.0};
+    double product_digest_us{0.0};
+    double accepted_candidate_total_us{0.0};
+};
+
+std::optional<uint64_t> ParseUintArg(std::string_view text)
+{
+    try {
+        size_t consumed{0};
+        std::string value_text{text};
+        int base{10};
+        if (value_text.size() > 2 &&
+            value_text[0] == '0' &&
+            (value_text[1] == 'x' || value_text[1] == 'X')) {
+            base = 16;
+        }
+        const uint64_t value = std::stoull(value_text, &consumed, base);
+        if (consumed != text.size()) return std::nullopt;
+        return value;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+bool ParseInt64Arg(std::string_view text, int64_t& out)
+{
+    try {
+        size_t consumed{0};
+        const long long parsed = std::stoll(std::string{text}, &consumed, 10);
+        if (consumed != text.size()) return false;
+        out = parsed;
+        return true;
+    } catch (const std::exception&) {
+        return false;
+    }
+}
+
+uint256 ParseUint256(std::string_view hex)
+{
+    const auto parsed = uint256::FromHex(hex);
+    if (!parsed.has_value()) {
+        throw std::runtime_error("invalid uint256 literal in matmul cost benchmark");
+    }
+    return *parsed;
+}
+
+void PrintUsage(std::ostream& out)
+{
+    out << "Usage: btx-matmul-cost-bench"
+        << " [--iterations <count>] [--n <dim>] [--b <block>] [--r <rank>]"
+        << " [--nbits <compact>] [--epsilon-bits <count>]"
+        << " [--seed-version <2|3>] [--block-height <height>] [--parent-mtp <time>]"
+        << std::endl;
+}
+
+bool ParseArgs(int argc, char* argv[], Options& options)
+{
+    auto parse_uint32 = [&](std::string_view arg_name, std::string_view value, uint32_t& out) -> bool {
+        const auto parsed = ParseUintArg(value);
+        if (!parsed.has_value() || *parsed == 0 || *parsed > std::numeric_limits<uint32_t>::max()) {
+            std::cerr << "error: invalid value for " << arg_name << ": " << value << std::endl;
+            return false;
+        }
+        out = static_cast<uint32_t>(*parsed);
+        return true;
+    };
+    auto parse_uint32_allow_zero = [&](std::string_view arg_name, std::string_view value, uint32_t& out) -> bool {
+        const auto parsed = ParseUintArg(value);
+        if (!parsed.has_value() || *parsed > std::numeric_limits<uint32_t>::max()) {
+            std::cerr << "error: invalid value for " << arg_name << ": " << value << std::endl;
+            return false;
+        }
+        out = static_cast<uint32_t>(*parsed);
+        return true;
+    };
+
+    auto parse_int32 = [&](std::string_view arg_name, std::string_view value, int32_t& out) -> bool {
+        int64_t parsed{0};
+        if (!ParseInt64Arg(value, parsed) ||
+            parsed < std::numeric_limits<int32_t>::min() ||
+            parsed > std::numeric_limits<int32_t>::max()) {
+            std::cerr << "error: invalid value for " << arg_name << ": " << value << std::endl;
+            return false;
+        }
+        out = static_cast<int32_t>(parsed);
+        return true;
+    };
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg{argv[i]};
+        if (arg == "--help" || arg == "-h") {
+            PrintUsage(std::cout);
+            return false;
+        }
+
+        auto parse_kv = [&](std::string_view name, auto&& setter) -> bool {
+            const std::string prefix = std::string{name} + "=";
+            if (arg.rfind(prefix, 0) == 0) {
+                return setter(std::string_view{arg}.substr(prefix.size()));
+            }
+            if (arg == name) {
+                if (i + 1 >= argc) {
+                    std::cerr << "error: " << name << " requires a value" << std::endl;
+                    return false;
+                }
+                return setter(argv[++i]);
+            }
+            return true;
+        };
+
+        bool consumed = false;
+        if (arg == "--iterations" || arg.rfind("--iterations=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--iterations", [&](std::string_view value) { return parse_uint32("--iterations", value, options.iterations); })) return false;
+        } else if (arg == "--n" || arg.rfind("--n=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--n", [&](std::string_view value) { return parse_uint32("--n", value, options.n); })) return false;
+        } else if (arg == "--b" || arg.rfind("--b=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--b", [&](std::string_view value) { return parse_uint32("--b", value, options.b); })) return false;
+        } else if (arg == "--r" || arg.rfind("--r=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--r", [&](std::string_view value) { return parse_uint32("--r", value, options.r); })) return false;
+        } else if (arg == "--nbits" || arg.rfind("--nbits=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--nbits", [&](std::string_view value) { return parse_uint32("--nbits", value, options.nbits); })) return false;
+        } else if (arg == "--epsilon-bits" || arg.rfind("--epsilon-bits=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--epsilon-bits", [&](std::string_view value) { return parse_uint32_allow_zero("--epsilon-bits", value, options.epsilon_bits); })) return false;
+        } else if (arg == "--seed-version" || arg.rfind("--seed-version=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--seed-version", [&](std::string_view value) {
+                    if (!parse_uint32("--seed-version", value, options.seed_version)) return false;
+                    if (options.seed_version != 2 && options.seed_version != 3) {
+                        std::cerr << "error: --seed-version must be 2 or 3" << std::endl;
+                        return false;
+                    }
+                    return true;
+                })) return false;
+        } else if (arg == "--block-height" || arg.rfind("--block-height=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--block-height", [&](std::string_view value) { return parse_int32("--block-height", value, options.block_height); })) return false;
+        } else if (arg == "--parent-mtp" || arg.rfind("--parent-mtp=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--parent-mtp", [&](std::string_view value) {
+                    if (!ParseInt64Arg(value, options.parent_mtp)) {
+                        std::cerr << "error: invalid value for --parent-mtp: " << value << std::endl;
+                        return false;
+                    }
+                    return true;
+                })) return false;
+        }
+
+        if (!consumed) {
+            std::cerr << "error: unknown argument: " << arg << std::endl;
+            PrintUsage(std::cerr);
+            return false;
+        }
+    }
+    return true;
+}
+
+CBlockHeader BuildCandidateHeader(uint32_t n, uint32_t nbits, uint64_t nonce64)
+{
+    CBlockHeader candidate{};
+    candidate.nVersion = 4;
+    candidate.hashPrevBlock = ParseUint256("0000000000000000000000000000000000000000000000000000000000000011");
+    candidate.hashMerkleRoot = ParseUint256("0000000000000000000000000000000000000000000000000000000000000022");
+    candidate.nTime = 1'773'277'390U;
+    candidate.nBits = nbits;
+    candidate.nNonce64 = nonce64;
+    candidate.nNonce = static_cast<uint32_t>(nonce64);
+    candidate.matmul_dim = static_cast<uint16_t>(n);
+    candidate.matmul_digest.SetNull();
+    return candidate;
+}
+
+template <typename F>
+double TimeUs(F&& func)
+{
+    const auto start = std::chrono::steady_clock::now();
+    func();
+    const auto stop = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::micro>(stop - start).count();
+}
+
+double Mean(const std::vector<double>& values)
+{
+    if (values.empty()) return 0.0;
+    return std::accumulate(values.begin(), values.end(), 0.0) / static_cast<double>(values.size());
+}
+
+double Median(std::vector<double> values)
+{
+    if (values.empty()) return 0.0;
+    std::sort(values.begin(), values.end());
+    const size_t mid = values.size() / 2;
+    if ((values.size() & 1U) == 0U) return (values[mid - 1] + values[mid]) / 2.0;
+    return values[mid];
+}
+
+UniValue SummarizeSeries(const std::vector<double>& values)
+{
+    UniValue out(UniValue::VOBJ);
+    out.pushKV("count", static_cast<uint64_t>(values.size()));
+    if (values.empty()) {
+        out.pushKV("mean_us", 0.0);
+        out.pushKV("median_us", 0.0);
+        out.pushKV("min_us", 0.0);
+        out.pushKV("max_us", 0.0);
+        return out;
+    }
+
+    const auto [min_it, max_it] = std::minmax_element(values.begin(), values.end());
+    out.pushKV("mean_us", Mean(values));
+    out.pushKV("median_us", Median(values));
+    out.pushKV("min_us", *min_it);
+    out.pushKV("max_us", *max_it);
+    return out;
+}
+
+void AppendTiming(std::vector<double>& values, double value)
+{
+    values.push_back(value);
+}
+
+arith_uint256 SaturatingLeftShiftLocal(const arith_uint256& value, uint32_t shift)
+{
+    if (shift == 0 || value == 0) return value;
+    if (shift >= 256) return ~arith_uint256{0};
+    arith_uint256 mask = ~arith_uint256{0};
+    mask >>= shift;
+    if (value > mask) return ~arith_uint256{0};
+    return value << shift;
+}
+
+} // namespace
+
+int main(int argc, char* argv[])
+{
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg{argv[i]};
+        if (arg == "--help" || arg == "-h") {
+            PrintUsage(std::cout);
+            return 0;
+        }
+    }
+
+    Options options;
+    if (!ParseArgs(argc, argv, options)) return argc > 1 ? 1 : 0;
+    if (options.n == 0 || options.b == 0 || options.r == 0 ||
+        options.n % options.b != 0 || options.r > options.n ||
+        options.n > std::numeric_limits<uint16_t>::max()) {
+        std::cerr << "error: invalid MatMul dimensions" << std::endl;
+        return 1;
+    }
+
+    std::vector<double> seed_derivation;
+    std::vector<double> matrix_generation;
+    std::vector<double> sigma;
+    std::vector<double> noise_generation;
+    std::vector<double> perturbation;
+    std::vector<double> product_digest;
+    std::vector<double> accepted_total;
+    seed_derivation.reserve(options.iterations);
+    matrix_generation.reserve(options.iterations);
+    sigma.reserve(options.iterations);
+    noise_generation.reserve(options.iterations);
+    perturbation.reserve(options.iterations);
+    product_digest.reserve(options.iterations);
+    accepted_total.reserve(options.iterations);
+
+    std::vector<uint256> digest_sink;
+    digest_sink.reserve(options.iterations);
+
+    for (uint32_t i = 0; i < options.iterations; ++i) {
+        Timings timings;
+        CBlockHeader candidate = BuildCandidateHeader(options.n, options.nbits, i + 1);
+
+        const auto candidate_start = std::chrono::steady_clock::now();
+        timings.seed_derivation_us = TimeUs([&] {
+            if (options.seed_version == 3) {
+                candidate.seed_a = DeterministicMatMulSeedV3(candidate, static_cast<uint32_t>(options.block_height), options.parent_mtp, 0);
+                candidate.seed_b = DeterministicMatMulSeedV3(candidate, static_cast<uint32_t>(options.block_height), options.parent_mtp, 1);
+            } else {
+                candidate.seed_a = DeterministicMatMulSeedV2(candidate, static_cast<uint32_t>(options.block_height), 0);
+                candidate.seed_b = DeterministicMatMulSeedV2(candidate, static_cast<uint32_t>(options.block_height), 1);
+            }
+        });
+
+        matmul::Matrix a(1, 1);
+        matmul::Matrix b_matrix(1, 1);
+        timings.matrix_generation_us = TimeUs([&] {
+            a = matmul::FromSeed(candidate.seed_a, options.n);
+            b_matrix = matmul::FromSeed(candidate.seed_b, options.n);
+        });
+
+        uint256 candidate_sigma;
+        timings.sigma_us = TimeUs([&] {
+            candidate_sigma = matmul::DeriveSigma(candidate);
+        });
+
+        std::optional<matmul::noise::NoisePair> noise;
+        timings.noise_generation_us = TimeUs([&] {
+            noise = matmul::noise::Generate(candidate_sigma, options.n, options.r);
+        });
+
+        matmul::Matrix a_prime(1, 1);
+        matmul::Matrix b_prime(1, 1);
+        timings.perturbation_us = TimeUs([&] {
+            const matmul::Matrix e = noise->E_L * noise->E_R;
+            const matmul::Matrix f = noise->F_L * noise->F_R;
+            a_prime = a + e;
+            b_prime = b_matrix + f;
+        });
+
+        uint256 digest;
+        timings.product_digest_us = TimeUs([&] {
+            digest = matmul::transcript::ComputeProductCommittedDigestFromPerturbed(
+                a_prime,
+                b_prime,
+                options.b,
+                candidate_sigma);
+        });
+        const auto candidate_stop = std::chrono::steady_clock::now();
+        timings.accepted_candidate_total_us =
+            std::chrono::duration<double, std::micro>(candidate_stop - candidate_start).count();
+        digest_sink.push_back(digest);
+
+        AppendTiming(seed_derivation, timings.seed_derivation_us);
+        AppendTiming(matrix_generation, timings.matrix_generation_us);
+        AppendTiming(sigma, timings.sigma_us);
+        AppendTiming(noise_generation, timings.noise_generation_us);
+        AppendTiming(perturbation, timings.perturbation_us);
+        AppendTiming(product_digest, timings.product_digest_us);
+        AppendTiming(accepted_total, timings.accepted_candidate_total_us);
+    }
+
+    const double mean_total = Mean(accepted_total);
+    const double mean_matrix = Mean(matrix_generation);
+    const double mean_digest = Mean(product_digest);
+    const double mean_noise = Mean(noise_generation);
+    const double mean_perturbation = Mean(perturbation);
+    const double mean_seed = Mean(seed_derivation);
+    const double mean_sigma = Mean(sigma);
+
+    double pre_hash_pass_probability = 1.0;
+    if (options.epsilon_bits > 0) {
+        if (const auto target = DeriveTarget(options.nbits, uint256{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"})) {
+            constexpr double kTwoToMinus256 = 8.6361685550944446253863518628003995711160003644363e-78;
+            const arith_uint256 sigma_target = SaturatingLeftShiftLocal(*target, options.epsilon_bits);
+            pre_hash_pass_probability = std::min(1.0, sigma_target.getdouble() * kTwoToMinus256);
+        }
+    }
+    const double gate_hash_us = mean_seed + mean_sigma;
+    const double expensive_candidate_us = mean_matrix + mean_noise + mean_perturbation + mean_digest;
+    const double amortized_per_scanned_nonce_us = gate_hash_us + pre_hash_pass_probability * expensive_candidate_us;
+
+    UniValue output(UniValue::VOBJ);
+    UniValue options_obj(UniValue::VOBJ);
+    options_obj.pushKV("iterations", options.iterations);
+    options_obj.pushKV("n", options.n);
+    options_obj.pushKV("b", options.b);
+    options_obj.pushKV("r", options.r);
+    options_obj.pushKV("nbits", options.nbits);
+    options_obj.pushKV("epsilon_bits", options.epsilon_bits);
+    options_obj.pushKV("seed_version", options.seed_version);
+    options_obj.pushKV("block_height", options.block_height);
+    options_obj.pushKV("parent_mtp", options.parent_mtp);
+    output.pushKV("options", std::move(options_obj));
+
+    UniValue timings_obj(UniValue::VOBJ);
+    timings_obj.pushKV("seed_derivation", SummarizeSeries(seed_derivation));
+    timings_obj.pushKV("matrix_generation_ab", SummarizeSeries(matrix_generation));
+    timings_obj.pushKV("sigma", SummarizeSeries(sigma));
+    timings_obj.pushKV("noise_generation", SummarizeSeries(noise_generation));
+    timings_obj.pushKV("perturbation", SummarizeSeries(perturbation));
+    timings_obj.pushKV("product_digest_dense", SummarizeSeries(product_digest));
+    timings_obj.pushKV("accepted_candidate_total", SummarizeSeries(accepted_total));
+    output.pushKV("timings", std::move(timings_obj));
+
+    UniValue ratios(UniValue::VOBJ);
+    ratios.pushKV("matrix_generation_share_of_accepted_total", mean_total > 0.0 ? mean_matrix / mean_total : 0.0);
+    ratios.pushKV("product_digest_share_of_accepted_total", mean_total > 0.0 ? mean_digest / mean_total : 0.0);
+    ratios.pushKV("noise_generation_share_of_accepted_total", mean_total > 0.0 ? mean_noise / mean_total : 0.0);
+    ratios.pushKV("perturbation_share_of_accepted_total", mean_total > 0.0 ? mean_perturbation / mean_total : 0.0);
+    ratios.pushKV("matrix_generation_vs_product_digest", mean_digest > 0.0 ? mean_matrix / mean_digest : 0.0);
+    output.pushKV("ratios", std::move(ratios));
+
+    UniValue amortized(UniValue::VOBJ);
+    amortized.pushKV("pre_hash_gate_enabled", options.epsilon_bits > 0);
+    amortized.pushKV("pre_hash_gate_pass_probability_estimate", pre_hash_pass_probability);
+    amortized.pushKV("gate_hash_us_per_scanned_nonce", gate_hash_us);
+    amortized.pushKV("expensive_candidate_us_on_gate_pass", expensive_candidate_us);
+    amortized.pushKV("amortized_us_per_scanned_nonce", amortized_per_scanned_nonce_us);
+    amortized.pushKV("gate_hash_share", amortized_per_scanned_nonce_us > 0.0 ? gate_hash_us / amortized_per_scanned_nonce_us : 0.0);
+    amortized.pushKV("matrix_generation_share", amortized_per_scanned_nonce_us > 0.0 ? (pre_hash_pass_probability * mean_matrix) / amortized_per_scanned_nonce_us : 0.0);
+    amortized.pushKV("product_digest_share", amortized_per_scanned_nonce_us > 0.0 ? (pre_hash_pass_probability * mean_digest) / amortized_per_scanned_nonce_us : 0.0);
+    amortized.pushKV("noise_generation_share", amortized_per_scanned_nonce_us > 0.0 ? (pre_hash_pass_probability * mean_noise) / amortized_per_scanned_nonce_us : 0.0);
+    amortized.pushKV("perturbation_share", amortized_per_scanned_nonce_us > 0.0 ? (pre_hash_pass_probability * mean_perturbation) / amortized_per_scanned_nonce_us : 0.0);
+    output.pushKV("amortized_per_scanned_nonce", std::move(amortized));
+
+    UniValue estimates(UniValue::VOBJ);
+    estimates.pushKV("ab_matrix_oracle_calls", static_cast<uint64_t>(2) * options.n * options.n);
+    estimates.pushKV("noise_matrix_oracle_calls", static_cast<uint64_t>(4) * options.n * options.r);
+    estimates.pushKV("compression_vector_oracle_calls", static_cast<uint64_t>(options.b) * options.b);
+    estimates.pushKV("dense_product_field_muladds", static_cast<uint64_t>(options.n) * options.n * options.n);
+    estimates.pushKV("noise_low_rank_field_muladds", static_cast<uint64_t>(2) * options.n * options.n * options.r);
+    estimates.pushKV("pre_hash_gate_pass_probability_estimate", pre_hash_pass_probability);
+    if (options.epsilon_bits > 0) {
+        estimates.pushKV("expected_sigma_passes_per_digest_hit_from_epsilon", static_cast<uint64_t>(1) << std::min<uint32_t>(options.epsilon_bits, 63));
+    }
+    output.pushKV("operation_estimates", std::move(estimates));
+
+    output.pushKV("digest_sink", digest_sink.empty() ? "" : digest_sink.back().GetHex());
+    std::cout << output.write(2) << std::endl;
+    return 0;
+}

--- a/src/btx-matmul-solve-bench.cpp
+++ b/src/btx-matmul-solve-bench.cpp
@@ -49,6 +49,8 @@ struct Options {
     uint32_t epsilon_bits{MAINNET_LIVE_LIKE_EPSILON_BITS};
     int32_t block_height{static_cast<int32_t>(MAINNET_POST_PRODUCT_HEIGHT)};
     std::optional<int32_t> nonce_seed_height_override;
+    std::optional<int32_t> parent_mtp_seed_height_override;
+    std::optional<int64_t> parent_mtp_override;
     std::optional<int32_t> product_digest_height_override;
     uint32_t parallel{1};
     std::optional<std::string> backend_override;
@@ -98,7 +100,9 @@ void PrintUsage(std::ostream& out)
         << " [--iterations <count>] [--tries <count>]"
         << " [--n <dim>] [--b <block>] [--r <rank>]"
         << " [--nbits <compact>] [--epsilon-bits <count>]"
-        << " [--block-height <height>] [--nonce-seed-height <height>] [--product-digest-height <height>]"
+        << " [--block-height <height>] [--nonce-seed-height <height>]"
+        << " [--parent-mtp-seed-height <height>] [--parent-mtp <time>]"
+        << " [--product-digest-height <height>]"
         << " [--parallel <count>]"
         << " [--backend <cpu|metal|cuda|mlx>]"
         << " [--async <0|1>] [--gpu-inputs <0|1>]"
@@ -111,6 +115,15 @@ bool ParseArgs(int argc, char* argv[], Options& options)
     auto parse_uint32 = [&](std::string_view arg_name, std::string_view value, uint32_t& out) -> bool {
         const auto parsed = ParseUintArg(value);
         if (!parsed.has_value() || *parsed == 0 || *parsed > std::numeric_limits<uint32_t>::max()) {
+            std::cerr << "error: invalid value for " << arg_name << ": " << value << std::endl;
+            return false;
+        }
+        out = static_cast<uint32_t>(*parsed);
+        return true;
+    };
+    auto parse_uint32_allow_zero = [&](std::string_view arg_name, std::string_view value, uint32_t& out) -> bool {
+        const auto parsed = ParseUintArg(value);
+        if (!parsed.has_value() || *parsed > std::numeric_limits<uint32_t>::max()) {
             std::cerr << "error: invalid value for " << arg_name << ": " << value << std::endl;
             return false;
         }
@@ -189,7 +202,7 @@ bool ParseArgs(int argc, char* argv[], Options& options)
             if (!parse_kv("--nbits", [&](std::string_view value) { return parse_uint32("--nbits", value, options.nbits); })) return false;
         } else if (arg == "--epsilon-bits" || arg.rfind("--epsilon-bits=", 0) == 0) {
             consumed = true;
-            if (!parse_kv("--epsilon-bits", [&](std::string_view value) { return parse_uint32("--epsilon-bits", value, options.epsilon_bits); })) return false;
+            if (!parse_kv("--epsilon-bits", [&](std::string_view value) { return parse_uint32_allow_zero("--epsilon-bits", value, options.epsilon_bits); })) return false;
         } else if (arg == "--block-height" || arg.rfind("--block-height=", 0) == 0) {
             consumed = true;
             if (!parse_kv("--block-height", [&](std::string_view value) { return parse_int32("--block-height", value, options.block_height); })) return false;
@@ -204,6 +217,35 @@ bool ParseArgs(int argc, char* argv[], Options& options)
                     }
                     options.nonce_seed_height_override = parsed;
                     return true;
+                })) return false;
+        } else if (arg == "--parent-mtp-seed-height" || arg.rfind("--parent-mtp-seed-height=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--parent-mtp-seed-height", [&](std::string_view value) {
+                    int32_t parsed{0};
+                    if (!parse_int32("--parent-mtp-seed-height", value, parsed)) return false;
+                    if (parsed < 0) {
+                        std::cerr << "error: invalid value for --parent-mtp-seed-height: " << value << std::endl;
+                        return false;
+                    }
+                    options.parent_mtp_seed_height_override = parsed;
+                    return true;
+                })) return false;
+        } else if (arg == "--parent-mtp" || arg.rfind("--parent-mtp=", 0) == 0) {
+            consumed = true;
+            if (!parse_kv("--parent-mtp", [&](std::string_view value) {
+                    try {
+                        size_t consumed_chars{0};
+                        const long long parsed = std::stoll(std::string{value}, &consumed_chars, 10);
+                        if (consumed_chars != value.size()) {
+                            std::cerr << "error: invalid value for --parent-mtp: " << value << std::endl;
+                            return false;
+                        }
+                        options.parent_mtp_override = static_cast<int64_t>(parsed);
+                        return true;
+                    } catch (const std::exception&) {
+                        std::cerr << "error: invalid value for --parent-mtp: " << value << std::endl;
+                        return false;
+                    }
                 })) return false;
         } else if (arg == "--product-digest-height" || arg.rfind("--product-digest-height=", 0) == 0) {
             consumed = true;
@@ -403,7 +445,15 @@ IterationResult RunSolveIteration(const Options& options, const Consensus::Param
             options.nbits,
             static_cast<uint64_t>(iteration_index) * options.max_tries + 1U);
         uint64_t tries = options.max_tries;
-        if (SolveMatMul(candidate, consensus, tries, options.block_height)) {
+        if (SolveMatMul(
+                candidate,
+                consensus,
+                tries,
+                options.block_height,
+                nullptr,
+                nullptr,
+                nullptr,
+                options.parent_mtp_override)) {
             ++result.solved_count;
         }
         result.nonces_per_sec = static_cast<double>(options.max_tries - tries);
@@ -419,7 +469,15 @@ IterationResult RunSolveIteration(const Options& options, const Consensus::Param
                     ((static_cast<uint64_t>(iteration_index) * options.parallel + worker_index) * options.max_tries) + 1U;
                 CBlockHeader candidate = BuildCandidateHeader(options.n, options.nbits, nonce64);
                 uint64_t tries = options.max_tries;
-                if (SolveMatMul(candidate, consensus, tries, options.block_height)) {
+                if (SolveMatMul(
+                        candidate,
+                        consensus,
+                        tries,
+                        options.block_height,
+                        nullptr,
+                        nullptr,
+                        nullptr,
+                        options.parent_mtp_override)) {
                     solved_counts[worker_index] = 1;
                 }
                 attempts_used[worker_index] = options.max_tries - tries;
@@ -482,6 +540,9 @@ int main(int argc, char* argv[])
     if (options.nonce_seed_height_override.has_value()) {
         consensus.nMatMulNonceSeedHeight = *options.nonce_seed_height_override;
     }
+    if (options.parent_mtp_seed_height_override.has_value()) {
+        consensus.nMatMulParentMtpSeedHeight = *options.parent_mtp_seed_height_override;
+    }
     if (options.product_digest_height_override.has_value()) {
         consensus.nMatMulProductDigestHeight = *options.product_digest_height_override;
     }
@@ -519,6 +580,9 @@ int main(int argc, char* argv[])
     options_obj.pushKV("block_height", options.block_height);
     options_obj.pushKV("nonce_seed_height", options.nonce_seed_height_override.has_value() ? UniValue(*options.nonce_seed_height_override) : UniValue());
     options_obj.pushKV("nonce_seed_active", consensus.IsMatMulNonceSeedActive(options.block_height));
+    options_obj.pushKV("parent_mtp_seed_height", options.parent_mtp_seed_height_override.has_value() ? UniValue(*options.parent_mtp_seed_height_override) : UniValue());
+    options_obj.pushKV("parent_mtp_seed_active", consensus.IsMatMulParentMtpSeedActive(options.block_height));
+    options_obj.pushKV("parent_mtp", options.parent_mtp_override.has_value() ? UniValue(*options.parent_mtp_override) : UniValue());
     options_obj.pushKV("product_digest_height", options.product_digest_height_override.has_value() ? UniValue(*options.product_digest_height_override) : UniValue());
     options_obj.pushKV("product_digest_active", consensus.IsMatMulProductDigestActive(options.block_height));
     options_obj.pushKV("parallel", options.parallel);

--- a/src/cuda/oracle_accel.cu
+++ b/src/cuda/oracle_accel.cu
@@ -905,6 +905,39 @@ __device__ inline uint32_t BuildMatMulSeedV2Message(const OracleSeedBytes& previ
     return offset;
 }
 
+// Builds the seed_v3 message; the nonce lands at offset 107 and `which` at 117,
+// both inside the SECOND SHA-256 block. Returns the message length (118).
+__device__ inline uint32_t BuildMatMulSeedV3Message(const OracleSeedBytes& previous_block_hash,
+                                                    const OracleSeedBytes& merkle_root,
+                                                    uint64_t parent_median_time_past,
+                                                    uint32_t height,
+                                                    uint32_t version,
+                                                    uint32_t time,
+                                                    uint32_t bits,
+                                                    uint64_t nonce,
+                                                    uint16_t matmul_dim,
+                                                    uint8_t which,
+                                                    uint8_t message[118])
+{
+    uint32_t offset{0};
+    constexpr char TAG[] = "BTX_MATMUL_SEED_V3";
+    AppendByte(message, offset, 18U);
+    for (uint32_t i = 0; i < 18U; ++i) {
+        AppendByte(message, offset, static_cast<uint8_t>(TAG[i]));
+    }
+    AppendBytes(message, offset, previous_block_hash.data, 32U);
+    AppendLE64(message, offset, parent_median_time_past);
+    AppendLE32(message, offset, height);
+    AppendLE32(message, offset, version);
+    AppendBytes(message, offset, merkle_root.data, 32U);
+    AppendLE32(message, offset, time);
+    AppendLE32(message, offset, bits);
+    AppendLE64(message, offset, nonce);
+    AppendLE16(message, offset, matmul_dim);
+    AppendByte(message, offset, which);
+    return offset;
+}
+
 // Builds the header-hash message; the nonce lands at offset 76 and the seeds at
 // 86/118, all inside the second and third SHA-256 blocks. Returns length (150).
 __device__ inline uint32_t BuildMatMulHeaderHashMessage(uint32_t version,
@@ -949,10 +982,12 @@ __global__ void ScanNonceSeedPreHashKernel(OracleSeedBytes previous_block_hash,
                                            uint32_t bits,
                                            uint64_t start_nonce,
                                            uint16_t matmul_dim,
+                                           uint32_t seed_version,
+                                           uint64_t parent_median_time_past,
                                            Element* out_flags,
                                            uint32_t scan_count)
 {
-    // Block 0 of both messages is nonce-independent (see the Build* comments),
+    // Block 0 of the seed and header messages is nonce-independent,
     // so its compression is done ONCE per CUDA block and shared: 8 -> 5 SHA-256
     // compressions per nonce. The midstates must be computed before the bounds
     // guard so every thread reaches the barrier.
@@ -960,9 +995,16 @@ __global__ void ScanNonceSeedPreHashKernel(OracleSeedBytes previous_block_hash,
     __shared__ uint32_t header_midstate[8];
     if (threadIdx.x == 0) {
         uint8_t prefix[150];
-        BuildMatMulSeedV2Message(
-            previous_block_hash, merkle_root, height, version, time, bits,
-            /*nonce=*/0U, matmul_dim, /*which=*/0U, prefix);
+        if (seed_version == 3U) {
+            BuildMatMulSeedV3Message(
+                previous_block_hash, merkle_root, parent_median_time_past,
+                height, version, time, bits,
+                /*nonce=*/0U, matmul_dim, /*which=*/0U, prefix);
+        } else {
+            BuildMatMulSeedV2Message(
+                previous_block_hash, merkle_root, height, version, time, bits,
+                /*nonce=*/0U, matmul_dim, /*which=*/0U, prefix);
+        }
         Sha256Block0Midstate(prefix, seed_midstate);
         BuildMatMulHeaderHashMessage(
             version, previous_block_hash, merkle_root, time, bits,
@@ -984,9 +1026,14 @@ __global__ void ScanNonceSeedPreHashKernel(OracleSeedBytes previous_block_hash,
     uint8_t seed_b[32];
     uint8_t header_hash[32];
     uint8_t sigma[32];
-    const uint32_t seed_len = BuildMatMulSeedV2Message(
-        previous_block_hash, merkle_root, height, version, time, bits,
-        nonce, matmul_dim, 0U, message);
+    const uint32_t seed_len = seed_version == 3U
+        ? BuildMatMulSeedV3Message(
+            previous_block_hash, merkle_root, parent_median_time_past,
+            height, version, time, bits,
+            nonce, matmul_dim, 0U, message)
+        : BuildMatMulSeedV2Message(
+            previous_block_hash, merkle_root, height, version, time, bits,
+            nonce, matmul_dim, 0U, message);
     Sha256BytesFromMidstate(seed_midstate, message, seed_len, seed_a);
     message[seed_len - 1U] = 1U; // `which` is the final byte; the rest is identical
     Sha256BytesFromMidstate(seed_midstate, message, seed_len, seed_b);
@@ -1312,6 +1359,14 @@ MatMulNonceSeedPreHashScanResult ScanMatMulNonceSeedPreHashGPU(
         result.error = "CUDA nonce-seed pre-hash scan requires non-zero matmul_dim";
         return result;
     }
+    if (request.seed_version != 2U && request.seed_version != 3U) {
+        result.error = "CUDA nonce-seed pre-hash scan requires seed_version 2 or 3";
+        return result;
+    }
+    if (request.seed_version == 3U && request.parent_median_time_past < 0) {
+        result.error = "CUDA seed-v3 nonce-seed pre-hash scan requires non-negative parent median time past";
+        return result;
+    }
 
     auto& workspace = g_workspace;
     ResetWorkspaceForDevice(workspace, runtime.device_index);
@@ -1344,6 +1399,8 @@ MatMulNonceSeedPreHashScanResult ScanMatMulNonceSeedPreHashGPU(
         request.bits,
         request.start_nonce,
         request.matmul_dim,
+        request.seed_version,
+        static_cast<uint64_t>(request.parent_median_time_past),
         workspace.out_scan_flags,
         request.scan_count);
     error = cudaGetLastError();

--- a/src/cuda/oracle_accel.h
+++ b/src/cuda/oracle_accel.h
@@ -74,6 +74,8 @@ struct MatMulNonceSeedPreHashScanRequest {
     uint32_t block_height{0};
     uint32_t scan_count{0};
     uint256 pre_hash_target;
+    uint32_t seed_version{2};
+    int64_t parent_median_time_past{0};
 };
 
 struct MatMulNonceSeedPreHashScanResult {

--- a/src/metal/oracle_accel.h
+++ b/src/metal/oracle_accel.h
@@ -57,6 +57,8 @@ struct MatMulNonceSeedPreHashScanRequest {
     uint32_t block_height{0};
     uint32_t scan_count{0};
     uint256 pre_hash_target;
+    uint32_t seed_version{2};
+    int64_t parent_median_time_past{0};
 };
 
 struct MatMulNonceSeedPreHashScanResult {

--- a/src/metal/oracle_accel.mm
+++ b/src/metal/oracle_accel.mm
@@ -398,6 +398,40 @@ inline void compute_matmul_seed_v2(constant uchar* previous_block_hash,
     sha256_bytes(message, offset, out);
 }
 
+inline void compute_matmul_seed_v3(constant uchar* previous_block_hash,
+                                   constant uchar* merkle_root,
+                                   ulong parent_median_time_past,
+                                   uint height,
+                                   uint version,
+                                   uint time,
+                                   uint bits,
+                                   ulong nonce,
+                                   ushort matmul_dim,
+                                   uchar which,
+                                   thread uchar out[32])
+{
+    thread uchar message[118];
+    uint offset = 0u;
+    const uchar tag[18] = {
+        'B', 'T', 'X', '_', 'M', 'A', 'T', 'M', 'U', 'L', '_', 'S', 'E', 'E', 'D', '_', 'V', '3'
+    };
+    append_byte(message, offset, 18u);
+    for (uint i = 0; i < 18u; ++i) {
+        append_byte(message, offset, tag[i]);
+    }
+    append_constant_bytes(message, offset, previous_block_hash, 32u);
+    append_le64(message, offset, parent_median_time_past);
+    append_le32(message, offset, height);
+    append_le32(message, offset, version);
+    append_constant_bytes(message, offset, merkle_root, 32u);
+    append_le32(message, offset, time);
+    append_le32(message, offset, bits);
+    append_le64(message, offset, nonce);
+    append_le16(message, offset, matmul_dim);
+    append_byte(message, offset, which);
+    sha256_bytes(message, offset, out);
+}
+
 inline void compute_matmul_header_hash(uint version,
                                        constant uchar* previous_block_hash,
                                        constant uchar* merkle_root,
@@ -433,13 +467,16 @@ inline bool uint256_internal_bytes_less_or_equal(thread uchar lhs[32], constant 
 }
 
 struct NonceSeedScanParams {
+    ulong start_nonce;
+    ulong parent_median_time_past;
     uint version;
     uint height;
     uint time;
     uint bits;
-    ulong start_nonce;
     uint matmul_dim;
     uint scan_count;
+    uint seed_version;
+    uint padding;
 };
 
 kernel void scan_nonce_seed_pre_hash(constant NonceSeedScanParams& p [[buffer(0)]],
@@ -458,28 +495,55 @@ kernel void scan_nonce_seed_pre_hash(constant NonceSeedScanParams& p [[buffer(0)
     thread uchar seed_b[32];
     thread uchar header_hash[32];
     thread uchar sigma[32];
-    compute_matmul_seed_v2(
-        previous_block_hash,
-        merkle_root,
-        p.height,
-        p.version,
-        p.time,
-        p.bits,
-        nonce,
-        (ushort)p.matmul_dim,
-        0u,
-        seed_a);
-    compute_matmul_seed_v2(
-        previous_block_hash,
-        merkle_root,
-        p.height,
-        p.version,
-        p.time,
-        p.bits,
-        nonce,
-        (ushort)p.matmul_dim,
-        1u,
-        seed_b);
+    if (p.seed_version == 3u) {
+        compute_matmul_seed_v3(
+            previous_block_hash,
+            merkle_root,
+            p.parent_median_time_past,
+            p.height,
+            p.version,
+            p.time,
+            p.bits,
+            nonce,
+            (ushort)p.matmul_dim,
+            0u,
+            seed_a);
+        compute_matmul_seed_v3(
+            previous_block_hash,
+            merkle_root,
+            p.parent_median_time_past,
+            p.height,
+            p.version,
+            p.time,
+            p.bits,
+            nonce,
+            (ushort)p.matmul_dim,
+            1u,
+            seed_b);
+    } else {
+        compute_matmul_seed_v2(
+            previous_block_hash,
+            merkle_root,
+            p.height,
+            p.version,
+            p.time,
+            p.bits,
+            nonce,
+            (ushort)p.matmul_dim,
+            0u,
+            seed_a);
+        compute_matmul_seed_v2(
+            previous_block_hash,
+            merkle_root,
+            p.height,
+            p.version,
+            p.time,
+            p.bits,
+            nonce,
+            (ushort)p.matmul_dim,
+            1u,
+            seed_b);
+    }
     compute_matmul_header_hash(
         p.version,
         previous_block_hash,
@@ -1049,6 +1113,16 @@ MatMulNonceSeedPreHashScanResult ScanMatMulNonceSeedPreHashGPU(
         result.error = "Metal nonce-seed pre-hash scan requires non-zero matmul_dim";
         return result;
     }
+    if (request.seed_version != 2U && request.seed_version != 3U) {
+        result.success = false;
+        result.error = "Metal nonce-seed pre-hash scan requires seed_version 2 or 3";
+        return result;
+    }
+    if (request.seed_version == 3U && request.parent_median_time_past < 0) {
+        result.success = false;
+        result.error = "Metal seed-v3 nonce-seed pre-hash scan requires non-negative parent median time past";
+        return result;
+    }
 
     @autoreleasepool {
         const size_t flags_bytes = static_cast<size_t>(request.scan_count) * sizeof(uint32_t);
@@ -1079,22 +1153,28 @@ MatMulNonceSeedPreHashScanResult ScanMatMulNonceSeedPreHashGPU(
         }
 
         struct NonceSeedScanParams {
+            uint64_t start_nonce;
+            uint64_t parent_median_time_past;
             uint32_t version;
             uint32_t height;
             uint32_t time;
             uint32_t bits;
-            uint64_t start_nonce;
             uint32_t matmul_dim;
             uint32_t scan_count;
+            uint32_t seed_version;
+            uint32_t padding;
         };
         const NonceSeedScanParams scan_params{
+            request.start_nonce,
+            static_cast<uint64_t>(request.parent_median_time_past),
             static_cast<uint32_t>(request.version),
             request.block_height,
             request.time,
             request.bits,
-            request.start_nonce,
             request.matmul_dim,
             request.scan_count,
+            request.seed_version,
+            0U,
         };
 
         [encoder setComputePipelineState:context.nonce_seed_scan_pipeline];

--- a/src/metal/oracle_accel_kernels.metal
+++ b/src/metal/oracle_accel_kernels.metal
@@ -315,6 +315,40 @@ inline void compute_matmul_seed_v2(constant uchar* previous_block_hash,
     sha256_bytes(message, offset, out);
 }
 
+inline void compute_matmul_seed_v3(constant uchar* previous_block_hash,
+                                   constant uchar* merkle_root,
+                                   ulong parent_median_time_past,
+                                   uint height,
+                                   uint version,
+                                   uint time,
+                                   uint bits,
+                                   ulong nonce,
+                                   ushort matmul_dim,
+                                   uchar which,
+                                   thread uchar out[32])
+{
+    thread uchar message[118];
+    uint offset = 0u;
+    const uchar tag[18] = {
+        'B', 'T', 'X', '_', 'M', 'A', 'T', 'M', 'U', 'L', '_', 'S', 'E', 'E', 'D', '_', 'V', '3'
+    };
+    append_byte(message, offset, 18u);
+    for (uint i = 0; i < 18u; ++i) {
+        append_byte(message, offset, tag[i]);
+    }
+    append_constant_bytes(message, offset, previous_block_hash, 32u);
+    append_le64(message, offset, parent_median_time_past);
+    append_le32(message, offset, height);
+    append_le32(message, offset, version);
+    append_constant_bytes(message, offset, merkle_root, 32u);
+    append_le32(message, offset, time);
+    append_le32(message, offset, bits);
+    append_le64(message, offset, nonce);
+    append_le16(message, offset, matmul_dim);
+    append_byte(message, offset, which);
+    sha256_bytes(message, offset, out);
+}
+
 inline void compute_matmul_header_hash(uint version,
                                        constant uchar* previous_block_hash,
                                        constant uchar* merkle_root,
@@ -350,13 +384,16 @@ inline bool uint256_internal_bytes_less_or_equal(thread uchar lhs[32], constant 
 }
 
 struct NonceSeedScanParams {
+    ulong start_nonce;
+    ulong parent_median_time_past;
     uint version;
     uint height;
     uint time;
     uint bits;
-    ulong start_nonce;
     uint matmul_dim;
     uint scan_count;
+    uint seed_version;
+    uint padding;
 };
 
 kernel void scan_nonce_seed_pre_hash(constant NonceSeedScanParams& p [[buffer(0)]],
@@ -375,28 +412,55 @@ kernel void scan_nonce_seed_pre_hash(constant NonceSeedScanParams& p [[buffer(0)
     thread uchar seed_b[32];
     thread uchar header_hash[32];
     thread uchar sigma[32];
-    compute_matmul_seed_v2(
-        previous_block_hash,
-        merkle_root,
-        p.height,
-        p.version,
-        p.time,
-        p.bits,
-        nonce,
-        (ushort)p.matmul_dim,
-        0u,
-        seed_a);
-    compute_matmul_seed_v2(
-        previous_block_hash,
-        merkle_root,
-        p.height,
-        p.version,
-        p.time,
-        p.bits,
-        nonce,
-        (ushort)p.matmul_dim,
-        1u,
-        seed_b);
+    if (p.seed_version == 3u) {
+        compute_matmul_seed_v3(
+            previous_block_hash,
+            merkle_root,
+            p.parent_median_time_past,
+            p.height,
+            p.version,
+            p.time,
+            p.bits,
+            nonce,
+            (ushort)p.matmul_dim,
+            0u,
+            seed_a);
+        compute_matmul_seed_v3(
+            previous_block_hash,
+            merkle_root,
+            p.parent_median_time_past,
+            p.height,
+            p.version,
+            p.time,
+            p.bits,
+            nonce,
+            (ushort)p.matmul_dim,
+            1u,
+            seed_b);
+    } else {
+        compute_matmul_seed_v2(
+            previous_block_hash,
+            merkle_root,
+            p.height,
+            p.version,
+            p.time,
+            p.bits,
+            nonce,
+            (ushort)p.matmul_dim,
+            0u,
+            seed_a);
+        compute_matmul_seed_v2(
+            previous_block_hash,
+            merkle_root,
+            p.height,
+            p.version,
+            p.time,
+            p.bits,
+            nonce,
+            (ushort)p.matmul_dim,
+            1u,
+            seed_b);
+    }
     compute_matmul_header_hash(
         p.version,
         previous_block_hash,

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -1507,12 +1507,19 @@ std::optional<MatMulNonceBatchWindow> BuildMatMulNonceSeededGpuPreHashBatchWindo
     const arith_uint256& target,
     uint32_t attempts_since_time_refresh,
     uint32_t header_time_refresh_interval,
+    std::optional<int64_t> parent_median_time_past,
     bool allow_min_difficulty)
 {
-    if (configured_batch_size == 0 || pre_hash_epsilon_bits == 0 || block_height < 0 ||
-        params.IsMatMulParentMtpSeedActive(block_height)) {
+    if (configured_batch_size == 0 || pre_hash_epsilon_bits == 0 || block_height < 0) {
         return std::nullopt;
     }
+    const bool use_parent_mtp_seed = params.IsMatMulParentMtpSeedActive(block_height);
+    if (use_parent_mtp_seed &&
+        (!parent_median_time_past.has_value() || *parent_median_time_past < 0)) {
+        return std::nullopt;
+    }
+    const uint32_t seed_version = use_parent_mtp_seed ? 3U : 2U;
+    const int64_t scan_parent_mtp = use_parent_mtp_seed ? *parent_median_time_past : 0;
 
     MatMulNonceBatchWindow window;
     arith_uint256 pre_hash_target = target;
@@ -1563,6 +1570,8 @@ std::optional<MatMulNonceBatchWindow> BuildMatMulNonceSeededGpuPreHashBatchWindo
             .block_height = static_cast<uint32_t>(block_height),
             .scan_count = scan_limit,
             .pre_hash_target = ArithToUint256(pre_hash_target),
+            .seed_version = seed_version,
+            .parent_median_time_past = scan_parent_mtp,
         });
         scan.success = cuda_scan.success;
         scan.scanned_count = cuda_scan.scanned_count;
@@ -1580,6 +1589,8 @@ std::optional<MatMulNonceBatchWindow> BuildMatMulNonceSeededGpuPreHashBatchWindo
             .block_height = static_cast<uint32_t>(block_height),
             .scan_count = scan_limit,
             .pre_hash_target = ArithToUint256(pre_hash_target),
+            .seed_version = seed_version,
+            .parent_median_time_past = scan_parent_mtp,
         });
         scan.success = metal_scan.success;
         scan.scanned_count = metal_scan.scanned_count;
@@ -1609,7 +1620,7 @@ std::optional<MatMulNonceBatchWindow> BuildMatMulNonceSeededGpuPreHashBatchWindo
         CBlockHeader header{block};
         header.nNonce64 = block.nNonce64 + i;
         header.nNonce = static_cast<uint32_t>(header.nNonce64);
-        if (!SetDeterministicMatMulSeeds(header, params, block_height)) {
+        if (!SetDeterministicMatMulSeeds(header, params, block_height, parent_median_time_past)) {
             return std::nullopt;
         }
         header.matmul_digest.SetNull();
@@ -3487,6 +3498,7 @@ bool SolveMatMulNonceSeeded(CBlockHeader& block,
                     *bnTarget,
                     attempts_since_time_refresh,
                     header_time_refresh_interval,
+                    parent_median_time_past,
                     params.fPowAllowMinDifficultyBlocks);
                 if (scanned_window.has_value()) {
                     if (scanned_window->nonce_space_exhausted) {
@@ -3774,7 +3786,10 @@ bool SolveMatMul(CBlockHeader& block, const Consensus::Params& params, uint64_t&
         }
         block.matmul_dim = static_cast<uint16_t>(params.nMatMulDimension);
     }
-    if (params.IsMatMulNonceSeedActive(block_height) || params.IsMatMulParentMtpSeedActive(block_height)) {
+    const bool nonce_seeded_solver_active =
+        params.IsMatMulNonceSeedActive(block_height) ||
+        params.IsMatMulParentMtpSeedActive(block_height);
+    if (nonce_seeded_solver_active) {
         if (!SetDeterministicMatMulSeeds(block, params, block_height, parent_median_time_past)) {
             return false;
         }
@@ -3804,10 +3819,10 @@ bool SolveMatMul(CBlockHeader& block, const Consensus::Params& params, uint64_t&
         return false;
     }
     const auto active_backend = backend_selection.active;
-    if (params.IsMatMulNonceSeedActive(block_height)) {
-        // V2 nonce-seeded solving cannot reuse the legacy shared A/B matrix instance. CPU backends
+    if (nonce_seeded_solver_active) {
+        // Nonce-seeded solving cannot reuse the legacy shared A/B matrix instance. CPU backends
         // still fan out disjoint nonce ranges across workers, while GPU backends with nonce-seed
-        // scan support keep a single mining lane and move the expensive seed-v2 pre-hash scan into
+        // scan support keep a single mining lane and move the expensive nonce-seed pre-hash scan into
         // a GPU window before digesting only the candidates that passed the sigma gate.
         if (!g_matmul_parallel_worker_context) {
             const uint32_t solver_threads = static_cast<uint32_t>(ResolveMatMulSolverThreadCount());
@@ -3816,8 +3831,7 @@ bool SolveMatMul(CBlockHeader& block, const Consensus::Params& params, uint64_t&
             const bool gpu_nonce_seed_scan_enabled =
                 (active_backend == matmul::backend::Kind::CUDA ||
                  active_backend == matmul::backend::Kind::METAL) &&
-                pre_hash_epsilon_bits > 0 &&
-                !params.IsMatMulParentMtpSeedActive(block_height);
+                pre_hash_epsilon_bits > 0;
             const uint32_t nonce_seed_batch_size = gpu_nonce_seed_scan_enabled
                 ? ResolveGpuNonceSeedBatchSize(
                     active_backend,

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1520,6 +1520,9 @@ struct MatMulWorkProfileOptions {
     std::string seed_derivation_scope{"per_parent_block"};
     std::string seed_derivation_rule{"sha256(prev_block_hash || height || which)"};
     bool winner_knows_next_seeds_first{true};
+    bool private_parent_withholding_head_start_possible{true};
+    std::string private_parent_withholding_head_start_scope{
+        "standard_pow_parent_withholding_only"};
     bool publicly_precomputable_before_parent_seen{false};
     uint64_t public_precompute_horizon_blocks{0};
     std::vector<std::string> template_mutations_preserve_seed{"merkle_root", "nonce", "time"};
@@ -1538,7 +1541,15 @@ static UniValue BuildMatMulWorkProfile(
     MatMulWorkProfileOptions options = {})
 {
     if (options.reflect_consensus_nonce_seed_upgrade &&
-        consensus.IsMatMulNonceSeedActive(block_height)) {
+        consensus.IsMatMulParentMtpSeedActive(block_height)) {
+        options.seed_derivation_scope = "per_nonce_header_parent_mtp";
+        options.seed_derivation_rule =
+            "sha256(\"BTX_MATMUL_SEED_V3\" || prev_block_hash || parent_median_time_past || height || version || merkle_root || time || bits || nonce64 || matmul_dim || which)";
+        options.winner_knows_next_seeds_first = false;
+        options.template_mutations_preserve_seed.clear();
+        options.fixed_instance_reuse_possible = false;
+    } else if (options.reflect_consensus_nonce_seed_upgrade &&
+               consensus.IsMatMulNonceSeedActive(block_height)) {
         options.seed_derivation_scope = "per_nonce_header";
         options.seed_derivation_rule =
             "sha256(\"BTX_MATMUL_SEED_V2\" || prev_block_hash || height || version || merkle_root || time || bits || nonce64 || matmul_dim || which)";
@@ -1662,6 +1673,12 @@ static UniValue BuildMatMulWorkProfile(
     next_block_seed_access.pushKV("seed_derivation_scope", options.seed_derivation_scope);
     next_block_seed_access.pushKV("seed_derivation_rule", options.seed_derivation_rule);
     next_block_seed_access.pushKV("winner_knows_next_seeds_first", options.winner_knows_next_seeds_first);
+    next_block_seed_access.pushKV(
+        "private_parent_withholding_head_start_possible",
+        options.private_parent_withholding_head_start_possible);
+    next_block_seed_access.pushKV(
+        "private_parent_withholding_head_start_scope",
+        options.private_parent_withholding_head_start_scope);
     next_block_seed_access.pushKV("publicly_precomputable_before_parent_seen", options.publicly_precomputable_before_parent_seen);
     next_block_seed_access.pushKV("public_precompute_horizon_blocks", options.public_precompute_horizon_blocks);
     next_block_seed_access.pushKV(
@@ -3353,6 +3370,8 @@ static UniValue BuildMatMulServiceChallengeResponse(
     work_profile_options.seed_derivation_scope = "per_service_challenge";
     work_profile_options.seed_derivation_rule = MATMUL_SERVICE_SEED_DERIVATION_RULE;
     work_profile_options.winner_knows_next_seeds_first = false;
+    work_profile_options.private_parent_withholding_head_start_possible = false;
+    work_profile_options.private_parent_withholding_head_start_scope = "not_a_next_block_mining_seed";
     work_profile_options.publicly_precomputable_before_parent_seen = false;
     work_profile_options.public_precompute_horizon_blocks = 0;
     work_profile_options.template_mutations_preserve_seed = {"nonce"};

--- a/src/test/matmul_mining_tests.cpp
+++ b/src/test/matmul_mining_tests.cpp
@@ -521,6 +521,49 @@ BOOST_AUTO_TEST_CASE(getmatmulchallenge_reports_chain_guard_and_time_policy)
     }
 }
 
+BOOST_AUTO_TEST_CASE(getmatmulchallenge_work_profile_reports_parent_mtp_seed_v3)
+{
+    SetMiningChainGuard(false);
+
+    auto& mutable_consensus = const_cast<Consensus::Params&>(m_node.chainman->GetConsensus());
+    struct RestoreMatMulSeedHeights
+    {
+        Consensus::Params& consensus;
+        int32_t saved_nonce_seed_height;
+        int32_t saved_parent_mtp_seed_height;
+        ~RestoreMatMulSeedHeights()
+        {
+            consensus.nMatMulNonceSeedHeight = saved_nonce_seed_height;
+            consensus.nMatMulParentMtpSeedHeight = saved_parent_mtp_seed_height;
+        }
+    } restore_seed_heights{
+        mutable_consensus,
+        mutable_consensus.nMatMulNonceSeedHeight,
+        mutable_consensus.nMatMulParentMtpSeedHeight};
+
+    const int32_t next_height = ActiveHeight() + 1;
+    mutable_consensus.nMatMulNonceSeedHeight = next_height;
+    mutable_consensus.nMatMulParentMtpSeedHeight = next_height;
+
+    const auto challenge = CallRPC("getmatmulchallenge").get_obj();
+    const auto work_profile = challenge.find_value("work_profile").get_obj();
+    const auto seed_access = work_profile.find_value("next_block_seed_access").get_obj();
+    const std::string seed_rule = seed_access.find_value("seed_derivation_rule").get_str();
+
+    BOOST_CHECK_EQUAL(seed_access.find_value("seed_derivation_scope").get_str(), "per_nonce_header_parent_mtp");
+    BOOST_CHECK(seed_rule.find("BTX_MATMUL_SEED_V3") != std::string::npos);
+    BOOST_CHECK(seed_rule.find("parent_median_time_past") != std::string::npos);
+    BOOST_CHECK(!seed_access.find_value("winner_knows_next_seeds_first").get_bool());
+    BOOST_CHECK(seed_access.find_value("private_parent_withholding_head_start_possible").get_bool());
+    BOOST_CHECK_EQUAL(
+        seed_access.find_value("private_parent_withholding_head_start_scope").get_str(),
+        "standard_pow_parent_withholding_only");
+    BOOST_CHECK_EQUAL(seed_access.find_value("template_mutations_preserve_seed").get_array().size(), 0U);
+
+    const auto cross_nonce_reuse = work_profile.find_value("cross_nonce_reuse").get_obj();
+    BOOST_CHECK(!cross_nonce_reuse.find_value("fixed_instance_reuse_possible").get_bool());
+}
+
 BOOST_AUTO_TEST_CASE(getmatmulchallenge_reports_chain_guard_advisory_without_pausing)
 {
     SetMiningChainGuard(true);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -350,6 +350,32 @@ public:
     }
 };
 
+class ScopedGpuInputsEnv
+{
+public:
+    explicit ScopedGpuInputsEnv(const char* value)
+    {
+#if defined(WIN32)
+        _putenv_s("BTX_MATMUL_GPU_INPUTS", value != nullptr ? value : "");
+#else
+        if (value != nullptr) {
+            setenv("BTX_MATMUL_GPU_INPUTS", value, 1);
+        } else {
+            unsetenv("BTX_MATMUL_GPU_INPUTS");
+        }
+#endif
+    }
+
+    ~ScopedGpuInputsEnv()
+    {
+#if defined(WIN32)
+        _putenv_s("BTX_MATMUL_GPU_INPUTS", "");
+#else
+        unsetenv("BTX_MATMUL_GPU_INPUTS");
+#endif
+    }
+};
+
 class ScopedSolverThreadsEnv
 {
 public:
@@ -1591,6 +1617,128 @@ BOOST_AUTO_TEST_CASE(MatMulNonceSeed_metal_prehash_scan_matches_cpu_gate)
     }
 }
 
+BOOST_AUTO_TEST_CASE(MatMulParentMtpSeed_cuda_prehash_scan_matches_cpu_gate)
+{
+    auto consensus = CreateChainParams(*m_node.args, ChainType::REGTEST)->GetConsensus();
+    consensus.fMatMulPOW = true;
+    consensus.nMatMulDimension = 16;
+    consensus.nMatMulMinDimension = 16;
+    consensus.nMatMulTranscriptBlockSize = 8;
+    consensus.nMatMulNoiseRank = 4;
+    consensus.nMatMulPreHashEpsilonBits = 4;
+    consensus.nMatMulPreHashEpsilonBitsUpgradeHeight = std::numeric_limits<int32_t>::max();
+    consensus.nMatMulNonceSeedHeight = 2;
+    consensus.nMatMulParentMtpSeedHeight = 2;
+    consensus.powLimit = uint256{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
+
+    constexpr int64_t parent_mtp{1'779'999'900};
+    arith_uint256 block_target{1};
+    block_target <<= 250;
+    CBlockHeader header{};
+    header.nVersion = 4;
+    header.hashPrevBlock = uint256{"00000000000000000000000000000000000000000000000000000000000000c3"};
+    header.hashMerkleRoot = uint256{"00000000000000000000000000000000000000000000000000000000000000c4"};
+    header.nTime = 1'780'000'009U;
+    header.nBits = block_target.GetCompact();
+    header.nNonce64 = 29;
+    header.nNonce = static_cast<uint32_t>(header.nNonce64);
+    header.matmul_dim = static_cast<uint16_t>(consensus.nMatMulDimension);
+
+    arith_uint256 pre_hash_target = DecodeTarget(header.nBits);
+    pre_hash_target <<= consensus.nMatMulPreHashEpsilonBits;
+    constexpr uint32_t kScanCount{96};
+    const auto scan = btx::cuda::ScanMatMulNonceSeedPreHashGPU({
+        .version = header.nVersion,
+        .previous_block_hash = header.hashPrevBlock,
+        .merkle_root = header.hashMerkleRoot,
+        .time = header.nTime,
+        .bits = header.nBits,
+        .start_nonce = header.nNonce64,
+        .matmul_dim = header.matmul_dim,
+        .block_height = 2,
+        .scan_count = kScanCount,
+        .pre_hash_target = ArithToUint256(pre_hash_target),
+        .seed_version = 3,
+        .parent_median_time_past = parent_mtp,
+    });
+    if (!scan.available) {
+        return;
+    }
+
+    BOOST_REQUIRE_MESSAGE(scan.success, scan.error);
+    BOOST_REQUIRE_EQUAL(scan.scanned_count, kScanCount);
+    BOOST_REQUIRE_EQUAL(scan.pass_flags.size(), kScanCount);
+    for (uint32_t i = 0; i < kScanCount; ++i) {
+        CBlockHeader candidate{header};
+        candidate.nNonce64 = header.nNonce64 + i;
+        candidate.nNonce = static_cast<uint32_t>(candidate.nNonce64);
+        BOOST_REQUIRE(SetDeterministicMatMulSeeds(candidate, consensus, 2, parent_mtp));
+        const bool expected = CheckMatMulPreHashGate(candidate, consensus, 2);
+        BOOST_CHECK_EQUAL(scan.pass_flags[i] != 0, expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(MatMulParentMtpSeed_metal_prehash_scan_matches_cpu_gate)
+{
+    auto consensus = CreateChainParams(*m_node.args, ChainType::REGTEST)->GetConsensus();
+    consensus.fMatMulPOW = true;
+    consensus.nMatMulDimension = 16;
+    consensus.nMatMulMinDimension = 16;
+    consensus.nMatMulTranscriptBlockSize = 8;
+    consensus.nMatMulNoiseRank = 4;
+    consensus.nMatMulPreHashEpsilonBits = 4;
+    consensus.nMatMulPreHashEpsilonBitsUpgradeHeight = std::numeric_limits<int32_t>::max();
+    consensus.nMatMulNonceSeedHeight = 2;
+    consensus.nMatMulParentMtpSeedHeight = 2;
+    consensus.powLimit = uint256{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
+
+    constexpr int64_t parent_mtp{1'779'999'901};
+    arith_uint256 block_target{1};
+    block_target <<= 250;
+    CBlockHeader header{};
+    header.nVersion = 4;
+    header.hashPrevBlock = uint256{"00000000000000000000000000000000000000000000000000000000000000d3"};
+    header.hashMerkleRoot = uint256{"00000000000000000000000000000000000000000000000000000000000000d4"};
+    header.nTime = 1'780'000'010U;
+    header.nBits = block_target.GetCompact();
+    header.nNonce64 = 31;
+    header.nNonce = static_cast<uint32_t>(header.nNonce64);
+    header.matmul_dim = static_cast<uint16_t>(consensus.nMatMulDimension);
+
+    arith_uint256 pre_hash_target = DecodeTarget(header.nBits);
+    pre_hash_target <<= consensus.nMatMulPreHashEpsilonBits;
+    constexpr uint32_t kScanCount{96};
+    const auto scan = btx::metal::ScanMatMulNonceSeedPreHashGPU({
+        .version = header.nVersion,
+        .previous_block_hash = header.hashPrevBlock,
+        .merkle_root = header.hashMerkleRoot,
+        .time = header.nTime,
+        .bits = header.nBits,
+        .start_nonce = header.nNonce64,
+        .matmul_dim = header.matmul_dim,
+        .block_height = 2,
+        .scan_count = kScanCount,
+        .pre_hash_target = ArithToUint256(pre_hash_target),
+        .seed_version = 3,
+        .parent_median_time_past = parent_mtp,
+    });
+    if (!scan.available) {
+        return;
+    }
+
+    BOOST_REQUIRE_MESSAGE(scan.success, scan.error);
+    BOOST_REQUIRE_EQUAL(scan.scanned_count, kScanCount);
+    BOOST_REQUIRE_EQUAL(scan.pass_flags.size(), kScanCount);
+    for (uint32_t i = 0; i < kScanCount; ++i) {
+        CBlockHeader candidate{header};
+        candidate.nNonce64 = header.nNonce64 + i;
+        candidate.nNonce = static_cast<uint32_t>(candidate.nNonce64);
+        BOOST_REQUIRE(SetDeterministicMatMulSeeds(candidate, consensus, 2, parent_mtp));
+        const bool expected = CheckMatMulPreHashGate(candidate, consensus, 2);
+        BOOST_CHECK_EQUAL(scan.pass_flags[i] != 0, expected);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(MatMulNonceSeed_metal_solver_uses_gpu_scan_and_variable_base_batch)
 {
     const auto capability = matmul::backend::CapabilityFor(matmul::backend::Kind::METAL);
@@ -1646,6 +1794,149 @@ BOOST_AUTO_TEST_CASE(MatMulNonceSeed_metal_solver_uses_gpu_scan_and_variable_bas
     BOOST_CHECK(!payload.empty());
     BOOST_CHECK_EQUAL(header.seed_a, DeterministicMatMulSeedV2(header, 2, 0));
     BOOST_CHECK_EQUAL(header.seed_b, DeterministicMatMulSeedV2(header, 2, 1));
+
+    CBlock block{header};
+    block.matrix_c_data = payload;
+    BOOST_CHECK(CheckMatMulProofOfWork_ProductCommitted(block, consensus, 2));
+}
+
+BOOST_AUTO_TEST_CASE(MatMulParentMtpSeed_metal_solver_uses_gpu_scan_and_variable_base_batch)
+{
+    const auto capability = matmul::backend::CapabilityFor(matmul::backend::Kind::METAL);
+    if (!capability.available) {
+        BOOST_TEST_MESSAGE("Skipping Metal parent-MTP nonce-seed solver integration test: Metal backend unavailable ("
+            << capability.reason << ")");
+        return;
+    }
+
+    ScopedBackendEnv backend_env("metal");
+    ScopedBatchSizeEnv solve_batch_env(nullptr);
+    ScopedNonceSeedBatchSizeEnv nonce_seed_batch_env("3");
+    ScopedCpuConfirmEnv cpu_confirm_env("1");
+
+    auto consensus = CreateChainParams(*m_node.args, ChainType::REGTEST)->GetConsensus();
+    consensus.fSkipMatMulValidation = false;
+    consensus.fMatMulPOW = true;
+    consensus.nMatMulDimension = 16;
+    consensus.nMatMulMinDimension = 16;
+    consensus.nMatMulTranscriptBlockSize = 8;
+    consensus.nMatMulNoiseRank = 4;
+    consensus.nMatMulPreHashEpsilonBits = 4;
+    consensus.nMatMulPreHashEpsilonBitsUpgradeHeight = std::numeric_limits<int32_t>::max();
+    consensus.nMatMulNonceSeedHeight = 2;
+    consensus.nMatMulParentMtpSeedHeight = 2;
+    consensus.nMatMulProductDigestHeight = 2;
+    consensus.powLimit = uint256{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
+
+    constexpr int64_t parent_mtp{1'779'999'902};
+    CBlockHeader header{};
+    header.nVersion = 4;
+    header.hashPrevBlock = uint256{"00000000000000000000000000000000000000000000000000000000000000e3"};
+    header.hashMerkleRoot = uint256{"00000000000000000000000000000000000000000000000000000000000000e4"};
+    header.nTime = 1'780'000'011U;
+    header.nBits = UintToArith256(consensus.powLimit).GetCompact();
+    header.nNonce64 = 0;
+    header.nNonce = 0;
+    header.matmul_dim = static_cast<uint16_t>(consensus.nMatMulDimension);
+    header.matmul_digest.SetNull();
+
+    ResetMatMulSolvePipelineStats();
+    ResetMatMulGpuPreHashScanStats();
+    matmul::accelerated::ResetMatMulBackendRuntimeStats();
+    std::vector<uint32_t> payload;
+    uint64_t max_tries{3};
+    BOOST_REQUIRE(SolveMatMul(header, consensus, max_tries, 2, nullptr, &payload, nullptr, parent_mtp));
+
+    const auto scan_stats = ProbeMatMulGpuPreHashScanStats();
+    BOOST_CHECK(scan_stats.attempts > 0);
+    BOOST_CHECK(scan_stats.successes > 0);
+    BOOST_CHECK_EQUAL(scan_stats.failures, 0U);
+
+    const auto solve_stats = ProbeMatMulSolvePipelineStats();
+    BOOST_CHECK_EQUAL(solve_stats.batch_size, 3U);
+    BOOST_CHECK_EQUAL(solve_stats.batched_digest_requests, 1U);
+    BOOST_CHECK_EQUAL(solve_stats.batched_nonce_attempts, 3U);
+    BOOST_CHECK(!solve_stats.parallel_solver_enabled);
+
+    const auto backend_stats = matmul::accelerated::ProbeMatMulBackendRuntimeStats();
+    BOOST_CHECK_EQUAL(backend_stats.requested_metal, 3U);
+    BOOST_CHECK_EQUAL(backend_stats.metal_successes, 3U);
+    BOOST_CHECK(!payload.empty());
+    BOOST_CHECK_EQUAL(header.seed_a, DeterministicMatMulSeedV3(header, 2, parent_mtp, 0));
+    BOOST_CHECK_EQUAL(header.seed_b, DeterministicMatMulSeedV3(header, 2, parent_mtp, 1));
+
+    CBlock block{header};
+    block.matrix_c_data = payload;
+    BOOST_CHECK(CheckMatMulProofOfWork_ProductCommitted(block, consensus, 2));
+}
+
+BOOST_AUTO_TEST_CASE(MatMulParentMtpSeed_cuda_solver_uses_gpu_scan_and_variable_base_batch)
+{
+    const auto capability = matmul::backend::CapabilityFor(matmul::backend::Kind::CUDA);
+    if (!capability.available) {
+        BOOST_TEST_MESSAGE("Skipping CUDA parent-MTP nonce-seed solver integration test: CUDA backend unavailable ("
+            << capability.reason << ")");
+        return;
+    }
+
+    ScopedBackendEnv backend_env("cuda");
+    ScopedBatchSizeEnv solve_batch_env(nullptr);
+    ScopedNonceSeedBatchSizeEnv nonce_seed_batch_env("3");
+    ScopedCpuConfirmEnv cpu_confirm_env("1");
+    ScopedGpuInputsEnv gpu_inputs_env("1");
+
+    auto consensus = CreateChainParams(*m_node.args, ChainType::REGTEST)->GetConsensus();
+    consensus.fSkipMatMulValidation = false;
+    consensus.fMatMulPOW = true;
+    consensus.nMatMulDimension = 16;
+    consensus.nMatMulMinDimension = 16;
+    consensus.nMatMulTranscriptBlockSize = 8;
+    consensus.nMatMulNoiseRank = 4;
+    consensus.nMatMulPreHashEpsilonBits = 4;
+    consensus.nMatMulPreHashEpsilonBitsUpgradeHeight = std::numeric_limits<int32_t>::max();
+    consensus.nMatMulNonceSeedHeight = 2;
+    consensus.nMatMulParentMtpSeedHeight = 2;
+    consensus.nMatMulProductDigestHeight = 2;
+    consensus.powLimit = uint256{"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"};
+
+    constexpr int64_t parent_mtp{1'779'999'903};
+    CBlockHeader header{};
+    header.nVersion = 4;
+    header.hashPrevBlock = uint256{"00000000000000000000000000000000000000000000000000000000000000e5"};
+    header.hashMerkleRoot = uint256{"00000000000000000000000000000000000000000000000000000000000000e6"};
+    header.nTime = 1'780'000'012U;
+    header.nBits = UintToArith256(consensus.powLimit).GetCompact();
+    header.nNonce64 = 0;
+    header.nNonce = 0;
+    header.matmul_dim = static_cast<uint16_t>(consensus.nMatMulDimension);
+    header.matmul_digest.SetNull();
+
+    ResetMatMulSolvePipelineStats();
+    ResetMatMulGpuPreHashScanStats();
+    matmul::accelerated::ResetMatMulBackendRuntimeStats();
+    std::vector<uint32_t> payload;
+    uint64_t max_tries{3};
+    BOOST_REQUIRE(SolveMatMul(header, consensus, max_tries, 2, nullptr, &payload, nullptr, parent_mtp));
+
+    const auto scan_stats = ProbeMatMulGpuPreHashScanStats();
+    BOOST_CHECK(scan_stats.attempts > 0);
+    BOOST_CHECK(scan_stats.successes > 0);
+    BOOST_CHECK_EQUAL(scan_stats.failures, 0U);
+    BOOST_CHECK_EQUAL(scan_stats.cuda_fallbacks_to_cpu, 0U);
+
+    const auto solve_stats = ProbeMatMulSolvePipelineStats();
+    BOOST_CHECK_EQUAL(solve_stats.batch_size, 3U);
+    BOOST_CHECK_EQUAL(solve_stats.batched_digest_requests, 1U);
+    BOOST_CHECK_EQUAL(solve_stats.batched_nonce_attempts, 3U);
+    BOOST_CHECK(!solve_stats.parallel_solver_enabled);
+
+    const auto backend_stats = matmul::accelerated::ProbeMatMulBackendRuntimeStats();
+    BOOST_CHECK_EQUAL(backend_stats.requested_cuda, 3U);
+    BOOST_CHECK_EQUAL(backend_stats.cuda_successes, 3U);
+    BOOST_CHECK_EQUAL(backend_stats.cuda_fallbacks_to_cpu, 0U);
+    BOOST_CHECK(!payload.empty());
+    BOOST_CHECK_EQUAL(header.seed_a, DeterministicMatMulSeedV3(header, 2, parent_mtp, 0));
+    BOOST_CHECK_EQUAL(header.seed_b, DeterministicMatMulSeedV3(header, 2, parent_mtp, 1));
 
     CBlock block{header};
     block.matrix_c_data = payload;

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -228,6 +228,22 @@ def deterministic_matmul_seed_v2(header, height, which):
     return uint256_from_str(sha256(payload))
 
 
+def deterministic_matmul_seed_v3(header, height, parent_median_time_past, which):
+    payload = b""
+    payload += ser_string(b"BTX_MATMUL_SEED_V3")
+    payload += ser_uint256(header.hashPrevBlock)
+    payload += int(parent_median_time_past).to_bytes(8, "little", signed=True)
+    payload += int(height).to_bytes(4, "little")
+    payload += int(header.nVersion).to_bytes(4, "little", signed=True)
+    payload += ser_uint256(header.hashMerkleRoot)
+    payload += int(header.nTime).to_bytes(4, "little")
+    payload += int(header.nBits).to_bytes(4, "little")
+    payload += int(header._effective_nonce64()).to_bytes(8, "little")
+    payload += int(header.matmul_dim).to_bytes(2, "little")
+    payload += bytes([which & 0xFF])
+    return uint256_from_str(sha256(payload))
+
+
 def _matmul_nonce_seed_height():
     raw = os.getenv("BTX_PY_MATMUL_NONCE_SEED_HEIGHT", "")
     if raw == "":
@@ -237,6 +253,34 @@ def _matmul_nonce_seed_height():
     except ValueError:
         return None
     return height if height >= 0 else None
+
+
+def _matmul_parent_mtp_seed_height():
+    raw = os.getenv("BTX_PY_MATMUL_PARENT_MTP_SEED_HEIGHT", "")
+    if raw == "":
+        return None
+    try:
+        height = int(raw)
+    except ValueError:
+        return None
+    return height if height >= 0 else None
+
+
+def _median_time_past(block_hash):
+    times = []
+    current_hash = block_hash
+    for _ in range(11):
+        entry = lookup_solved_block_index(current_hash)
+        if entry is None:
+            break
+        times.append(int(entry["n_time"]))
+        current_hash = entry.get("prev_hash", 0)
+        if current_hash == 0:
+            break
+    if not times:
+        return None
+    times.sort()
+    return times[len(times) // 2]
 
 
 def _default_matmul_dim():
@@ -988,22 +1032,35 @@ class CBlock(CBlockHeader):
                 self.matmul_dim = _default_matmul_dim()
             next_height = _next_header_height(self.hashPrevBlock)
             nonce_seed_height = _matmul_nonce_seed_height()
+            parent_mtp_seed_height = _matmul_parent_mtp_seed_height()
+            parent_mtp = _median_time_past(self.hashPrevBlock)
+            parent_mtp_seed_active = (
+                parent_mtp_seed_height is not None
+                and next_height is not None
+                and next_height >= parent_mtp_seed_height
+                and parent_mtp is not None
+            )
             nonce_seed_active = (
                 nonce_seed_height is not None
                 and next_height is not None
                 and next_height >= nonce_seed_height
             )
-            if nonce_seed_active:
+            if parent_mtp_seed_active:
+                self.seed_a = deterministic_matmul_seed_v3(self, next_height, parent_mtp, 0)
+                self.seed_b = deterministic_matmul_seed_v3(self, next_height, parent_mtp, 1)
+            elif nonce_seed_active:
                 self.seed_a = deterministic_matmul_seed_v2(self, next_height, 0)
                 self.seed_b = deterministic_matmul_seed_v2(self, next_height, 1)
             elif self.seed_a == 0:
                 self.seed_a = deterministic_matmul_seed(self.hashPrevBlock, next_height, 0)
-            if not nonce_seed_active and self.seed_b == 0:
+            if not parent_mtp_seed_active and not nonce_seed_active and self.seed_b == 0:
                 self.seed_b = deterministic_matmul_seed(self.hashPrevBlock, next_height, 1)
             self.matmul_digest = 0
             self.mixHash = self.matmul_digest
         else:
             next_height = None
+            parent_mtp = None
+            parent_mtp_seed_active = False
             nonce_seed_active = False
 
         self.rehash()
@@ -1013,7 +1070,10 @@ class CBlock(CBlockHeader):
             self.nNonce64 = (self._effective_nonce64() + 1) & 0xFFFFFFFFFFFFFFFF
             self.nNonce = self.nNonce64 & 0xFFFFFFFF
             if self.hashPrevBlock != 0:
-                if nonce_seed_active:
+                if parent_mtp_seed_active:
+                    self.seed_a = deterministic_matmul_seed_v3(self, next_height, parent_mtp, 0)
+                    self.seed_b = deterministic_matmul_seed_v3(self, next_height, parent_mtp, 1)
+                elif nonce_seed_active:
                     self.seed_a = deterministic_matmul_seed_v2(self, next_height, 0)
                     self.seed_b = deterministic_matmul_seed_v2(self, next_height, 1)
                 self.matmul_digest = 0
@@ -1028,6 +1088,12 @@ class CBlock(CBlockHeader):
             self.nNonce = 0
             self.nNonce64 = 0
             if self.hashPrevBlock != 0:
+                if parent_mtp_seed_active:
+                    self.seed_a = deterministic_matmul_seed_v3(self, next_height, parent_mtp, 0)
+                    self.seed_b = deterministic_matmul_seed_v3(self, next_height, parent_mtp, 1)
+                elif nonce_seed_active:
+                    self.seed_a = deterministic_matmul_seed_v2(self, next_height, 0)
+                    self.seed_b = deterministic_matmul_seed_v2(self, next_height, 1)
                 self.matmul_digest = 0
                 self.mixHash = self.matmul_digest
             self.rehash()


### PR DESCRIPTION
## Summary

Refreshes the public v0.32.11 source with the latest `btx-node` main delta on top of the already-merged v0.32.11 shielded velocity hardening.

New in this refresh:
- hardens MatMul v3 parent-MTP seed handling across CPU, Metal, and CUDA paths;
- carries seed version and parent median-time-past context through GPU nonce prehash scanning;
- updates `getmatmulchallenge` work-profile metadata for seed-v3 scope;
- adds MatMul v3 benchmark/CI helper scripts and public decision record;
- updates v0.32.11 release notes to mention the seed-handling hardening.

## Validation so far

- `git diff --cached --check`
- `bash -n scripts/ci/run_cuda_matmul_v3.sh`
- `bash -n scripts/ci/run_matmul_v3_experiment_matrix.sh`

Full native build/test, refreshed v9 snapshot, signed bundle, and binary release assets will follow before publication.
