### PR TITLE
fix(gpu/build): make measure-hardware.sh build and engage a CUDA device

### DIFF
--- a/contrib/matmul-v4/measure-hardware.sh
+++ b/contrib/matmul-v4/measure-hardware.sh
@@ -58,7 +58,7 @@ BUILD="${BUILD_DIR:-$ROOT/build-measure-$BACKEND}"
 
 case "$BACKEND" in
   cpu)   CMAKE_FLAGS=() ;;
-  cuda)  CMAKE_FLAGS=(-DBTX_ENABLE_CUDA_EXPERIMENTAL=ON "-DBTX_CUDA_ARCHITECTURES=${CUDA_ARCH:-75;80;89;90}") ;;
+  cuda)  CMAKE_FLAGS=(-DBTX_ENABLE_CUDA_EXPERIMENTAL=ON "-DBTX_CUDA_ARCHITECTURES=${CUDA_ARCH:-75;80;89;90;100;120}") ;;
   metal) CMAKE_FLAGS=(-DBTX_ENABLE_METAL=ON) ;;
   hip)   CMAKE_FLAGS=(-DBTX_ENABLE_HIP=ON "-DBTX_HIP_ARCHITECTURES=${HIP_ARCH:?set HIP_ARCH e.g. gfx942}") ;;
   *) echo "usage: $0 <cpu|cuda|metal|hip> [extra --flags for matmul-v4-report]"; exit 2 ;;
@@ -84,7 +84,7 @@ echo "-- configuring ($BUILD)"
 # ENABLE_WALLET=ON + WITH_SQLITE=ON avoids a known CPU-only link failure; the
 # report tool only needs the consensus/matmul libraries, so tests are off.
 cmake -S "$ROOT" -B "$BUILD" -DCMAKE_BUILD_TYPE=Release -DBUILD_GUI=OFF \
-      -DENABLE_WALLET=ON -DWITH_SQLITE=ON -DBUILD_TESTS=OFF \
+      -DENABLE_WALLET=ON -DWITH_SQLITE=ON -DBUILD_TESTS=OFF -DBUILD_UTIL=ON \
       "${CMAKE_FLAGS[@]}" >/dev/null || { echo "CONFIGURE FAILED"; exit 2; }
 
 echo "-- building matmul-v4-report"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -516,8 +516,13 @@ if(BTX_ENABLE_CUDA_EXPERIMENTAL)
     cuda/matmul_accel.cu
     cuda/oracle_accel.cu
     cuda/matmul_v4_accel.cu
+    cuda/matmul_v4_bmx4_accel.cu
   )
   target_compile_definitions(btx_matmul_backend PRIVATE BTX_ENABLE_CUDA_EXPERIMENTAL=1)
+  # backend_capabilities_v4.cpp (CudaEligibility) is compiled into bitcoin_common;
+  # without the define there it takes the #else -> DisabledByBuild() branch and the
+  # tool/miner silently reports the CUDA backend as unavailable and runs the CPU path.
+  target_compile_definitions(bitcoin_common PRIVATE BTX_ENABLE_CUDA_EXPERIMENTAL=1)
   if(BTX_CUDA_RUNTIME_LIBRARY STREQUAL "Static")
     target_link_libraries(btx_matmul_backend PRIVATE CUDA::cudart_static)
   else()

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -353,10 +353,12 @@ public:
 
     /** This deserializing constructor is provided instead of an Unserialize method.
      *  Unserialize is not possible, since it would require overwriting const fields. */
+#ifndef __CUDACC__  // nvcc cannot instantiate these deserializing ctors (incomplete-type in device TU)
     template <typename Stream>
     CTransaction(deserialize_type, const TransactionSerParams& params, Stream& s) : CTransaction(CMutableTransaction(deserialize, params, s)) {}
     template <typename Stream>
     CTransaction(deserialize_type, Stream& s) : CTransaction(CMutableTransaction(deserialize, s)) {}
+#endif  // __CUDACC__
 
     bool IsNull() const {
         return vin.empty() && vout.empty() && shielded_bundle.IsEmpty();


### PR DESCRIPTION
Build fixes so `contrib/matmul-v4/measure-hardware.sh` configures, builds, and runs on an NVIDIA GPU. This is the tooling side of the discussion in #89: without these the tool either fails to build or silently runs the CPU path.

Verified end to end on an RTX 5090 (nvcc 13.3, sm_120) and built on an H100 (nvcc 12.4, sm_90). After these, the tool reports `compiled=yes available=yes admissible=yes`, `device identity: imma_s8s8s32_tensor_path:sm_120`, and the B1 device bit-exact gate passes on real Blackwell.

The five changes (rationale in the commit body):

1. add `cuda/matmul_v4_bmx4_accel.cu` to the CUDA sources so the BMX4-C backend links.
2. define `BTX_ENABLE_CUDA_EXPERIMENTAL` for `bitcoin_common` too, so `CudaEligibility()` in `backend_capabilities_v4.cpp` does not compile to `DisabledByBuild()`. This is the important one: without it the tool prints `compiled=no reason=disabled_by_build` and runs the CPU path while looking like a device run, silently invalidating any measurement an operator sends back.
3. `#ifndef __CUDACC__` guard on the two `CTransaction(deserialize_type, ...)` template ctors (nvcc incomplete-type in the device TU).
4. pass `-DBUILD_UTIL=ON`. The `matmul-v4-report` target is gated by `BUILD_UTIL`, which defaults to the `BUILD_TESTS` the script sets OFF, so the tool is never configured.
5. add `100;120` to the default `CUDA_ARCH`. The default `75;80;89;90` has no sm_100 or sm_120, so Blackwell parts run JIT compiled sm_90.

Build-only, no consensus or runtime behavior change. Building the backend with these also compile-verifies the G1-G6 backend edits from 1edd3c6 on nvcc 12.4 and 13.3.
