### PR TITLE
OTC: bonded offers with verifiable supply — design doc + contrib/otc tooling

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -26,6 +26,11 @@ wallet backups.
 Optional operator helper for attaching and recovering historical stuck bridge
 batches through the wallet-managed pending journal.
 
+### [OTC](/contrib/otc) ###
+Bonded OTC offer tooling: create, verify, and watch offers whose quoted supply
+is provably locked on-chain and bound to a single offer, plus HTLC settlement
+helpers. See doc/btx-otc-escrow-supply-validation.md for the design.
+
 Build Tools and Keys
 ---------------------
 

--- a/contrib/otc/README.md
+++ b/contrib/otc/README.md
@@ -1,0 +1,150 @@
+# contrib/otc — Bonded OTC offers with verifiable supply
+
+Tooling for the design in
+[doc/btx-otc-escrow-supply-validation.md](../../doc/btx-otc-escrow-supply-validation.md):
+OTC offers backed by **bonded offer vaults**, so that quoted supply is
+provably real, exclusively committed to one offer, and not withdrawable
+while the quote is live. An offer that does not carry a valid proof bundle
+should be treated by the market as **no supply**.
+
+Everything here drives a stock `btxd` over RPC — there are no consensus,
+policy, or node changes. Funds-critical spends go through the node's
+audited `buildhtlcclaim` / `buildhtlcrefund` wallet RPCs.
+
+**Status: reference tooling. UNAUDITED.** Same caveat as `contrib/wbtx`:
+review before using with meaningful value.
+
+## What problem this solves
+
+OTC desks can suppress price by quoting size they do not have (phantom
+supply): fabricated balances, the same coins shown to many venues at once,
+borrowed coins shown then returned, or "it's in the shielded pool, trust
+me" (per-account shielded balances are deliberately unprovable on BTX, and
+the pool stopped accepting new credits at block 125,000). A bonded offer
+makes every one of those tricks mechanically detectable with nothing but a
+full node.
+
+## The bond
+
+A bond is a P2MR vault built from descriptor leaves that already ship in
+the node, holding the offered coins with exactly two kinds of spend path:
+
+| Tier | Descriptor | Pre-expiry spend | Guarantee |
+|------|-----------|------------------|-----------|
+| A+ | `mr(ctv_multi_pq(<tmpl>,1,S),{refund(H,R)})` | only the pre-committed settlement tx | exists, exclusive, unpullable, destination-fixed |
+| A  | `mr(multi_pq(2,S,V),{refund(H,R)})` | seller + venue co-sign | exists, exclusive, unpullable (venue can only delay) |
+| B  | `mr(S,{refund(H,R)})` | seller alone | exists, exclusive; an early pull is publicly visible |
+
+`refund(H,R)` returns the coins to the seller only at/after block `H`,
+which must be ≥ the offer's advertised `expiry_height`.
+
+**Exclusivity** comes from the funding transaction: it must include
+
+```
+OP_RETURN "BTXOTC1" || SHA256(canonical offer terms)     (39-byte payload)
+```
+
+An outpoint has one funding tx and that tx commits to one terms hash, so
+the same coins can never verifiably back two different offers — on any
+venue, with no coordination.
+
+## Quick start (CLI)
+
+```bash
+# 1. Seller: write terms.json (ints only — floats are rejected)
+cat > terms.json <<'EOF'
+{
+  "version": 1,
+  "amount_sats": 300000000,
+  "expiry_height": 815000,
+  "price": "spot-0.5%",
+  "settle_asset": "wBTX",
+  "seller_address": "btx1z...",
+  "nonce": "<32 hex chars, fresh per offer>"
+}
+EOF
+
+# 2. Seller: build the bond descriptor (tier B shown; see SDK for A/A+),
+#    fund it, and print the publishable offer bundle
+python3 btx_otc.py --cli "btx-cli -rpcwallet=desk" \
+    create terms.json \
+    "mr(<settle_pk>,{refund(815000,<refund_pk>)})" > bundle.json
+
+# 3. Anyone: verify against their own node (exit 0 = verified)
+python3 btx_otc.py --cli "btx-cli" verify bundle.json --min-conf 20
+
+# 4. Anyone: watch the bond until it settles / is pulled / expires
+python3 btx_otc.py --cli "btx-cli" watch bundle.json
+
+# 5. Seller, after expiry: reclaim via the refund leaf
+python3 btx_otc.py --cli "btx-cli -rpcwallet=desk" \
+    refund-bond bundle.json <dest_address> --broadcast
+```
+
+`verify` re-checks everything on-chain and trusts nothing in the bundle:
+
+1. terms canonicalize; the descriptor parses and matches a **known tier
+   shape exactly** (unknown script trees fail closed — a leaf you can't
+   classify could be a hidden exit path);
+2. the refund timelock covers the advertised expiry;
+3. every outpoint is a live, sufficiently-confirmed UTXO paying the vault
+   address, summing to at least `amount_sats` (no duplicates);
+4. every funding tx carries the `OP_RETURN` commitment to **these** terms
+   (this is what catches double-pledging);
+5. the offer has not expired;
+6. optionally, a fresh-challenge BIP-322 attestation verifies against the
+   seller's declared address.
+
+If the node has no `-txindex`, add a `"blockhash"` hint to each outpoint
+in the bundle so step 4 can fetch the funding tx.
+
+## Settlement (stage 2)
+
+When a buyer engages, the bond is spent into a settlement vault. For
+crypto↔crypto trades use the HTLC vault (identical shape and hashlock
+domain to the wBTX Model-B EVM leg, `contrib/wbtx`):
+
+```python
+from btx_otc import (swap_vault_descriptor, new_preimage, swap_hash160_hex,
+                     build_swap_claim, build_swap_refund)
+
+secret = new_preimage()
+desc = swap_vault_descriptor(internal_pk, swap_hash160_hex(secret),
+                             buyer_pk, refund_height, seller_pk)
+# buyer claims with the preimage (revealing it for the other chain's leg):
+raw = build_swap_claim(rpc_buyer, desc_ck, txid, vout, secret, buyer_dest)
+# or the seller refunds after the timeout:
+raw = build_swap_refund(rpc_seller, desc_ck, txid, vout, seller_dest, refund_height)
+```
+
+For fiat legs, see the bounded-arbiter CTV escrow and CSFS oracle
+constructions in the design doc (§5.2–5.4); their descriptors are
+node-native today, and turnkey builders here are follow-up work.
+
+## Trust model, honestly stated
+
+- **Tier B**: coins exist and are bound to one offer; the seller *can*
+  settle-or-pull early, but a pull kills the offer visibly (the watcher
+  flags the spent outpoint). Fine for small size; discount accordingly.
+- **Tier A**: the venue co-key removes unilateral pulls; the venue never
+  has custody and at worst delays the seller until the refund height.
+  Co-signing uses the node's standard PQ-multisig PSBT flow.
+- **Tier A+**: no third party at all; the covenant fixes the settlement
+  destination at bond time. Needs the settlement template known up front
+  (negotiated block trades).
+- **Attestation binding is declared, not derived**: the challenge
+  signature proves the publisher controls `terms.seller_address`, not
+  that this address owns the refund key — the *supply* guarantees come
+  from the UTXO/commitment/descriptor checks, which need no attestation.
+- **Confirmations**: MatMul PoW is young; default to `--min-conf 20`
+  (~30 min at 90 s blocks) and scale with size.
+- **Long-lived bonds**: consider SLH-DSA keys (`pk_slh(...)` works in
+  every leaf) for bonds whose expiry is far out, per the design doc's
+  note on the ML-DSA emergency-disable path.
+
+## Files
+
+- `btx_otc.py` — SDK + CLI (offer terms hashing, bond descriptors,
+  create/verify/watch, bond refund, HTLC settlement wrappers). Run
+  `python3 btx_otc.py selftest` for the offline unit checks; the full
+  lifecycle is exercised by `test/functional/wallet_otc_offer.py`.

--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -1,0 +1,761 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTX developers
+# Distributed under the MIT software license.
+"""
+btx_otc — BTX OTC bonded-offer SDK + CLI (proof-of-offered-supply and escrow settlement).
+
+Implements the Phase-1 tooling of doc/btx-otc-escrow-supply-validation.md: an OTC
+offer only counts as real supply when it is backed by a *bonded offer vault* — coins
+locked in a P2MR output whose only spend paths are (a) settle this specific offer and
+(b) refund to the seller after the offer expires — with the offer terms bound to the
+funding transaction via an OP_RETURN commitment so the same coins can never back two
+different offers.
+
+The SDK drives a stock btxd via RPC only (no core dependency). Structure mirrors
+contrib/wbtx/btx_wbtx.py: pure helpers work offline; anything that touches the chain
+takes an `rpc` / `rpc_wallet` callable: rpc(method, *params) -> parsed JSON.
+
+Offer lifecycle::
+
+    from btx_otc import (OfferTerms, soft_bond_descriptor, create_offer, verify_offer)
+
+    # --- Seller: build + fund + publish -------------------------------------
+    terms = {
+        "version": 1,
+        "amount_sats": 5_000_000_000_000,      # 50,000 BTX
+        "expiry_height": 812_000,
+        "price": "spot-0.5%",                  # free-form; hashed verbatim
+        "settle_asset": "wBTX",
+        "seller_contact": "otc@desk.example",
+        "nonce": os.urandom(16).hex(),         # one offer == one terms hash
+    }
+    desc = soft_bond_descriptor(settle_pk, terms["expiry_height"], refund_pk)
+    bundle = create_offer(rpc, rpc_wallet, terms, desc)   # funds vault + OP_RETURN
+    publish(json.dumps(bundle))                            # any channel works
+
+    # --- Buyer / venue: verify against their own node -----------------------
+    report = verify_offer(rpc, bundle, min_conf=20)
+    assert report.ok, report.failures()
+
+Bond tiers (see the design doc §4.5)::
+
+    A+  ctv_bond_descriptor(...)    no third party; spendable ONLY into the
+                                    pre-committed settlement tx, or refund at expiry
+    A   venue_bond_descriptor(...)  2-of-2 seller+venue before expiry, refund after;
+                                    venue can grief (delay) but never take or redirect
+    B   soft_bond_descriptor(...)   seller can settle unilaterally pre-expiry; an
+                                    early pull is publicly visible (offer reads dead)
+
+Verification NEVER trusts the seller: descriptor shape is checked against a strict
+allow-list (unknown shapes fail closed), outpoints are checked in the UTXO set,
+the OP_RETURN terms-hash commitment is checked in the funding transactions, and the
+optional attestation is checked with verifymessage.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Callable, Optional
+
+Rpc = Callable[..., object]
+
+COIN = 100_000_000
+
+# Tag prefixing every OTC bond commitment: OP_RETURN <"BTXOTC1" || sha256(terms)>.
+OTC_TAG = b"BTXOTC1"
+# Serialized commitment scriptPubKey: OP_RETURN(0x6a) PUSH39(0x27) tag(7) hash(32).
+_COMMITMENT_SCRIPT_LEN = 1 + 1 + len(OTC_TAG) + 32
+
+
+# ============================= terms canonicalization =============================
+
+REQUIRED_TERMS_FIELDS = ("version", "amount_sats", "expiry_height", "nonce")
+
+
+def _reject_floats(value, path="terms"):
+    """Floats are not allowed anywhere in offer terms — they do not canonicalize."""
+    if isinstance(value, bool):
+        return
+    if isinstance(value, float):
+        raise ValueError(f"{path}: floats are forbidden in offer terms (use ints/strings)")
+    if isinstance(value, dict):
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise ValueError(f"{path}: non-string key {k!r}")
+            _reject_floats(v, f"{path}.{k}")
+    elif isinstance(value, (list, tuple)):
+        for i, v in enumerate(value):
+            _reject_floats(v, f"{path}[{i}]")
+
+
+def validate_terms(terms: dict) -> None:
+    if not isinstance(terms, dict):
+        raise ValueError("terms must be a JSON object")
+    _reject_floats(terms)
+    for f in REQUIRED_TERMS_FIELDS:
+        if f not in terms:
+            raise ValueError(f"terms missing required field '{f}'")
+    if not isinstance(terms["amount_sats"], int) or terms["amount_sats"] <= 0:
+        raise ValueError("terms.amount_sats must be a positive integer (satoshis)")
+    if not isinstance(terms["expiry_height"], int) or terms["expiry_height"] <= 0:
+        raise ValueError("terms.expiry_height must be a positive integer (block height)")
+
+
+def canonical_terms_bytes(terms: dict) -> bytes:
+    """Deterministic encoding: JSON with sorted keys, no whitespace, ASCII escapes."""
+    validate_terms(terms)
+    return json.dumps(terms, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=True).encode("ascii")
+
+
+def terms_hash(terms: dict) -> bytes:
+    return hashlib.sha256(canonical_terms_bytes(terms)).digest()
+
+
+def terms_hash_hex(terms: dict) -> str:
+    return terms_hash(terms).hex()
+
+
+def commitment_payload_hex(terms: dict) -> str:
+    """The OP_RETURN data payload (39 bytes) binding a funding tx to one offer."""
+    return (OTC_TAG + terms_hash(terms)).hex()
+
+
+def commitment_script_hex(terms: dict) -> str:
+    """The full expected OP_RETURN scriptPubKey hex (41 bytes serialized)."""
+    payload = OTC_TAG + terms_hash(terms)
+    assert len(payload) == 39
+    return "6a27" + payload.hex()
+
+
+def attestation_message(terms: dict, challenge: str) -> str:
+    """The exact string signed/verified for the offer attestation."""
+    return f"BTXOTC1|{terms_hash_hex(terms)}|{challenge}"
+
+
+# ============================= bond descriptors =============================
+
+# A descriptor key expression: raw ML-DSA hex, or pk_slh(<slh-dsa hex>).
+_KEY = r"(?:[0-9a-fA-F]+|pk_slh\([0-9a-fA-F]+\))"
+
+_TIER_B_RE = re.compile(
+    rf"^mr\(({_KEY}),\{{refund\((\d+),({_KEY})\)\}}\)$")
+_TIER_A_RE = re.compile(
+    rf"^mr\(multi_pq\(2,({_KEY}),({_KEY})\),\{{refund\((\d+),({_KEY})\)\}}\)$")
+_TIER_APLUS_RE = re.compile(
+    rf"^mr\(ctv_multi_pq\(([0-9a-fA-F]{{64}}),1,({_KEY})\),\{{refund\((\d+),({_KEY})\)\}}\)$")
+
+
+def soft_bond_descriptor(settle_pubkey: str, refund_locktime: int, refund_pubkey: str) -> str:
+    """Tier B: seller settles unilaterally pre-expiry; refund leaf after expiry."""
+    return f"mr({settle_pubkey},{{refund({refund_locktime},{refund_pubkey})}})"
+
+
+def venue_bond_descriptor(settle_pubkey: str, venue_pubkey: str,
+                          refund_locktime: int, refund_pubkey: str) -> str:
+    """Tier A: 2-of-2 seller+venue settlement handoff; seller-only refund after expiry."""
+    return (f"mr(multi_pq(2,{settle_pubkey},{venue_pubkey}),"
+            f"{{refund({refund_locktime},{refund_pubkey})}})")
+
+
+def ctv_bond_descriptor(ctv_template_hash_hex: str, settle_pubkey: str,
+                        refund_locktime: int, refund_pubkey: str) -> str:
+    """Tier A+: settlement constrained by covenant to one pre-committed transaction."""
+    if len(ctv_template_hash_hex) != 64:
+        raise ValueError("ctv_template_hash_hex must be 32 bytes of hex")
+    return (f"mr(ctv_multi_pq({ctv_template_hash_hex},1,{settle_pubkey}),"
+            f"{{refund({refund_locktime},{refund_pubkey})}})")
+
+
+@dataclass
+class BondInfo:
+    tier: str                     # "A+", "A", or "B"
+    refund_locktime: int
+    refund_pubkey: str
+    settle_pubkey: str
+    venue_pubkey: Optional[str] = None
+    ctv_hash: Optional[str] = None
+
+
+def strip_checksum(descriptor: str) -> str:
+    return descriptor.split("#", 1)[0]
+
+
+def parse_bond_descriptor(descriptor: str) -> BondInfo:
+    """
+    Classify a bond descriptor against the strict allow-list of known shapes.
+    Anything else raises — verification MUST fail closed on unknown script trees,
+    because an unrecognized leaf could be a hidden early-exit path.
+    """
+    desc = strip_checksum(descriptor).replace(" ", "")
+    m = _TIER_APLUS_RE.match(desc)
+    if m:
+        return BondInfo(tier="A+", ctv_hash=m.group(1).lower(), settle_pubkey=m.group(2),
+                        refund_locktime=int(m.group(3)), refund_pubkey=m.group(4))
+    m = _TIER_A_RE.match(desc)
+    if m:
+        return BondInfo(tier="A", settle_pubkey=m.group(1), venue_pubkey=m.group(2),
+                        refund_locktime=int(m.group(3)), refund_pubkey=m.group(4))
+    m = _TIER_B_RE.match(desc)
+    if m:
+        return BondInfo(tier="B", settle_pubkey=m.group(1),
+                        refund_locktime=int(m.group(2)), refund_pubkey=m.group(3))
+    raise ValueError("unrecognized bond descriptor shape (fail-closed); "
+                     "expected one of the documented tier A+/A/B forms")
+
+
+# ============================= node helpers =============================
+
+def add_checksum(rpc: Rpc, descriptor: str) -> str:
+    info = rpc("getdescriptorinfo", strip_checksum(descriptor))
+    return f"{strip_checksum(descriptor)}#{info['checksum']}"
+
+
+def bond_address(rpc: Rpc, descriptor_with_checksum: str) -> str:
+    addrs = rpc("deriveaddresses", descriptor_with_checksum)
+    if len(addrs) != 1:
+        raise ValueError("bond descriptor must derive exactly one address")
+    return addrs[0]
+
+
+def sats_to_btx_str(sats: int) -> str:
+    return f"{sats // COIN}.{sats % COIN:08d}"
+
+
+def to_sat(amount_btx) -> int:
+    """Convert a node decimal-BTX value (str/Decimal) to int satoshis exactly."""
+    sats = Decimal(str(amount_btx)).scaleb(8)
+    if sats != sats.to_integral_value():
+        raise ValueError(f"amount {amount_btx} has sub-satoshi precision")
+    return int(sats)
+
+
+# ============================= offer creation =============================
+
+def create_offer(rpc: Rpc, rpc_wallet: Rpc, terms: dict, descriptor: str,
+                 challenge: Optional[str] = None, attest: bool = True,
+                 fee_rate: Optional[int] = None) -> dict:
+    """
+    Fund the bond vault and emit the self-contained offer bundle.
+
+    Builds ONE transaction paying `terms.amount_sats` to the vault address plus the
+    OP_RETURN commitment `"BTXOTC1" || sha256(canonical terms)`, via the wallet
+    `send` RPC. The commitment in the funding tx is what makes the bond exclusive
+    to this offer (§4.2 of the design doc).
+
+    If `attest` is set, the bundle also carries a BIP-322 attestation: a fresh
+    challenge signed (signmessage) with the wallet address that owns the refund
+    key, proving the offer publisher controls the bond's exit key.
+    """
+    validate_terms(terms)
+    bond = parse_bond_descriptor(descriptor)
+    if bond.refund_locktime < terms["expiry_height"]:
+        raise ValueError("refund locktime is below terms.expiry_height: the seller "
+                         "could exit before the offer expires")
+
+    desc_ck = add_checksum(rpc, descriptor)
+    address = bond_address(rpc, desc_ck)
+
+    outputs = [{address: sats_to_btx_str(terms["amount_sats"])},
+               {"data": commitment_payload_hex(terms)}]
+    options = {}
+    if fee_rate is not None:
+        options["fee_rate"] = fee_rate
+    res = rpc_wallet("send", outputs, None, "unset", None, options)
+    if not res.get("complete", False):
+        raise RuntimeError("wallet send did not complete (locked wallet / insufficient funds?)")
+    txid = res["txid"]
+
+    # Locate the vault vout in the funding tx.
+    raw = rpc_wallet("gettransaction", txid)
+    decoded = rpc("decoderawtransaction", raw["hex"])
+    vout = None
+    for out in decoded["vout"]:
+        spk = out.get("scriptPubKey", {})
+        if spk.get("address") == address:
+            vout = out["n"]
+            break
+    if vout is None:
+        raise RuntimeError("funding tx does not pay the bond address (unexpected)")
+
+    bundle = {
+        "version": 1,
+        "terms": terms,
+        "bond": {
+            "descriptor": desc_ck,
+            "tier": bond.tier,
+            "outpoints": [{"txid": txid, "vout": vout}],
+        },
+    }
+
+    if attest:
+        challenge = challenge or os.urandom(16).hex()
+        attest_addr = terms.get("seller_address")
+        if not attest_addr:
+            raise ValueError("attest=True requires terms.seller_address (a wallet "
+                             "address the seller signs the challenge with); pass "
+                             "attest=False to skip")
+        sig = rpc_wallet("signmessage", attest_addr, attestation_message(terms, challenge))
+        bundle["attestation"] = {"address": attest_addr, "challenge": challenge,
+                                 "signature": sig}
+    return bundle
+
+
+# ============================= offer verification =============================
+
+@dataclass
+class Check:
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class OfferVerification:
+    ok: bool
+    tier: str
+    address: str
+    verified_sats: int
+    expiry_height: int
+    checks: list = field(default_factory=list)
+
+    def failures(self) -> list:
+        return [c for c in self.checks if not c.ok]
+
+    def as_dict(self) -> dict:
+        return {
+            "ok": self.ok, "tier": self.tier, "address": self.address,
+            "verified_sats": self.verified_sats, "expiry_height": self.expiry_height,
+            "checks": [{"name": c.name, "ok": c.ok, "detail": c.detail} for c in self.checks],
+        }
+
+
+def _get_funding_tx(rpc: Rpc, txid: str, blockhash: Optional[str],
+                    funding_height: Optional[int] = None):
+    """
+    Verbose funding tx without requiring -txindex: try the mempool/txindex path,
+    then the bundle's optional 'blockhash' hint, then the block derived from the
+    UTXO's own confirmation depth (height - confirmations + 1).
+    """
+    try:
+        return rpc("getrawtransaction", txid, True)
+    except Exception:  # noqa: BLE001 - fall through to the block-scoped paths
+        pass
+    if blockhash:
+        return rpc("getrawtransaction", txid, True, blockhash)
+    if funding_height is not None:
+        derived = rpc("getblockhash", funding_height)
+        return rpc("getrawtransaction", txid, True, derived)
+    raise RuntimeError("funding tx not retrievable (no -txindex, no blockhash hint)")
+
+
+def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
+                 require_attestation: bool = False) -> OfferVerification:
+    """
+    Run the full §4.3 verification against a local node. Returns a report whose
+    `ok` is True only if every executed check passed. Trust-minimized: nothing is
+    accepted from the bundle without being re-checked on-chain, and unknown
+    descriptor shapes fail closed.
+    """
+    checks: list = []
+    tier, address, verified_sats, expiry = "?", "", 0, 0
+
+    def check(name: str, ok: bool, detail: str = "") -> bool:
+        checks.append(Check(name, bool(ok), detail))
+        return bool(ok)
+
+    # C1 — terms are well-formed and canonicalizable.
+    terms = bundle.get("terms")
+    try:
+        want_script_hex = commitment_script_hex(terms)
+        expiry = terms["expiry_height"]
+        check("terms-canonical", True, f"terms_hash={terms_hash_hex(terms)}")
+    except Exception as e:  # noqa: BLE001
+        check("terms-canonical", False, str(e))
+        return OfferVerification(False, tier, address, 0, 0, checks)
+
+    # C2 — descriptor parses, is a known bond shape, and its timelock covers expiry.
+    try:
+        desc = bundle["bond"]["descriptor"]
+        desc_ck = add_checksum(rpc, desc)  # node-side parse + canonical checksum
+        address = bond_address(rpc, desc_ck)
+        bond = parse_bond_descriptor(desc)
+        tier = bond.tier
+        ok = bond.refund_locktime >= expiry
+        check("descriptor-shape", ok,
+              f"tier={bond.tier} refund_locktime={bond.refund_locktime} expiry={expiry}"
+              + ("" if ok else " (refund unlocks BEFORE offer expiry)"))
+    except Exception as e:  # noqa: BLE001
+        check("descriptor-shape", False, str(e))
+        return OfferVerification(False, tier, address, 0, expiry, checks)
+
+    # C3 — outpoints exist, are unspent, pay the vault, and are confirmed.
+    outpoints = bundle["bond"].get("outpoints", [])
+    seen = set()
+    funding_heights: dict = {}
+    all_utxos_ok = len(outpoints) > 0
+    if not outpoints:
+        check("outpoints", False, "bundle lists no outpoints")
+    for op in outpoints:
+        key = (op["txid"], op["vout"])
+        if key in seen:
+            all_utxos_ok = check("outpoints", False, f"duplicate outpoint {key}") and all_utxos_ok
+            continue
+        seen.add(key)
+        utxo = rpc("gettxout", op["txid"], op["vout"], False)
+        if utxo is None:
+            all_utxos_ok = check("outpoints", False,
+                                 f"{op['txid']}:{op['vout']} not in UTXO set "
+                                 "(spent, unconfirmed, or fabricated)") and all_utxos_ok
+            continue
+        spk_addr = utxo.get("scriptPubKey", {}).get("address")
+        if spk_addr != address:
+            all_utxos_ok = check("outpoints", False,
+                                 f"{op['txid']}:{op['vout']} pays {spk_addr}, "
+                                 f"not the bond vault {address}") and all_utxos_ok
+            continue
+        confs = int(utxo.get("confirmations", 0))
+        if confs < min_conf:
+            all_utxos_ok = check("outpoints", False,
+                                 f"{op['txid']}:{op['vout']} has {confs} confirmations "
+                                 f"(< {min_conf})") and all_utxos_ok
+            continue
+        verified_sats += to_sat(utxo["value"])
+        funding_heights[key] = rpc("getblockcount") - confs + 1
+        check("outpoints", True, f"{op['txid']}:{op['vout']} {utxo['value']} BTX, {confs} conf")
+
+    amount_ok = verified_sats >= terms["amount_sats"]
+    check("amount", amount_ok,
+          f"verified {verified_sats} sats vs terms.amount_sats {terms['amount_sats']}")
+    all_utxos_ok = all_utxos_ok and amount_ok
+
+    # C4 — every funding tx carries the OP_RETURN commitment to THESE terms.
+    commit_ok = True
+    for op in outpoints:
+        if (op["txid"], op["vout"]) not in seen:
+            continue
+        try:
+            fund_tx = _get_funding_tx(rpc, op["txid"], op.get("blockhash"),
+                                      funding_heights.get((op["txid"], op["vout"])))
+        except Exception as e:  # noqa: BLE001
+            commit_ok = check("commitment", False,
+                              f"{op['txid']}: funding tx unavailable ({e}); add a "
+                              "'blockhash' hint to the outpoint or run with -txindex") and commit_ok
+            continue
+        found = any(out.get("scriptPubKey", {}).get("hex", "").lower() == want_script_hex
+                    for out in fund_tx.get("vout", []))
+        commit_ok = check("commitment", found,
+                          f"{op['txid']}: OP_RETURN BTXOTC1||terms_hash "
+                          + ("present" if found else "MISSING or committed to different terms "
+                             "(possible double-pledge)")) and commit_ok
+
+    # C5 — offer not already expired.
+    height = rpc("getblockcount")
+    not_expired = height < expiry
+    check("not-expired", not_expired, f"height={height} expiry={expiry}")
+
+    # C6 — attestation (freshness / publisher-controls-a-seller-key). Optional:
+    # binding is 'declared' (attestation address is whatever the bundle names),
+    # so it proves challenge freshness and control of that address — the hard
+    # supply guarantees come from C2/C3/C4, not from this signature.
+    att = bundle.get("attestation")
+    att_ok = True
+    if att:
+        try:
+            msg = attestation_message(terms, att["challenge"])
+            att_ok = bool(rpc("verifymessage", att["address"], att["signature"], msg))
+            check("attestation", att_ok, f"address={att['address']}")
+        except Exception as e:  # noqa: BLE001
+            att_ok = check("attestation", False, str(e))
+    elif require_attestation:
+        att_ok = check("attestation", False, "bundle carries no attestation")
+
+    ok = all(c.ok for c in checks)
+    return OfferVerification(ok, tier, address, verified_sats, expiry, checks)
+
+
+def watch_offer(rpc: Rpc, bundle: dict, interval: float = 30.0,
+                on_event: Optional[Callable[[str, dict], None]] = None) -> str:
+    """
+    Poll the bond outpoints until the offer terminates. Returns one of:
+    "spent" (a bond outpoint left the UTXO set before expiry — settlement or,
+    for tier B, a pull; either way the offer is no longer backed), or
+    "expired" (chain passed terms.expiry_height).
+    """
+    terms = bundle["terms"]
+    outpoints = bundle["bond"]["outpoints"]
+
+    def emit(kind: str, data: dict):
+        if on_event:
+            on_event(kind, data)
+
+    while True:
+        height = rpc("getblockcount")
+        # Spent-ness wins over expiry: it is the terminal fact about the coins.
+        for op in outpoints:
+            if rpc("gettxout", op["txid"], op["vout"], False) is None:
+                emit("spent", {"outpoint": op, "height": height})
+                return "spent"
+        if height >= terms["expiry_height"]:
+            emit("expired", {"height": height})
+            return "expired"
+        emit("tick", {"height": height})
+        time.sleep(interval)
+
+
+# ============================= settlement (stage 2) =============================
+
+def _is_unknown_method(exc: Exception) -> bool:
+    err = getattr(exc, "error", None)
+    code = err.get("code") if isinstance(err, dict) else getattr(exc, "code", None)
+    if code == -32601:
+        return True
+    msg = str(exc).lower()
+    return "method not found" in msg or "unknown command" in msg
+
+
+def build_bond_refund(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
+                      vout: int, dest_address: str, locktime: int,
+                      fee_sat: int = 20000) -> str:
+    """
+    Reclaim an expired bond via its refund(locktime, key) leaf. Reuses the node's
+    buildhtlcrefund RPC, which accepts any mr() descriptor containing a refund
+    leaf and signs with the wallet-held sender key. Returns signed raw tx hex.
+    """
+    try:
+        res = rpc_wallet("buildhtlcrefund", descriptor_with_checksum,
+                         {"txid": txid, "vout": vout}, dest_address, locktime, fee_sat)
+    except Exception as e:  # noqa: BLE001
+        if _is_unknown_method(e):
+            raise NotImplementedError(
+                "buildhtlcrefund RPC unavailable on this node; upgrade to a btxd "
+                "with the HTLC bridging RPCs") from e
+        raise
+    if not res.get("complete", False):
+        raise RuntimeError("bond refund did not sign completely; check the locktime "
+                           "has been reached and the wallet owns the refund key")
+    return res["hex"]
+
+
+def swap_vault_descriptor(internal_pubkey: str, preimage_hash160_hex: str,
+                          claimer_pubkey: str, refund_locktime: int,
+                          sender_pubkey: str) -> str:
+    """Stage-2 HTLC settlement vault (identical shape to the wBTX Model-B leg)."""
+    return (f"mr({internal_pubkey},"
+            f"{{htlc({preimage_hash160_hex},{claimer_pubkey}),"
+            f"refund({refund_locktime},{sender_pubkey})}})")
+
+
+def new_preimage() -> bytes:
+    return os.urandom(32)
+
+
+def swap_hash160_hex(preimage: bytes) -> str:
+    """RIPEMD160(SHA256(preimage)) — same hashlock domain as the EVM HTLC contract."""
+    return hashlib.new("ripemd160", hashlib.sha256(preimage).digest()).hexdigest()
+
+
+def build_swap_claim(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
+                     vout: int, preimage: bytes, dest_address: str,
+                     fee_sat: int = 20000) -> str:
+    """Buyer claims the settlement vault with the preimage (reveals it on-chain)."""
+    try:
+        res = rpc_wallet("buildhtlcclaim", descriptor_with_checksum,
+                         {"txid": txid, "vout": vout}, preimage.hex(),
+                         dest_address, fee_sat)
+    except Exception as e:  # noqa: BLE001
+        if _is_unknown_method(e):
+            raise NotImplementedError(
+                "buildhtlcclaim RPC unavailable on this node; upgrade to a btxd "
+                "with the HTLC bridging RPCs") from e
+        raise
+    if not res.get("complete", False):
+        raise RuntimeError("swap claim did not sign completely; check the preimage "
+                           "and that the wallet owns the claimer key")
+    return res["hex"]
+
+
+def build_swap_refund(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
+                      vout: int, dest_address: str, locktime: int,
+                      fee_sat: int = 20000) -> str:
+    """Seller reclaims an unclaimed settlement vault after its timeout."""
+    return build_bond_refund(rpc_wallet, descriptor_with_checksum, txid, vout,
+                             dest_address, locktime, fee_sat)
+
+
+# ============================= offline selftest =============================
+
+def selftest() -> None:
+    """Offline sanity of the pure helpers (no node needed). Raises on failure."""
+    terms = {"version": 1, "amount_sats": 12345, "expiry_height": 100,
+             "nonce": "00" * 16, "b": [1, {"a": "x"}]}
+    # Canonicalization is order-insensitive and whitespace-free.
+    reordered = json.loads(json.dumps(terms)[::-1][::-1])
+    assert terms_hash(terms) == terms_hash(dict(reversed(list(reordered.items()))))
+    assert canonical_terms_bytes(terms) == canonical_terms_bytes(reordered)
+    # Floats are rejected.
+    try:
+        terms_hash({"version": 1, "amount_sats": 1, "expiry_height": 1,
+                    "nonce": "00", "price": 1.5})
+        raise AssertionError("float in terms must be rejected")
+    except ValueError:
+        pass
+    # Commitment script framing.
+    assert commitment_script_hex(terms) == "6a27" + (OTC_TAG + terms_hash(terms)).hex()
+    assert len(bytes.fromhex(commitment_script_hex(terms))) == _COMMITMENT_SCRIPT_LEN
+    # Descriptor round-trips for all tiers.
+    k1, k2, k3 = "aa" * 1312, "bb" * 1312, "cc" * 1312
+    b = parse_bond_descriptor(soft_bond_descriptor(k1, 900, k2))
+    assert (b.tier, b.refund_locktime, b.settle_pubkey, b.refund_pubkey) == ("B", 900, k1, k2)
+    a = parse_bond_descriptor(venue_bond_descriptor(k1, k3, 901, k2) + "#abcd1234")
+    assert (a.tier, a.venue_pubkey, a.refund_locktime) == ("A", k3, 901)
+    ap = parse_bond_descriptor(ctv_bond_descriptor("11" * 32, k1, 902, k2))
+    assert (ap.tier, ap.ctv_hash, ap.refund_locktime) == ("A+", "11" * 32, 902)
+    # SLH-DSA key forms parse too.
+    parse_bond_descriptor(soft_bond_descriptor(f"pk_slh({'dd' * 32})", 900, k2))
+    # Unknown shapes fail closed.
+    for bad in (f"mr({k1})",                                             # no refund leaf
+                f"mr({k1},{{htlc({'ee' * 20},{k2}),refund(900,{k2})}})",  # extra leaf
+                f"mr(multi_pq(1,{k1},{k3}),{{refund(900,{k2})}})"):       # 1-of-2 settle
+        try:
+            parse_bond_descriptor(bad)
+            raise AssertionError(f"must fail closed: {bad[:40]}...")
+        except ValueError:
+            pass
+    # Amount formatting.
+    assert sats_to_btx_str(5_000_000_000_000) == "50000.00000000"
+    assert to_sat("50000.00000000") == 5_000_000_000_000
+    assert to_sat(Decimal("0.00000001")) == 1
+    print("btx_otc selftest: OK")
+
+
+# ============================= CLI =============================
+
+def _make_cli_rpc(cli_cmd: str) -> Rpc:
+    """rpc(method, *params) by shelling out to btx-cli (handles auth/cookie for us)."""
+    base = shlex.split(cli_cmd)
+
+    def rpc(method: str, *params):
+        argv = list(base) + [method]
+        for p in params:
+            if isinstance(p, str):
+                argv.append(p)
+            else:
+                argv.append(json.dumps(p))
+        out = subprocess.run(argv, capture_output=True, text=True)
+        if out.returncode != 0:
+            raise RuntimeError(f"{method} failed: {out.stderr.strip() or out.stdout.strip()}")
+        text = out.stdout.strip()
+        if not text:
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return text  # bare-string results (e.g. signmessage)
+    return rpc
+
+
+def _load_json(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(prog="btx_otc", description=__doc__.splitlines()[1])
+    p.add_argument("--cli", default="btx-cli",
+                   help="node CLI command incl. flags, e.g. "
+                        "'btx-cli -regtest -rpcwallet=desk' (default: btx-cli)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("hash-terms", help="print the canonical terms hash of a terms JSON file")
+    sp.add_argument("terms_json")
+
+    sp = sub.add_parser("create", help="fund a bond vault and print the offer bundle")
+    sp.add_argument("terms_json")
+    sp.add_argument("descriptor", help="bond descriptor (tier A+/A/B shape)")
+    sp.add_argument("--no-attest", action="store_true")
+    sp.add_argument("--challenge", default=None)
+
+    sp = sub.add_parser("verify", help="verify an offer bundle against the node")
+    sp.add_argument("bundle_json")
+    sp.add_argument("--min-conf", type=int, default=20)
+    sp.add_argument("--require-attestation", action="store_true")
+
+    sp = sub.add_parser("watch", help="watch a bundle's bond outpoints until spent/expired")
+    sp.add_argument("bundle_json")
+    sp.add_argument("--interval", type=float, default=30.0)
+
+    sp = sub.add_parser("refund-bond", help="reclaim an expired bond via its refund leaf")
+    sp.add_argument("bundle_json")
+    sp.add_argument("dest_address")
+    sp.add_argument("--fee-sat", type=int, default=20000)
+    sp.add_argument("--broadcast", action="store_true")
+
+    sub.add_parser("selftest", help="run the offline unit checks")
+
+    args = p.parse_args(argv)
+    if args.cmd == "selftest":
+        selftest()
+        return 0
+
+    if args.cmd == "hash-terms":
+        print(terms_hash_hex(_load_json(args.terms_json)))
+        return 0
+
+    rpc = _make_cli_rpc(args.cli)
+
+    if args.cmd == "create":
+        bundle = create_offer(rpc, rpc, _load_json(args.terms_json), args.descriptor,
+                              challenge=args.challenge, attest=not args.no_attest)
+        print(json.dumps(bundle, indent=2, sort_keys=True))
+        return 0
+
+    if args.cmd == "verify":
+        report = verify_offer(rpc, _load_json(args.bundle_json), min_conf=args.min_conf,
+                              require_attestation=args.require_attestation)
+        print(json.dumps(report.as_dict(), indent=2))
+        return 0 if report.ok else 1
+
+    if args.cmd == "watch":
+        outcome = watch_offer(rpc, _load_json(args.bundle_json), interval=args.interval,
+                              on_event=lambda k, d: print(f"{k}: {d}", flush=True))
+        return 0 if outcome == "expired" else 2
+
+    if args.cmd == "refund-bond":
+        bundle = _load_json(args.bundle_json)
+        bond = parse_bond_descriptor(bundle["bond"]["descriptor"])
+        for op in bundle["bond"]["outpoints"]:
+            raw = build_bond_refund(rpc, bundle["bond"]["descriptor"], op["txid"],
+                                    op["vout"], args.dest_address,
+                                    bond.refund_locktime, args.fee_sat)
+            if args.broadcast:
+                print(rpc("sendrawtransaction", raw))
+            else:
+                print(raw)
+        return 0
+
+    return 1
+
+
+__all__ = [
+    "OTC_TAG", "REQUIRED_TERMS_FIELDS", "validate_terms", "canonical_terms_bytes",
+    "terms_hash", "terms_hash_hex", "commitment_payload_hex", "commitment_script_hex",
+    "attestation_message", "soft_bond_descriptor", "venue_bond_descriptor",
+    "ctv_bond_descriptor", "BondInfo", "parse_bond_descriptor", "strip_checksum",
+    "add_checksum", "bond_address", "sats_to_btx_str", "to_sat", "create_offer",
+    "Check", "OfferVerification", "verify_offer", "watch_offer", "build_bond_refund",
+    "swap_vault_descriptor", "new_preimage", "swap_hash160_hex", "build_swap_claim",
+    "build_swap_refund", "selftest",
+]
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/doc/btx-otc-escrow-supply-validation.md
+++ b/doc/btx-otc-escrow-supply-validation.md
@@ -1,8 +1,12 @@
 # BTX OTC Escrow & Verifiable-Supply Design
 
-**Status:** Design proposal (rev 1). No consensus changes required — every
-construction in this document is expressible with script/descriptor/RPC
-surfaces that are already consensus-active and shipped on `main`.
+**Status:** Design (rev 1) + Phase-1 reference tooling implemented in
+[`contrib/otc/`](../contrib/otc/README.md) (offer creation, verification,
+watching, bond refund, HTLC settlement wrappers; exercised end to end by
+`test/functional/wallet_otc_offer.py`). No consensus changes required —
+every construction in this document is expressible with
+script/descriptor/RPC surfaces that are already consensus-active and
+shipped on `main`.
 
 **Problem being solved:** OTC desks and brokers are quoting large blocks of
 BTX for sale that they cannot actually deliver ("phantom supply"), which

--- a/doc/btx-otc-escrow-supply-validation.md
+++ b/doc/btx-otc-escrow-supply-validation.md
@@ -1,0 +1,548 @@
+# BTX OTC Escrow & Verifiable-Supply Design
+
+**Status:** Design proposal (rev 1). No consensus changes required — every
+construction in this document is expressible with script/descriptor/RPC
+surfaces that are already consensus-active and shipped on `main`.
+
+**Problem being solved:** OTC desks and brokers are quoting large blocks of
+BTX for sale that they cannot actually deliver ("phantom supply"), which
+suppresses the market price. Today a buyer or the market at large has no way
+to distinguish a real 50,000 BTX offer from a screenshot. This document
+specifies (a) a trustless-as-possible on-chain escrow for OTC settlement and
+(b) a *proof-of-offered-supply* convention that makes phantom offers
+mechanically detectable — an offer that does not carry a valid supply proof
+is, by market convention, treated as fake.
+
+---
+
+## 1. Threat model: how fake supply works today
+
+| # | Vector | Description |
+|---|--------|-------------|
+| T1 | **Pure fabrication** | Desk quotes size it never had. "Proof" is a screenshot, a self-reported balance, or nothing. |
+| T2 | **Double-pledging** | One real UTXO is shown to many counterparties / venues simultaneously, multiplying apparent supply. |
+| T3 | **Borrowed / flash inventory** | Coins are borrowed, shown for the proof, and returned. Supply exists at proof time but is not deliverable. |
+| T4 | **Pull-before-settle** | Real coins are shown, but the seller retains a unilateral spend path and withdraws them mid-negotiation while the quote stays live. |
+| T5 | **Unconfirmed / reorg-able deposits** | "Supply" is an unconfirmed tx or a low-confirmation output that can be reorged or RBF'd away. |
+| T6 | **Unverifiable shielded claims** | "The coins are in the shielded pool." Per-account shielded balances are cryptographically unprovable to third parties on BTX (see §6.3), so such claims are unfalsifiable — perfect cover for T1. |
+| T7 | **Settlement default** | Supply is real, but the seller takes the buyer's payment leg and never delivers (or vice versa). Not a supply problem, but the escrow must close it or the supply proof is moot. |
+
+Design goal: **T1–T6 must be detectable by any verifier running a BTX full
+node, with no trust in the seller, the venue, or any third party. T7 must be
+eliminated for crypto↔crypto trades (atomic) and reduced to a
+bounded, non-custodial arbiter for fiat legs.**
+
+## 2. Design principles
+
+1. **No consensus changes.** Everything uses shipped, genesis-active
+   features: P2MR MAST trees, ML-DSA-44 / SLH-DSA PQ signatures,
+   CLTV/CSV timelocks, CTV (`OP_CHECKTEMPLATEVERIFY`), CSFS
+   (`OP_CHECKSIGFROMSTACK`), PQ k-of-n via `OP_CHECKSIGADD_*`, HTLC
+   leaves, and the existing descriptor/PSBT/RPC tooling.
+2. **Supply proof = confirmed, exclusively-bound, time-locked UTXOs.**
+   Not signatures over balances, not attestations — actual coins in the
+   UTXO set, spendable only along paths the verifier can enumerate.
+3. **Trustless where physics allows.** Crypto↔crypto legs settle
+   atomically (HTLC). Fiat legs use an arbiter whose power is *bounded by
+   covenant*: the arbiter can pick between two pre-committed outcomes but
+   can never redirect funds to itself.
+4. **Everything a verifier needs is public.** An offer is a
+   self-contained bundle (descriptor + outpoints + terms hash) checkable
+   against any full node with `deriveaddresses` + `gettxout` /
+   `scantxoutset`. No RPC access to the seller required.
+
+## 3. What BTX already provides (capability inventory)
+
+The chain is unusually well equipped for this. Verified against current
+`main`:
+
+- **P2MR MAST** (witness v2, 32-byte Merkle root, `btx1z...`): arbitrary
+  multi-leaf script trees; the spend reveals only the taken leaf.
+  Reduced-data rules make P2MR the *only* standard output type
+  (34-byte scriptPubKey cap, `fEnforceP2MROnlyOutputs`,
+  `src/validation.cpp` `CheckReducedDataOutputLimits`), so escrow scripts
+  are always committed as Merkle roots — cheap and private.
+- **Timelocks:** `OP_CHECKLOCKTIMEVERIFY` / `OP_CHECKSEQUENCEVERIFY`
+  (`src/script/interpreter.cpp:559,598`).
+- **Covenants:** `OP_CHECKTEMPLATEVERIFY` (BIP-119-style, P2MR leaves,
+  `src/script/ctv.{h,cpp}`) — spends can be constrained to an exact
+  pre-committed output set.
+- **Oracle signatures:** `OP_CHECKSIGFROMSTACK` over
+  `TaggedHash("CSFS/btx")` with ML-DSA or SLH-DSA keys
+  (`src/script/interpreter.cpp:1286`).
+- **PQ k-of-n multisig:** `OP_CHECKSIGADD_MLDSA/_SLHDSA` accumulator
+  leaves, ≤ 8 ML-DSA keys per leaf (policy `MAX_PQ_PUBKEYS_PER_MULTISIG`),
+  or ~hundreds of 32-byte SLH-DSA keys.
+- **First-class escrow descriptors** (`src/script/descriptor.cpp`,
+  builders in `src/script/pqm.cpp`):
+  - `mr(multi_pq(m,k1,...))`, `sortedmulti_pq`
+  - `mr(cltv_multi_pq(locktime,m,k1,...))`, `csv_multi_pq(seq,...)`
+  - `mr(ctv_multi_pq(ctv_hash,m,k1,...))`, `ctv(hash)`, CTV+CHECKSIG
+  - `htlc(<hash160>,<claimer_key>)` and `refund(<locktime>,<sender_key>)`
+    leaves, CSFS delegation leaves
+  - Trees: `mr(<primary_leaf>, {<leaf>, <leaf>})` — **the primary slot
+    accepts any leaf type** (same `parse_leaf_expr`), so a vault can be
+    built with *no* unconditional key path.
+- **Escrow spend RPCs:** `buildhtlcclaim` / `buildhtlcrefund`
+  (`src/wallet/shielded_rpc.cpp`), exercised end-to-end in
+  `test/functional/wallet_htlc_atomicswap.py`.
+- **Multi-party signing:** PSBT with dedicated P2MR fields
+  (`PSBT_IN_P2MR_LEAF_SCRIPT`, `PSBT_IN_P2MR_PQ_SIG`, CSFS msg/sig
+  fields), `createmultisig` (PQ-only), `addpqmultisigaddress`,
+  descriptor wallets, offline signing.
+- **Supply auditing substrate:** `gettxoutsetinfo` + coinstats index,
+  `scantxoutset` (descriptor scan of the UTXO set without wallet import),
+  `getshieldedstateinfo.pool_balance` (consensus turnstile = total value
+  inside the shielded pool, `src/shielded/turnstile.h`), PQ
+  `signmessage` for proof of key control.
+- **Cross-chain leg:** wBTX Model B trustless atomic swap
+  (`contrib/wbtx/evm/WBTXAtomicSwapHTLC.sol`) shares the exact
+  `RIPEMD160(SHA256(preimage))` hashlock with the BTX `htlc()` leaf.
+
+What does **not** exist (and this design routes around): DLC/adaptor
+signatures/PTLC (PQ adaptor signatures for ML-DSA are research-grade), any
+per-account shielded balance proof, and any proof-of-reserves RPC.
+
+## 4. Core construct: the Bonded Offer Vault (BOV)
+
+The unit of verifiable supply is a **bonded offer**: coins locked in a
+P2MR vault whose spend paths are exactly *{settle this offer}* or
+*{refund to seller after the offer expires}* — nothing else. The offer is
+fake-proof because the coins provably exist, provably cannot be pulled
+early (T4), cannot back a second offer (T2), and cannot be "returned to the
+lender" before expiry (T3).
+
+### 4.1 Two stages
+
+OTC offers are usually published before a specific buyer exists, so
+bonding happens in two stages:
+
+**Stage 1 — Offer bond (no buyer yet).**
+
+```
+BOND = mr( multi_pq(2, S_settle, V),          # settlement handoff: seller + venue co-sign
+           refund(H_expiry, S_refund) )        # seller-only exit after offer expiry
+```
+
+- `S_settle`, `S_refund`: seller ML-DSA keys. `V`: the venue/orderbook
+  operator's key (or a 2-of-3 of neutral co-signers for venue-less OTC).
+- Before `H_expiry`, coins can move **only** with the venue co-signing,
+  and the venue's published policy is to co-sign only a spend whose
+  outputs are a Stage-2 trade escrow for *this* offer (venue software
+  enforces this mechanically; see §4.4 for the covenant-hardened
+  variant). The venue never gains custody — it holds 1 of 2 keys and can
+  at worst grief (refuse to co-sign), in which case the seller recovers
+  everything at `H_expiry` via the `refund` leaf.
+- After `H_expiry` the seller exits unilaterally. A live offer therefore
+  always points at an unspent, timelocked UTXO.
+
+For self-published offers with no venue at all, a weaker
+**soft bond** is acceptable: `mr(S_settle, {refund(H_expiry, S_cold)})`.
+The seller *can* pull early (T4 partially returns), but the pull is
+instantly visible — verifiers treat "outpoint spent, offer still quoted"
+as proof of bad faith. Markets should prefer hard bonds for size.
+
+**Stage 2 — Trade escrow (buyer engaged).** The bond UTXO is spent
+(seller + venue) directly into one of the settlement vaults of §5,
+committing to the specific buyer and terms. One transaction; the coins
+are never in anyone's unilateral custody in between.
+
+### 4.2 Offer binding: one UTXO, one offer (kills T2)
+
+Every offer has a canonical **terms hash**:
+
+```
+offer_terms_hash = SHA256(canonical_json{
+    version, seller_id_pubkey, amount_sats, price_or_pricing_formula,
+    settle_asset, settle_venue, H_expiry, bond_outpoints[],
+    settlement_type, arbiter/oracle keys if any, nonce })
+```
+
+The funding transaction that creates the bond UTXO(s) includes one
+`OP_RETURN` output:
+
+```
+OP_RETURN "BTXOTC1" || offer_terms_hash        # 7 + 32 = 39 bytes ≤ 83-byte cap
+```
+
+Because an outpoint has exactly one funding transaction and that
+transaction commits to exactly one terms hash, **the same coins can never
+verifiably back two different offers** — a second "offer bundle" citing
+the same outpoint with different terms fails verification at every
+verifier, on every venue, with no cross-venue coordination needed.
+Offers funded without the commitment simply verify as *unbound* (tier
+B in §4.5) and should be priced/trusted accordingly.
+
+### 4.3 The offer bundle and the verification algorithm
+
+An offer is published (on a venue, in a Signal chat, anywhere) as a
+self-contained JSON bundle:
+
+```json
+{
+  "version": 1,
+  "terms": { ...exact fields hashed above... },
+  "bond": {
+    "descriptor": "mr(multi_pq(2,<S_settle>,<V>),{refund(812000,<S_refund>)})#checksum",
+    "outpoints": [ {"txid": "...", "vout": 0} ]
+  },
+  "attestation": {
+    "challenge": "<venue-or-buyer-supplied nonce>",
+    "sig": "<PQ signmessage by S_refund over SHA256(terms) || challenge>"
+  }
+}
+```
+
+**Verification (any full node, no seller cooperation):**
+
+1. `getdescriptorinfo` / `deriveaddresses` on the descriptor → address
+   `A`. Reject if descriptor grammar or checksum is off.
+2. For each outpoint: `gettxout` → exists, unspent, pays to `A`,
+   confirmations ≥ `MIN_CONF` (recommend ≥ 20; 90-second blocks make
+   this ~30 minutes — see §8.1), sum ≥ `terms.amount_sats`. Kills T1/T5.
+3. Fetch each funding tx: `OP_RETURN "BTXOTC1" || H` present and
+   `H == SHA256(canonical terms)`. Kills T2.
+4. Parse the descriptor tree: the **only** pre-expiry paths are the
+   declared settlement path(s), and the refund leaf's locktime
+   ≥ `terms.H_expiry`. Kills T3/T4 (no early unilateral exit exists).
+5. Verify the PQ attestation signature against `S_refund` and the fresh
+   challenge (proves the offer publisher controls the refund key — i.e.
+   is the coin owner, not someone replaying a stranger's bond).
+6. Continuously: watch the outpoints (`scantxoutset` or a ZMQ watcher).
+   Spent-before-settlement ⇒ mark offer dead, flag the seller.
+
+Every step is a handful of standard RPC calls; §9 proposes packaging
+steps 1–5 as a single `otc_verifyoffer` RPC / SDK call so wallets and
+venues can one-shot it.
+
+### 4.4 Covenant-hardened bond (optional, removes venue trust)
+
+Where the trade's settlement template can be fixed at bond time (known
+buyer, fixed split — e.g. a negotiated block trade rather than an open
+orderbook offer), replace the venue co-sign with CTV and get a fully
+trustless hard bond:
+
+```
+BOND = mr( ctv_multi_pq(<H_tmpl>, 1, S_settle),   # seller can ONLY spend into the
+           refund(H_expiry, S_refund) )            # pre-committed settlement tx
+```
+
+`H_tmpl` is the BIP-119-style template hash of the exact Stage-2 funding
+transaction (outputs = the trade escrow of §5 + change). The seller
+retains liveness (signs alone) but zero discretion over destination.
+This is the strongest form: **no third party, no early exit, no
+destination other than the agreed escrow.**
+
+### 4.5 Bond tiers (market convention)
+
+| Tier | Construction | Guarantees | Residual trust |
+|------|--------------|-----------|----------------|
+| A+ | CTV bond (§4.4) | exists, exclusive, unpullable, destination-fixed | none |
+| A | Venue co-sign bond (§4.1) | exists, exclusive, unpullable | venue liveness (griefing only) |
+| B | Soft bond + OP_RETURN binding | exists, exclusive, pull is publicly visible | seller restraint pre-settle |
+| C | Bare signmessage over arbitrary UTXOs | exists at proof time | everything else (T2/T3/T4) |
+| F | Balance screenshots, shielded claims, no proof | none | everything — **treat as no supply** |
+
+Venues and OTC aggregators should display the tier and refuse to list
+size above a threshold below tier B. The point of standardizing tiers is
+that *price discovery can discount unproven supply to zero*: once real
+desks bond at tier A/B, quoting phantom size at tier F stops moving the
+market — which is precisely the attack we are defusing.
+
+## 5. Settlement constructions (Stage 2)
+
+### 5.1 Crypto ↔ crypto: HTLC atomic swap — fully trustless (closes T7)
+
+For BTX vs wBTX / stablecoin / any HTLC-capable asset. Already shipped
+end to end:
+
+```
+SWAP = mr( <internal_or_ctv_leaf>,
+           { htlc(<H160>, K_buyer),          # buyer claims with preimage
+             refund(H_timeout_btx, S) } )    # seller refunds after timeout
+```
+
+- `H160 = RIPEMD160(SHA256(preimage))`, byte-identical to the hashlock in
+  `WBTXAtomicSwapHTLC.sol`, so BTX↔EVM swaps work today
+  (`contrib/wbtx/btx_wbtx.py`, `buildhtlcclaim` / `buildhtlcrefund`).
+- Standard timeout asymmetry: the party that reveals the preimage
+  (buyer, claiming the BTX leg) gets the *shorter* window on the other
+  chain: `H_timeout_other_leg + Δ < H_timeout_btx`, with `Δ` sized for
+  worst-case congestion on both chains (suggest ≥ 24h equivalent).
+- Stage-1→Stage-2 flow: the bond spend funds `SWAP` directly; the buyer
+  verifies the `SWAP` output in the same tx template before locking
+  their own leg.
+
+This is the recommended default for desk-to-desk and desk-to-whale
+trades: *no arbiter, no venue, no custody, atomic*.
+
+### 5.2 Fiat leg: bounded-arbiter CTV escrow (arbiter cannot steal)
+
+Fiat cannot be atomic, so we bound the arbiter with covenants instead of
+trusting a classic 2-of-3 (where two colluding parties — including the
+arbiter — can send funds anywhere):
+
+```
+ESCROW = mr( multi_pq(2, K_buyer, S),                      # happy path: both co-sign
+             { { ctv_multi_pq(<H_pay_buyer>,   1, K_arb),  # arbiter: release to buyer
+                 ctv_multi_pq(<H_refund_seller>,1, K_arb) },# arbiter: return to seller
+               refund(H_deadlock, S) } )                    # nuclear fallback
+```
+
+- `H_pay_buyer` / `H_refund_seller` are CTV template hashes of the only
+  two transactions the arbiter can authorize: *all funds → buyer* or
+  *all funds → seller* (templates include fee provisioning; see §8.2).
+  **The arbiter chooses an outcome; it can never choose a destination.**
+  Collusion with either party yields that party nothing beyond what the
+  dispute verdict would — and the arbiter can never pay itself.
+- Happy path (fiat arrived, both content) needs no arbiter at all.
+- `refund(H_deadlock, S)` with `H_deadlock` well past the dispute window
+  guarantees funds never strand if the arbiter vanishes. (Convention:
+  buyer must open a dispute — visible to the arbiter — well before
+  `H_deadlock`; an arbiter verdict tx confirmed before `H_deadlock`
+  settles the matter since the refund leaf is still time-locked.)
+- Split verdicts (e.g. 70/30) can be added as additional
+  `ctv_multi_pq` leaves for pre-agreed partial-fill templates.
+
+### 5.3 Payment-oracle variant: CSFS "DLC-lite"
+
+Where an automated payment rail can attest fiat arrival (bank API
+watcher, PSP webhook, e-money on-chain event), replace the human arbiter
+with CSFS oracle leaves:
+
+```
+ESCROW = mr( multi_pq(2, K_buyer, S),
+             { csfs_pk(K_oracle_offer, K_buyer),    # oracle attestation + buyer sig
+               refund(H_timeout, S) } )
+```
+
+The oracle signs an attestation message (convention:
+`settled:<offer_terms_hash>`, hashed under `TaggedHash("CSFS/btx")`) —
+it holds no funds and sees no funds. The buyer claims with the oracle
+attestation plus their own signature (`csfs_pk` = CSFS + CHECKSIG,
+`BuildP2MRDelegationScript` in `src/script/pqm.cpp:327`).
+
+**Replay caveat (important):** the shipped CSFS leaf is
+`<pubkey> OP_CHECKSIGFROMSTACK` — the *message is supplied in the
+witness, not pinned by the leaf script*. Any message the oracle key has
+ever signed satisfies the leaf. Binding to one trade therefore MUST come
+from **per-offer oracle keys**: the oracle derives a fresh key per
+`offer_terms_hash` and publishes the mapping; reusing one oracle key
+across escrows is unsafe. (A message-pinning leaf variant —
+`OP_SHA256 <msg_hash> OP_EQUALVERIFY` before the CSFS check — is
+consensus-valid today and is proposed as a Phase-1 descriptor/policy
+template addition in §9.)
+
+Oracle equivocation/outage: use k-of-n oracle leaves (n independent
+attesters with per-offer keys). Non-attestation degrades to the seller
+refund at `H_timeout`, i.e. buyer risk is bounded at "fiat sent, trade
+refunded" — which the dispute-window convention (send fiat only well
+before `H_timeout − dispute_margin`) plus an arbiter leaf (§5.2 and §5.3
+compose in one tree) reduces further.
+
+### 5.4 Classic 2-of-3 (available today, lowest engineering effort)
+
+`mr(multi_pq(2, K_buyer, S, K_arb), {refund(H_deadlock, S)})` via
+`createmultisig` / `addpqmultisigaddress` + PSBT. Weaker than §5.2
+(arbiter + one party can redirect funds arbitrarily) but deployable this
+week with zero new code. Acceptable for small size / trusted arbiters;
+venues should label it distinctly from bounded-arbiter escrow.
+
+## 6. Supply validation beyond single offers
+
+### 6.1 Desk-level proof of reserves (standing inventory)
+
+For desks that want to advertise standing inventory (not yet bonded to a
+specific offer):
+
+1. Desk publishes a descriptor set (watch-only, e.g. `mr()` ranged
+   descriptors) for its inventory addresses.
+2. Verifier: `scantxoutset` over the descriptors → total, confirmations.
+3. Freshness/control: challenge-response — verifier supplies a nonce,
+   desk returns PQ `signmessage` from each address key (or a designated
+   proof key per descriptor) over `nonce || height || descriptor_hash`.
+4. Anti-T3 (borrowed coins): repeat at random intervals; borrowed
+   inventory shows up as churn. For hard guarantees, only bonded offers
+   (§4) count — reserves proofs are marketing, bonds are commitments.
+
+This is renBTC/exchange-PoR-grade assurance and intentionally second
+class: the tier table (§4.5) prices it as tier C.
+
+### 6.2 Macro supply audit (is the *chain's* supply what it claims?)
+
+Any participant can independently confirm aggregate supply — useful when
+"fake supply" FUD is itself the manipulation:
+
+- `gettxoutsetinfo` (coinstats index) → transparent UTXO total +
+  UTXO-set hash.
+- `getshieldedstateinfo.pool_balance` → consensus turnstile total of
+  value inside the shielded pool (`src/shielded/turnstile.h` — the pool
+  cannot hold more than this; the invariant is consensus-enforced).
+- transparent total + pool balance ≤ emission schedule at height. Any
+  discrepancy is a consensus bug, not a market rumor.
+
+### 6.3 Shielded claims: the explicit market rule
+
+BTX has **no mechanism to prove a per-account shielded balance to a third
+party** — raw viewing-key export is disabled post-61000
+(`z_exportviewingkey` guarded by
+`RequireRawViewingKeySharingAllowedOrThrow`), view grants disclose
+individual bridge operations, not balances, and no attestation RPC
+exists. Moreover the pool is in wind-down: **no new shielded credits
+after block 125,000** — only viewing, recovery accounting, and
+transparent exits remain, so shielded inventory cannot even be
+replenished.
+
+The rule this design asks the market to adopt is therefore simple:
+**shielded-balance claims count as zero supply.** A desk with shielded
+inventory that wants it counted must exit it transparently (the exit is
+the proof) and bond it. This converts T6 from "unfalsifiable claim" into
+"non-claim".
+
+## 7. Why this kills phantom supply (economics)
+
+- **Capital lockup is the cost of quoting.** A tier-A/B offer requires
+  real coins locked for the offer lifetime. Suppressing price with 10×
+  phantom size now requires 10× real capital held out of use — and that
+  capital is *visibly committed sell-side*, which is information the
+  market prices correctly rather than manipulably.
+- **Exclusivity is cryptographic.** T2 (the main force multiplier for
+  phantom supply) dies with outpoint-unique OP_RETURN binding: N venues
+  showing the same coins collapse to one verifiable offer.
+- **Lying is detectable in one RPC round-trip.** Once wallets/venues run
+  `otc_verifyoffer` by default, an unproven quote is a self-labeling
+  scam. The equilibrium: unproven size trades at zero credibility, so it
+  stops being produced.
+- **Honest sellers get paid for bonding.** Verifiable firm offers are
+  worth a tighter spread (buyer's execution risk on a tier-A offer is
+  ~zero), so the convention is adoption-incentivized, not just
+  virtue-incentivized.
+
+## 8. Security considerations
+
+1. **Reorgs / PoW maturity (T5).** MatMul PoW is novel; be conservative:
+   `MIN_CONF ≥ 20` (~30 min at 90 s spacing) for bond recognition,
+   scale with offer size. Verifiers must re-check on reorg (watch
+   outpoints, not just one-shot verify).
+2. **Fees in CTV templates.** CTV commits to exact outputs; templates
+   must embed a fee (recommended: generous, since escrow settlements are
+   rare and high-value) or provide a small anchor-style output for CPFP.
+   The CTV implementation plan's L2 profile (Appendix E,
+   `docs/btx-ctv-csfs-implementation-plan.md`) documents CPFP/package
+   relay expectations. Never build a template chain that can strand at a
+   fee spike with no bump path.
+3. **ML-DSA kill switch.** Consensus carries an emergency
+   `nMLDSADisableHeight` (`SCRIPT_VERIFY_DISALLOW_MLDSA`). Long-lived
+   escrows should include SLH-DSA backup keys in a parallel leaf
+   (mixed-algorithm trees are supported) so funds cannot strand if
+   ML-DSA is ever disabled mid-escrow. Recommended for any bond with
+   `H_expiry` more than a few weeks out.
+4. **Leaf size / standardness.** Relay policy caps leaf scripts at 1,650
+   bytes except multisig leaf types (consensus 11,000). One ML-DSA key ≈
+   1,315 bytes in-leaf: keep non-multisig leaves to one ML-DSA key (+
+   32-byte SLH-DSA or oracle keys), exactly as the shipped `htlc()` /
+   `refund()` grammars do; k-of-n ML-DSA committees cap at n ≤ 8.
+5. **Oracle/arbiter key hygiene.** Arbiter and oracle keys must be
+   per-role, ideally per-offer (the CSFS message binds the terms hash,
+   the CTV templates bind destinations, so key reuse is contained — but
+   rotation limits blast radius of a key theft).
+6. **Privacy.** MAST hides untaken paths: a cooperatively settled trade
+   reveals only the 2-of-2 leaf — not the arbiter's existence, the
+   dispute templates, or the refund key. The OP_RETURN tag does mark
+   bond funding txs as OTC bonds; sellers who dislike that trade
+   linkability for tier-B verifiability by choice.
+7. **Venue griefing (tier A).** The venue's only power is refusing to
+   co-sign, delaying the seller until `H_expiry`. Sellers should size
+   `H_expiry` to what they can tolerate having locked, and venues that
+   grief are publicly observable (bond refunds at expiry without
+   settlement are on-chain).
+
+## 9. Implementation roadmap
+
+**Phase 0 — usable today, zero code.** Tier-B soft bonds + §5.4 2-of-3 +
+§5.1 HTLC swaps all work with existing RPCs (`getdescriptorinfo`,
+`deriveaddresses`, `importdescriptors`, `createmultisig`, PSBT flows,
+`buildhtlcclaim`/`buildhtlcrefund`, `scantxoutset`, PQ `signmessage`).
+Publish the offer-bundle JSON schema and the verification checklist
+(§4.3) as a market convention document.
+
+**Phase 1 — tooling (contrib/otc + wallet RPCs), no consensus changes.**
+The key-management guide already flags canned vault templates as a gap;
+fill it with:
+- `otc_createoffer` — builds the bond descriptor (tier A/A+/B), funds it
+  with the `OP_RETURN "BTXOTC1"||H` commitment, emits the offer bundle.
+- `otc_verifyoffer` — runs §4.3 steps 1–5 against the local node;
+  returns tier, verified size, expiry, and failure reasons. This is the
+  single most important deliverable: verification must be one command.
+- `otc_settle` / `otc_refund` — PSBT-based Stage-2 spend builders
+  (generalizing `buildhtlcclaim`/`buildhtlcrefund` to the multisig, CTV
+  and CSFS leaves), plus `otc_watchoffer` (ZMQ/poll watcher that flags
+  spent bonds — same skeleton as the wBTX backing-invariant watcher,
+  which is also still unbuilt).
+- A `ctv_template` helper RPC to compute BIP-119-style hashes for §4.4 /
+  §5.2 templates so integrators never hand-serialize them.
+- A message-pinned CSFS leaf (`csfs_msg(<msg_hash>,<oracle_key>,<spender_key>)`
+  → `OP_SHA256 <msg_hash> OP_EQUALVERIFY` before the CSFS check):
+  consensus-valid today, needs only a descriptor grammar + policy
+  template-matcher entry, and removes the per-offer oracle-key
+  requirement of §5.3.
+
+**Phase 2 — ecosystem.** Venue integration (display tiers, auto-verify,
+shared offer registry keyed by outpoint so double-pledges are flagged
+even at tier C), Python SDK in `contrib/otc/` mirroring
+`contrib/wbtx/btx_wbtx.py`, and a public verifier web tool backed by
+`scantxoutset`.
+
+**Phase 3 — research (optional).** PQ adaptor signatures / PTLC for
+scriptless swaps (open research for ML-DSA); zk proof-of-reserves for
+any future shielded surface; a standing "offer registry" OP_RETURN
+namespace if the market wants offer discovery fully on-chain.
+
+## 10. Worked example (tier A bond → HTLC settlement, regtest-ready)
+
+```bash
+# --- Seller creates keys ---
+S_SETTLE=$(btx-cli -rpcwallet=desk getnewaddress "" p2mr)
+S_SETTLE_PK=$(btx-cli -rpcwallet=desk exportpqkey "$S_SETTLE" | jq -r .pubkey)
+S_REFUND=$(btx-cli -rpcwallet=desk getnewaddress "" p2mr)
+S_REFUND_PK=$(btx-cli -rpcwallet=desk exportpqkey "$S_REFUND" | jq -r .pubkey)
+# Venue publishes V_PK out of band.
+
+# --- Stage 1: bond 50,000 BTX until height 812000 ---
+DESC="mr(multi_pq(2,$S_SETTLE_PK,$V_PK),{refund(812000,$S_REFUND_PK)})"
+CK=$(btx-cli getdescriptorinfo "$DESC" | jq -r .checksum)
+ADDR=$(btx-cli deriveaddresses "$DESC#$CK" | jq -r '.[0]')
+# Fund with a tx that also carries: OP_RETURN 4254584f544331 || <terms_hash>
+# (send via a raw tx / PSBT with a data output; wallet sendtoaddress + data
+#  output helper is a Phase-1 item)
+
+# --- Any buyer verifies (no seller involvement) ---
+btx-cli gettxout <txid> <vout>          # unspent, ≥20 conf, pays $ADDR, amount ok
+btx-cli getrawtransaction <txid> 2      # OP_RETURN commitment matches terms hash
+# descriptor grammar shows: no path before 812000 except 2-of-2 with venue ✔
+
+# --- Stage 2: buyer engages; bond is spent into the swap vault ---
+SWAP="mr($S_SETTLE_PK,{htlc($H160,$BUYER_PK),refund(811500,$S_REFUND_PK)})"
+# (seller+venue co-sign the bond spend whose sole non-change output is $SWAP_ADDR;
+#  buyer locks the wBTX/stable leg under the same H160 with a shorter timeout)
+
+# --- Settlement ---
+btx-cli -rpcwallet=buyer buildhtlcclaim "$SWAP#..." '{"txid":"...","vout":0}' \
+        "$PREIMAGE_HEX" "$BUYER_DEST" 20000
+# or, if the buyer never shows:
+btx-cli -rpcwallet=desk buildhtlcrefund "$SWAP#..." '{"txid":"...","vout":0}' \
+        "$S_REFUND_DEST" 811500 20000
+```
+
+## 11. Summary
+
+| Problem | Answer | Mechanism |
+|---------|--------|-----------|
+| Does the supply exist? | Provable by anyone | Bond UTXO + confirmations (`gettxout`/`scantxoutset`) |
+| Is it double-pledged? | Impossible to hide | `OP_RETURN` terms-hash binding, outpoint uniqueness |
+| Can it vanish mid-quote? | No (tier A/A+) | No unilateral pre-expiry path in the MAST tree |
+| Is it borrowed for show? | Not while bonded | Timelocked refund leaf ≥ offer expiry |
+| Will settlement actually happen? | Atomic for crypto legs | HTLC leaves + `buildhtlcclaim`/`buildhtlcrefund` |
+| Fiat-leg disputes? | Bounded arbiter, cannot steal | CTV verdict templates (`ctv_multi_pq`) / CSFS oracles |
+| Shielded "trust me" claims? | Counted as zero | No per-account proof exists; pool is sunsetting; exit-then-bond |
+| Consensus changes needed? | **None** | All leaves/opcodes/RPCs are live on `main` today |

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -447,6 +447,7 @@ BASE_SCRIPTS = [
     'wallet_bridge_attested_unshield.py --descriptors',
     'wallet_bridge_refund_timeout.py --descriptors',
     'wallet_htlc_atomicswap.py --descriptors',
+    'wallet_otc_offer.py --descriptors',
     'p2p_leak.py',
     'wallet_encryption.py --legacy-wallet',
     'wallet_encryption.py --descriptors',

--- a/test/functional/wallet_htlc_atomicswap.py
+++ b/test/functional/wallet_htlc_atomicswap.py
@@ -144,7 +144,8 @@ class WalletHtlcAtomicSwapTest(BitcoinTestFramework):
 
         # The preimage is now revealed on-chain in the claim witness (so the EVM leg
         # can be claimed). Scan the witness stack for the matching item.
-        claim_tx = node.getrawtransaction(claim_txid, True)
+        # No -txindex on this node: scope the lookup to the block that confirmed it.
+        claim_tx = node.getrawtransaction(claim_txid, True, node.getbestblockhash())
         revealed = False
         want = hash160(preimage)
         for vin in claim_tx["vin"]:

--- a/test/functional/wallet_otc_offer.py
+++ b/test/functional/wallet_otc_offer.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The BTX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+"""Bonded OTC offer lifecycle (doc/btx-otc-escrow-supply-validation.md, contrib/otc).
+
+Drives the contrib/otc/btx_otc.py SDK end to end against a regtest node:
+
+  1. CREATE   a tier-B bonded offer: fund the bond vault + the OP_RETURN
+              "BTXOTC1" || sha256(canonical terms) commitment in one tx.
+  2. VERIFY   the published bundle with a node only (no seller cooperation):
+              descriptor shape, UTXO existence/confirmations/amount, funding-tx
+              commitment, expiry, attestation.
+  3. REJECT   fakes: tampered terms, double-pledged outpoints (same coins, second
+              terms hash), fabricated outpoints, insufficient confirmations, and
+              descriptor trees with undeclared spend paths (fail closed).
+  4. REFUND   the bond via its refund(locktime, key) leaf after expiry.
+  5. SETTLE   stage 2: an HTLC settlement vault claimed by the buyer with the
+              preimage (the trustless crypto-vs-crypto trade leg).
+"""
+
+import importlib.util
+import os
+import sys
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_greater_than
+from test_framework.bridge_utils import create_bridge_wallet, find_output, mine_block
+
+
+def _load_btx_otc():
+    """Import contrib/otc/btx_otc.py from the source tree."""
+    here = os.path.dirname(os.path.realpath(__file__))
+    path = os.path.abspath(os.path.join(here, "..", "..", "contrib", "otc", "btx_otc.py"))
+    spec = importlib.util.spec_from_file_location("btx_otc", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["btx_otc"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+btx_otc = _load_btx_otc()
+COIN_SAT = 100_000_000
+
+
+def rpc_adapter(rpc_conn):
+    """btx_otc expects rpc(method, *params); adapt a test-framework RPC connection."""
+    def rpc(method, *params):
+        return getattr(rpc_conn, method)(*params)
+    return rpc
+
+
+class WalletOtcOfferTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser, legacy=False)
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-autoshieldcoinbase=0"]]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+
+    # ----------------------------- helpers -----------------------------
+
+    def pq_pubkey(self, wallet):
+        addr = wallet.getnewaddress(address_type="p2mr")
+        return wallet.exportpqkey(addr)["pubkey"]
+
+    def make_terms(self, seller_address, amount_sats, expiry_height, nonce):
+        return {
+            "version": 1,
+            "amount_sats": amount_sats,
+            "expiry_height": expiry_height,
+            "price": "spot-0.5%",
+            "settle_asset": "wBTX",
+            "seller_address": seller_address,
+            "nonce": nonce,
+        }
+
+    def assert_failed_checks(self, report, expected_failing):
+        """The report must fail overall, with failures exactly in `expected_failing` names."""
+        assert_equal(report.ok, False)
+        failing = {c.name for c in report.failures()}
+        assert failing & set(expected_failing), \
+            f"expected a failure among {expected_failing}, got {failing}"
+
+    # ----------------------------- test body -----------------------------
+
+    def run_test(self):
+        node = self.nodes[0]
+        self.log.info("btx_otc offline selftest")
+        btx_otc.selftest()
+
+        desk, mine_addr = create_bridge_wallet(self, node, wallet_name="desk",
+                                               amount=Decimal("15"))
+        node.createwallet(wallet_name="buyer", descriptors=True)
+        buyer = node.get_wallet_rpc("buyer")
+
+        rpc = rpc_adapter(node)
+        rpc_desk = rpc_adapter(desk)
+        rpc_buyer = rpc_adapter(buyer)
+
+        settle_pk = self.pq_pubkey(desk)
+        refund_pk = self.pq_pubkey(desk)
+        seller_address = desk.getnewaddress(address_type="p2mr")
+
+        # === 1. CREATE a tier-B bonded offer ==================================
+        self.log.info("create bonded offer (soft bond + OP_RETURN terms binding)")
+        amount_sats = 3 * COIN_SAT
+        expiry_height = node.getblockcount() + 30
+        terms = self.make_terms(seller_address, amount_sats, expiry_height,
+                                nonce="11" * 16)
+        desc = btx_otc.soft_bond_descriptor(settle_pk, expiry_height, refund_pk)
+
+        # A refund leaf that unlocks before the advertised expiry must be refused.
+        bad_desc = btx_otc.soft_bond_descriptor(settle_pk, expiry_height - 5, refund_pk)
+        try:
+            btx_otc.create_offer(rpc, rpc_desk, terms, bad_desc)
+            raise AssertionError("create_offer accepted refund_locktime < expiry_height")
+        except ValueError as e:
+            self.log.info(f"early-refund descriptor correctly refused: {e}")
+
+        bundle = btx_otc.create_offer(rpc, rpc_desk, terms, desc)
+        mine_block(self, node, mine_addr)
+
+        outpoint = bundle["bond"]["outpoints"][0]
+        assert_equal(bundle["bond"]["tier"], "B")
+        assert_equal(len(bundle["bond"]["outpoints"]), 1)
+
+        # The funding tx really carries the commitment output (no -txindex on this
+        # node, so scope the lookup to the block that just confirmed it).
+        fund_tx = node.getrawtransaction(outpoint["txid"], True, node.getbestblockhash())
+        want_script = btx_otc.commitment_script_hex(terms)
+        assert any(o["scriptPubKey"]["hex"] == want_script for o in fund_tx["vout"])
+
+        # === 2. VERIFY the bundle ==============================================
+        self.log.info("verify offer bundle (positive)")
+        report = btx_otc.verify_offer(rpc, bundle, min_conf=1)
+        for c in report.checks:
+            self.log.info(f"  [{'ok' if c.ok else 'FAIL'}] {c.name}: {c.detail}")
+        assert_equal(report.ok, True)
+        assert_equal(report.tier, "B")
+        assert_greater_than(report.verified_sats + 1, amount_sats)
+
+        # === 3. REJECT fakes ===================================================
+        self.log.info("reject: tampered terms (amount inflated after funding)")
+        tampered = dict(bundle, terms=dict(terms, amount_sats=amount_sats * 10))
+        self.assert_failed_checks(btx_otc.verify_offer(rpc, tampered, min_conf=1),
+                                  {"commitment", "amount"})
+
+        self.log.info("reject: double-pledge (same coins, second offer's terms)")
+        second_terms = dict(terms, nonce="22" * 16)
+        double = {
+            "version": 1,
+            "terms": second_terms,
+            "bond": dict(bundle["bond"]),  # cites the SAME outpoint
+        }
+        self.assert_failed_checks(btx_otc.verify_offer(rpc, double, min_conf=1),
+                                  {"commitment"})
+
+        self.log.info("reject: fabricated outpoint")
+        fake = dict(bundle, bond=dict(bundle["bond"],
+                                      outpoints=[{"txid": "00" * 32, "vout": 0}]))
+        self.assert_failed_checks(btx_otc.verify_offer(rpc, fake, min_conf=1),
+                                  {"outpoints"})
+
+        self.log.info("reject: insufficient confirmations")
+        self.assert_failed_checks(btx_otc.verify_offer(rpc, bundle, min_conf=1000),
+                                  {"outpoints"})
+
+        self.log.info("reject: descriptor with an undeclared spend path (fail closed)")
+        sneaky_desc = (f"mr({settle_pk},{{htlc({'ee' * 20},{settle_pk}),"
+                       f"refund({expiry_height},{refund_pk})}})")
+        sneaky = dict(bundle, bond=dict(bundle["bond"], descriptor=sneaky_desc))
+        self.assert_failed_checks(btx_otc.verify_offer(rpc, sneaky, min_conf=1),
+                                  {"descriptor-shape", "outpoints"})
+
+        self.log.info("reject: duplicate outpoints in one bundle")
+        dup = dict(bundle, bond=dict(bundle["bond"],
+                                     outpoints=[outpoint, dict(outpoint)]))
+        self.assert_failed_checks(btx_otc.verify_offer(rpc, dup, min_conf=1),
+                                  {"outpoints"})
+
+        # === 4. REFUND the bond after expiry ===================================
+        self.log.info("bond refund via refund leaf after expiry")
+        fee_sat = 20000
+        blocks_needed = max(0, expiry_height - node.getblockcount())
+        if blocks_needed:
+            mine_block(self, node, mine_addr, blocks_needed)
+
+        # Expired offers no longer verify.
+        self.assert_failed_checks(btx_otc.verify_offer(rpc, bundle, min_conf=1),
+                                  {"not-expired"})
+
+        refund_dest = desk.getnewaddress(address_type="p2mr")
+        raw = btx_otc.build_bond_refund(rpc_desk, bundle["bond"]["descriptor"],
+                                        outpoint["txid"], outpoint["vout"],
+                                        refund_dest, expiry_height, fee_sat)
+        refund_txid = node.sendrawtransaction(raw)
+        mine_block(self, node, mine_addr)
+        assert_equal(desk.gettransaction(refund_txid)["confirmations"] >= 1, True)
+        assert_equal(Decimal(str(desk.getreceivedbyaddress(refund_dest))),
+                     Decimal(amount_sats - fee_sat) / Decimal(COIN_SAT))
+
+        # A spent bond is detected instantly by the watcher.
+        assert_equal(btx_otc.watch_offer(rpc, bundle, interval=0.01), "spent")
+
+        # === 5. SETTLE stage 2: HTLC vault, buyer claims with preimage =========
+        self.log.info("stage-2 settlement: HTLC vault claim by buyer")
+        buyer_pk = self.pq_pubkey(buyer)
+        preimage = btx_otc.new_preimage()
+        h160 = btx_otc.swap_hash160_hex(preimage)
+        swap_locktime = node.getblockcount() + 100
+        swap_desc = btx_otc.swap_vault_descriptor(settle_pk, h160, buyer_pk,
+                                                  swap_locktime, refund_pk)
+        swap_desc_ck = btx_otc.add_checksum(rpc, swap_desc)
+        swap_addr = btx_otc.bond_address(rpc, swap_desc_ck)
+        for w in (desk, buyer):
+            w.importdescriptors([{"desc": swap_desc_ck, "timestamp": "now",
+                                  "internal": False}])
+
+        swap_amount = Decimal("2.0")
+        swap_txid = desk.sendtoaddress(swap_addr, swap_amount)
+        mine_block(self, node, mine_addr)
+        swap_vout, _ = find_output(node, swap_txid, swap_addr, desk)
+
+        buyer_dest = buyer.getnewaddress(address_type="p2mr")
+        claim_raw = btx_otc.build_swap_claim(rpc_buyer, swap_desc_ck, swap_txid,
+                                             swap_vout, preimage, buyer_dest, fee_sat)
+        claim_txid = node.sendrawtransaction(claim_raw)
+        mine_block(self, node, mine_addr)
+        assert_equal(buyer.gettransaction(claim_txid)["confirmations"] >= 1, True)
+        assert_equal(Decimal(str(buyer.getreceivedbyaddress(buyer_dest))),
+                     swap_amount - Decimal(fee_sat) / Decimal(COIN_SAT))
+
+        # The preimage is revealed on-chain (what makes cross-chain legs atomic).
+        claim_tx = node.getrawtransaction(claim_txid, True, node.getbestblockhash())
+        revealed = any(
+            btx_otc.swap_hash160_hex(bytes.fromhex(item)) == h160
+            for vin in claim_tx["vin"] for item in vin.get("txinwitness", []) or []
+            if len(item) % 2 == 0
+        )
+        assert_equal(revealed, True)
+
+
+if __name__ == "__main__":
+    WalletOtcOfferTest(__file__).main()


### PR DESCRIPTION
Targets the v0.33.2 release window.

## Motivation

OTC desks have been quoting BTX size they cannot deliver (phantom supply) to suppress price: fabricated balances, the same coins shown to several venues at once, borrowed coins shown then returned, and unverifiable "it's in the shielded pool" claims. This PR ships (1) a design document for trustless-as-possible OTC escrow with proof-of-offered-supply, and (2) working Phase-1 reference tooling implementing it, so that an offer without a valid proof bundle can be treated by the market as no supply.

**No consensus, policy, or node code changes** — everything is built from descriptor leaves, opcodes, and wallet RPCs already live on `main` (P2MR MAST, CLTV `refund()` leaves, `multi_pq`/`ctv_multi_pq`, HTLC leaves, `buildhtlcclaim`/`buildhtlcrefund`, BIP-322 `signmessage`).

## What's included

- **`doc/btx-otc-escrow-supply-validation.md`** — the design: Bonded Offer Vaults (tier A+ CTV covenant / tier A venue co-sign / tier B soft bond), OP_RETURN `"BTXOTC1"||sha256(canonical terms)` funding-tx commitment that makes one UTXO ↔ one offer cryptographically exclusive (kills double-pledging), HTLC atomic settlement for crypto legs, bounded-arbiter CTV escrow and per-offer-key CSFS oracles for fiat legs, threat model, and roadmap.
- **`contrib/otc/btx_otc.py`** — SDK + CLI: terms canonicalization/hashing, bond descriptor builders and a strict fail-closed parser, `create_offer` (funds the vault + commitment in one `send`), walletless `verify_offer` (descriptor shape, UTXO existence/confirmations/amount, funding-tx commitment without `-txindex`, expiry, BIP-322 attestation), `watch_offer`, bond refund and HTLC settlement wrappers over the audited wallet RPCs. `python3 btx_otc.py selftest` runs offline unit checks.
- **`contrib/otc/README.md`** — usage, tier table, and an honest trust-model statement.
- **`test/functional/wallet_otc_offer.py`** — end-to-end regtest coverage (registered in `test_runner.py`).
- **Drive-by fix:** `wallet_htlc_atomicswap.py` failed on txindex-less nodes at its preimage-reveal check (`getrawtransaction` after the tx left the mempool); now scoped to the confirming block. Same fix pattern used in the new test.

## Validation

- [x] I listed the tests that cover this change.
- [x] `src/libbitcoinpqc/**` untouched — fuzz smoke not applicable.

Ran locally on a fresh Release build (`-DBUILD_GUI=OFF -DBUILD_TESTS=OFF`):

- `test/functional/wallet_otc_offer.py --descriptors` — **passes**: offer creation; positive verification (incl. BIP-322 attestation over a p2mr address); rejection of tampered terms, double-pledged outpoints, fabricated outpoints, under-confirmed bonds, undeclared descriptor spend paths, duplicate outpoints; expiry handling; bond refund via the `refund()` leaf; watcher spent-detection; stage-2 HTLC claim with on-chain preimage reveal.
- `test/functional/wallet_htlc_atomicswap.py --descriptors` — **passes** (was failing before the drive-by fix on nodes without `-txindex`).
- `python3 contrib/otc/btx_otc.py selftest` — passes (canonicalization, descriptor round-trips, fail-closed parsing, commitment framing).
- Manual CLI smoke on a live regtest node: `create` → mine → `verify --min-conf 1 --require-attestation` returns `ok: true` with all seven checks green, wallet-less.
- `flake8 --select=F,E9` clean on both new Python files.

## Notes for reviewers

- The verifier **fails closed** on any descriptor shape outside the three documented tiers — an unclassifiable leaf could be a hidden early-exit path.
- Funding-tx lookup needs no `-txindex`: the block is derived from the bond UTXO's own confirmation depth (`getblockhash(height − confs + 1)`).
- Tier A/A+ turnkey settle-spend builders (venue co-sign PSBT flow, CTV template helper) and a message-pinned CSFS leaf are scoped as Phase-1 follow-ups in the design doc §9; tier B plus stage-2 HTLC settlement is fully working today.
- `contrib/otc` carries the same UNAUDITED caveat as `contrib/wbtx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyH9DxN4gxxXvBGQEoPkT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyH9DxN4gxxXvBGQEoPkT3)_