### PR TITLE
guix: enable ZMQ in release binaries (-DWITH_ZMQ=ON)

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -251,6 +251,11 @@ mkdir -p "$OUTDIR"
 
 # CONFIGFLAGS
 BASE_CONFIGFLAGS="-DREDUCE_EXPORTS=ON -DBUILD_BENCH=OFF -DBUILD_GUI_TESTS=OFF -DBUILD_FUZZ_BINARY=OFF"
+# Ship ZMQ notifications in release binaries. WITH_ZMQ defaults OFF in CMakeLists.txt,
+# so without this flag the released btxd silently ignores -zmqpub* settings
+# ("built without ZMQ support"). libzmq is already provided by the depends system
+# (packages.mk: zmq_packages=zeromq, built by default unless NO_ZMQ is set).
+BASE_CONFIGFLAGS="$BASE_CONFIGFLAGS -DWITH_ZMQ=ON"
 BASE_CONFIGFLAGS="$BASE_CONFIGFLAGS -DCMAKE_SKIP_BUILD_RPATH=TRUE"  # check-symbols is fussy about rpath and we don't need it
 
 make_cuda_host_compiler_wrapper() {


### PR DESCRIPTION
## Problem
The v0.33.0 release binaries are built **without ZMQ support**. Running `btxd` with `-zmqpubrawtx` / `-zmqpubsequence` / `-zmqpubhashblock` logs:

> `-zmqpubrawtx is set but this btxd was built without ZMQ support ... rebuild with -DWITH_ZMQ=ON`

and `getzmqnotifications` returns `[]`. Any integration relying on ZMQ notifications (mempool/block first-seen collectors, indexers, etc.) breaks silently.

## Root cause
`WITH_ZMQ` defaults `OFF` in `CMakeLists.txt`, and the guix release build (`contrib/guix/libexec/build.sh`) never passes `-DWITH_ZMQ=ON`, so ZMQ is compiled out of the shipped binaries.

## Fix
Add `-DWITH_ZMQ=ON` to `BASE_CONFIGFLAGS`. **No new dependency is required** — `libzmq` is already built by the depends system by default (`depends/packages/packages.mk`: `zmq_packages=zeromq`, added in `depends/Makefile` unless `NO_ZMQ` is set); the release simply wasn't enabling the CMake feature.

## Verification
- Reproduced on `btx-0.33.0-x86_64-linux-gnu`: `getzmqnotifications` empty, `-zmqpub*` ignored.
- One-line build-config change; depends already provides libzmq, so guix release builds will link it and `getzmqnotifications` will list the configured publishers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)