### PR TITLE
Fix pruned v9 snapshot restart

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -13635,6 +13635,7 @@ bool ChainstateManager::EnsureShieldedStateInitialized()
     };
     bool startup_velocity_checked{false};
     bool startup_velocity_verified_or_inactive{false};
+    bool startup_velocity_rebuild_deferred_to_state_pin{false};
     auto verify_or_repair_startup_velocity = [&]() EXCLUSIVE_LOCKS_REQUIRED(::cs_main) -> bool {
         AssertLockHeld(::cs_main);
         if (startup_velocity_checked) {
@@ -13642,6 +13643,7 @@ bool ChainstateManager::EnsureShieldedStateInitialized()
         }
         startup_velocity_checked = true;
         startup_velocity_verified_or_inactive = true;
+        startup_velocity_rebuild_deferred_to_state_pin = false;
         if (tip == nullptr) {
             return true;
         }
@@ -13664,6 +13666,25 @@ bool ChainstateManager::EnsureShieldedStateInitialized()
                                                    consensus,
                                                    rebuilt_velocity,
                                                    rebuild_error)) {
+            if (velocity_log_present &&
+                consensus.IsShieldedRecoveryExitActive(tip->nHeight) &&
+                m_active_chainstate != nullptr &&
+                m_active_chainstate->m_from_snapshot_blockhash.has_value() &&
+                !ShieldedFullRebuildBlocksAvailable(*m_active_chainstate, tip)) {
+                // AssumeUTXO snapshot nodes do not necessarily have the snapshot base block on disk.
+                // After they catch up, the persisted velocity window can still reference that base
+                // height, so a by-block reconstruction may be impossible even though the v9 snapshot
+                // loaded and persisted the velocity log. Defer the velocity check to the full
+                // recovery-exit state pin below. That pin covers the velocity log, nullifier root,
+                // note root, account-registry root, bridge metadata, and pool balance; mismatches
+                // still fail closed when full audit blocks are unavailable.
+                LogPrintf("EnsureShieldedStateInitialized: recent unshield velocity rebuild unavailable at height=%d hash=%s (%s); deferring verification to persisted full shielded state pin for pruned assumeutxo snapshot\n",
+                          tip->nHeight,
+                          tip->GetBlockHash().ToString(),
+                          rebuild_error);
+                startup_velocity_rebuild_deferred_to_state_pin = true;
+                return true;
+            }
             LogPrintf("EnsureShieldedStateInitialized: failed to verify persisted unshield velocity at height=%d hash=%s (%s)\n",
                       tip->nHeight,
                       tip->GetBlockHash().ToString(),
@@ -13796,6 +13817,7 @@ bool ChainstateManager::EnsureShieldedStateInitialized()
         }
         startup_velocity_checked = false;
         startup_velocity_verified_or_inactive = false;
+        startup_velocity_rebuild_deferred_to_state_pin = false;
         startup_shielded_repair_performed = true;
         LogPrintf("EnsureShieldedStateInitialized: initialized tree_size=%u root=%s nullifiers=%u pool=%lld\n",
                   static_cast<unsigned int>(m_shielded_merkle_tree.Size()),
@@ -14151,7 +14173,8 @@ bool ChainstateManager::EnsureShieldedStateInitialized()
                         persisted_pin.has_value() &&
                         current_pin.has_value() &&
                         startup_velocity_checked &&
-                        startup_velocity_verified_or_inactive) {
+                        startup_velocity_verified_or_inactive &&
+                        !startup_velocity_rebuild_deferred_to_state_pin) {
                         const auto legacy_v2_pin = ComputeShieldedSnapshotStatePinV2ForMigration();
                         const auto empty_velocity_v3_pin =
                             ComputeShieldedSnapshotStatePinEmptyVelocityV3ForMigration();


### PR DESCRIPTION
Fixes pruned assumeutxo nodes loaded from the v9 snapshot failing on restart because startup tried to reconstruct the recent shielded unshield-velocity window from the missing snapshot-base block before validating the persisted full shielded state pin.

This public hotfix branch is intentionally narrow because the v0.32.11 public tree already contains the 130501 v9 snapshot assumeutxo entry. The private btx-node source PR also adds those entries to btx-node main.

Validation:
- built the public v0.32.11 tree with target btxd/btx-cli;
- reproduced the failure with snapshot.dat height 130501, prune=600, fastshieldedstartup=1, retainshieldedcommitmentindex=1;
- after patching, the same pruned datadir restarted successfully at height 130608 and again at height 130700/130767;
- logs show the unavailable 130501 baseline block is handled by deferring velocity reconstruction to the persisted full shielded state pin, followed by successful state-pin verification and persisted-state restore.