### PR TITLE
contrib: add one-command mining supervisor handoff

### DIFF
--- a/contrib/faststart/README.md
+++ b/contrib/faststart/README.md
@@ -139,6 +139,36 @@ python3 contrib/faststart/btx-agent-setup.py \
   --datadir="$HOME/.btx-service"
 ```
 
+For a self-custody miner, installation, verified snapshot bootstrap, wallet
+provisioning, and live-mining supervisor startup can be handed off in one
+command:
+
+```bash
+python3 contrib/faststart/btx-agent-setup.py \
+  --repo btxchain/btx \
+  --release-tag v0.33.1 \
+  --preset miner \
+  --datadir="$HOME/.btx" \
+  --start-mining
+```
+
+`--start-mining` is accepted only with `--preset=miner`. It starts the bundled
+`contrib/mining/start-live-mining.sh` after fast-start succeeds, so the same
+wallet provisioning, backend enforcement, peer recovery, PID files, and logs
+used by the standalone helper remain authoritative. Use
+`--mining-wallet=NAME`, `--mining-results-dir=PATH`, or repeated
+`--mining-arg=VALUE` options for operator overrides. Values beginning with
+`--` must use the `--mining-arg=--option=value` form. Core handoff arguments
+(`datadir`, config, chain, binary paths, wallet, and results directory) cannot
+be replaced through `--mining-arg`; use the corresponding installer option so
+the generated start and stop commands remain consistent.
+
+The installer rejects `--start-mining` together with `--no-start-daemon` or
+`--follow`: the supervisor requires the daemon, and a followed bootstrap does
+not return to perform the mining handoff. In `--json` mode, bootstrap and
+supervisor output stay on stderr while the final summary reports
+`"mining_started": true` and the exact start/stop command arrays.
+
 That flow:
 
 1. downloads `btx-release-manifest.json`,

--- a/contrib/faststart/btx-agent-setup.py
+++ b/contrib/faststart/btx-agent-setup.py
@@ -9,7 +9,8 @@ This script is the "download a binary and go" companion to btx-faststart.py:
 - fetch `btx-release-manifest.json` from a published release (or local path),
 - select the matching binary archive for the current platform,
 - verify and extract it,
-- optionally invoke `btx-faststart.py` with the installed binaries.
+- optionally invoke `btx-faststart.py` with the installed binaries,
+- optionally hand a miner preset off to the live-mining supervisor.
 """
 
 from __future__ import annotations
@@ -455,7 +456,7 @@ def find_binary(install_dir: Path, names: tuple[str, ...]) -> Path:
     raise FileNotFoundError(f"could not find any of {', '.join(names)} under {install_dir}")
 
 
-def run_bootstrap_subprocess(cmd: list[str], *, json_mode: bool) -> None:
+def run_logged_subprocess(cmd: list[str], *, json_mode: bool) -> None:
     if not json_mode:
         subprocess.run(cmd, check=True)
         return
@@ -537,6 +538,26 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--daemon-arg", action="append", default=[], help="Extra argument passed to btxd during bootstrap.")
     parser.add_argument("--cli-arg", action="append", default=[], help="Extra argument passed to btx-cli during bootstrap.")
     parser.add_argument(
+        "--start-mining",
+        action="store_true",
+        help="After a successful --preset=miner bootstrap, start the live-mining supervisor.",
+    )
+    parser.add_argument(
+        "--mining-wallet",
+        default="miner",
+        help="Wallet used by --start-mining (default: miner).",
+    )
+    parser.add_argument(
+        "--mining-results-dir",
+        help="Mining supervisor state/log directory (default: <datadir>/mining-ops).",
+    )
+    parser.add_argument(
+        "--mining-arg",
+        action="append",
+        default=[],
+        help="Extra argument passed to start-live-mining.sh; repeat as needed.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Print a machine-readable JSON summary; bootstrap progress is written to stderr.",
@@ -545,7 +566,23 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str]) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.start_mining and args.preset != "miner":
+        parser.error("--start-mining requires --preset=miner")
+    if args.start_mining and args.no_start_daemon:
+        parser.error("--start-mining cannot be combined with --no-start-daemon")
+    if args.start_mining and args.follow:
+        parser.error("--start-mining cannot be combined with --follow because bootstrap would not return")
+    if (args.mining_wallet != "miner" or args.mining_results_dir or args.mining_arg) and args.preset != "miner":
+        parser.error("--mining-wallet, --mining-results-dir, and --mining-arg require --preset=miner")
+    managed_mining_args = ("--datadir", "--conf", "--chain", "--cli", "--daemon", "--wallet", "--results-dir")
+    for mining_arg in args.mining_arg:
+        if any(mining_arg == option or mining_arg.startswith(f"{option}=") for option in managed_mining_args):
+            parser.error(
+                f"--mining-arg cannot override installer-managed option {mining_arg.split('=', 1)[0]}"
+            )
 
     manifest_reference_source = args.release_manifest or default_release_manifest_source(
         args.repo,
@@ -688,7 +725,11 @@ def main(argv: list[str]) -> int:
         summary["faststart_conf"] = str(faststart_conf)
         summary["faststart_command"] = faststart_cmd
         if args.preset == "miner":
-            results_dir = datadir / "mining-ops"
+            results_dir = (
+                Path(args.mining_results_dir).expanduser()
+                if args.mining_results_dir
+                else datadir / "mining-ops"
+            )
             summary["mining_results_dir"] = str(results_dir)
             summary["start_live_mining_command"] = [
                 str(SCRIPT_DIR.parent / "mining" / "start-live-mining.sh"),
@@ -697,14 +738,18 @@ def main(argv: list[str]) -> int:
                 f"--chain={args.chain}",
                 f"--cli={btx_cli_path}",
                 f"--daemon={btxd_path}",
-                "--wallet=miner",
+                f"--wallet={args.mining_wallet}",
                 f"--results-dir={results_dir}",
+                *args.mining_arg,
             ]
             summary["stop_live_mining_command"] = [
                 str(SCRIPT_DIR.parent / "mining" / "stop-live-mining.sh"),
                 f"--results-dir={results_dir}",
             ]
-        run_bootstrap_subprocess(faststart_cmd, json_mode=args.json)
+        run_logged_subprocess(faststart_cmd, json_mode=args.json)
+        if args.start_mining:
+            run_logged_subprocess(summary["start_live_mining_command"], json_mode=args.json)
+            summary["mining_started"] = True
 
     if args.json:
         print(json.dumps(summary, indent=2))
@@ -716,6 +761,8 @@ def main(argv: list[str]) -> int:
             print(f"snapshot manifest: {snapshot_manifest_path}")
         if args.preset:
             print(f"bootstrapped preset: {args.preset}")
+        if args.start_mining:
+            print("started live mining supervisor")
     return 0
 
 

--- a/contrib/mining/README.md
+++ b/contrib/mining/README.md
@@ -103,6 +103,27 @@ Best practices:
 
 Quick start:
 
+For a new release-based installation, the complete verified install,
+AssumeUTXO bootstrap, mining-wallet provisioning, and supervisor handoff is one
+command:
+
+```bash
+python3 contrib/faststart/btx-agent-setup.py \
+  --repo btxchain/btx \
+  --release-tag v0.33.1 \
+  --preset miner \
+  --datadir="$HOME/.btx" \
+  --start-mining
+```
+
+The command returns only after the fast-start bootstrap succeeds and
+`start-live-mining.sh` passes its initial startup check. It does not duplicate
+the supervisor: repeated runs keep the existing PID-file idempotency. Pass
+additional supervisor options with repeated `--mining-arg=VALUE` arguments.
+
+For scripts that need to inspect or modify the generated handoff instead, omit
+`--start-mining` and consume the JSON command arrays:
+
 ```bash
 SETUP_JSON="$(python3 contrib/faststart/btx-agent-setup.py \
   --repo btxchain/btx \

--- a/doc/btx-download-and-go.md
+++ b/doc/btx-download-and-go.md
@@ -29,6 +29,24 @@ python3 contrib/faststart/btx-agent-setup.py \
   --datadir="$HOME/.btx"
 ```
 
+Add `--start-mining` when the same command should also provision the mining
+wallet/address and start the bundled live-mining supervisor after the verified
+fast-start bootstrap succeeds:
+
+```bash
+python3 contrib/faststart/btx-agent-setup.py \
+  --repo btxchain/btx \
+  --release-tag v0.33.1 \
+  --preset miner \
+  --datadir="$HOME/.btx" \
+  --start-mining
+```
+
+The handoff remains fail-closed: an installer or supervisor error makes the
+one-shot command fail, and Apple Silicon keeps the supervisor's strict Metal
+backend and zero-fallback defaults. Omit `--start-mining` when an external
+service manager should consume the generated command arrays instead.
+
 That one command installs the correct platform archive from the published
 `btx-release-manifest.json`, verifies the manifest/archive/snapshot-manifest
 against `SHA256SUMS` and `SHA256SUMS.asc` for remote releases, downloads the

--- a/test/util/btx_agent_setup_test.py
+++ b/test/util/btx_agent_setup_test.py
@@ -475,6 +475,100 @@ class BTXAgentSetupTest(unittest.TestCase):
                 ],
             )
 
+    def test_start_mining_runs_supervisor_after_bootstrap(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            archive_path = self._build_fake_archive(root)
+            manifest_path = self._write_manifest(root, archive_path)
+            install_dir = root / "install"
+            datadir = root / "datadir"
+            results_dir = root / "operator" / "mining"
+            recorded: list[tuple[list[str], dict[str, object]]] = []
+
+            original_run = self.module.subprocess.run
+            try:
+                def fake_run(cmd, check, **kwargs):
+                    recorded.append((list(cmd), {"check": check, **kwargs}))
+                    class Result:
+                        returncode = 0
+                        stdout = "command output\n"
+                        stderr = ""
+                    return Result()
+
+                self.module.subprocess.run = fake_run
+                output = io.StringIO()
+                errors = io.StringIO()
+                with contextlib.redirect_stdout(output), contextlib.redirect_stderr(errors):
+                    exit_code = self.module.main(
+                        [
+                            "--release-manifest",
+                            str(manifest_path),
+                            "--platform",
+                            "linux-x86_64",
+                            "--install-dir",
+                            str(install_dir),
+                            "--preset",
+                            "miner",
+                            "--chain",
+                            "regtest",
+                            "--datadir",
+                            str(datadir),
+                            "--start-mining",
+                            "--mining-wallet",
+                            "worker",
+                            "--mining-results-dir",
+                            str(results_dir),
+                            "--mining-arg=--rpcport=19000",
+                            "--json",
+                        ]
+                    )
+            finally:
+                self.module.subprocess.run = original_run
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(len(recorded), 2)
+            faststart_command, faststart_kwargs = recorded[0]
+            mining_command, mining_kwargs = recorded[1]
+            self.assertIn("btx-faststart.py", faststart_command[1])
+            self.assertTrue(faststart_kwargs["capture_output"])
+            self.assertEqual(
+                mining_command,
+                [
+                    str(ROOT / "contrib" / "mining" / "start-live-mining.sh"),
+                    f"--datadir={datadir}",
+                    f"--conf={datadir / 'faststart' / 'faststart.conf'}",
+                    "--chain=regtest",
+                    f"--cli={pathlib.Path(install_dir / 'btx-29.2' / 'bin' / 'btx-cli')}",
+                    f"--daemon={pathlib.Path(install_dir / 'btx-29.2' / 'bin' / 'btxd')}",
+                    "--wallet=worker",
+                    f"--results-dir={results_dir}",
+                    "--rpcport=19000",
+                ],
+            )
+            self.assertTrue(mining_kwargs["capture_output"])
+            summary = json.loads(output.getvalue())
+            self.assertTrue(summary["mining_started"])
+            self.assertEqual(summary["start_live_mining_command"], mining_command)
+            self.assertEqual(summary["mining_results_dir"], str(results_dir))
+            self.assertEqual(errors.getvalue(), "command output\ncommand output\n")
+
+    def test_start_mining_rejects_incompatible_modes(self):
+        cases = (
+            ["--start-mining"],
+            ["--preset=service", "--start-mining"],
+            ["--preset=miner", "--start-mining", "--no-start-daemon"],
+            ["--preset=miner", "--start-mining", "--follow"],
+            ["--preset=service", "--mining-arg=--rpcport=19000"],
+            ["--preset=service", "--mining-wallet=worker"],
+            ["--preset=miner", "--mining-arg=--results-dir=/tmp/mining"],
+            ["--preset=miner", "--mining-arg=--wallet=worker"],
+        )
+        for argv in cases:
+            with self.subTest(argv=argv), contextlib.redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit) as raised:
+                    self.module.main(list(argv))
+                self.assertEqual(raised.exception.code, 2)
+
     def test_remote_release_requires_signature_unless_overridden(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = pathlib.Path(tmpdir)


### PR DESCRIPTION
## What changed

This PR adds an opt-in `--start-mining` handoff to
`contrib/faststart/btx-agent-setup.py`.

With the new flag, one command can now:

1. select and install the matching published BTX binary archive;
2. verify the release manifest, checksums, signature, archive, and snapshot
   manifest through the existing agent-setup flow;
3. run the existing miner fast-start preset;
4. provision the mining wallet and payout address through the existing mining
   helper; and
5. start the existing live-mining supervisor after bootstrap succeeds.

Example:

```bash
python3 contrib/faststart/btx-agent-setup.py \
  --repo btxchain/btx \
  --release-tag v0.33.1 \
  --preset miner \
  --datadir="$HOME/.btx" \
  --start-mining
```

The installer also accepts:

- `--mining-wallet=NAME` to select the reward wallet;
- `--mining-results-dir=PATH` to select the supervisor state and log
  directory; and
- repeated `--mining-arg=VALUE` options for non-core supervisor overrides such
  as an RPC port, idle gate, or backend setting.

In `--json` mode, bootstrap and supervisor output remains on stderr so stdout
continues to contain a single machine-readable JSON document. A successful
handoff adds `"mining_started": true`, while the existing exact start and stop
command arrays remain available to downstream automation.

## Why

The miner preset already assembled all required components, but the final
handoff was still manual: `btx-agent-setup.py` emitted a
`start_live_mining_command`, and an operator or deployment agent had to parse
and execute that second command separately.

That gap encouraged deployment-specific shell glue around a security-sensitive
boundary involving the datadir, config, wallet, backend requirements, PID
files, and supervisor logs. Making the handoff an explicit opt-in installer
operation keeps those values in one authoritative command and reuses the
existing, tested mining supervisor rather than introducing another mining
loop.

## Safety and compatibility

- The new behavior is opt-in. Existing installer invocations are unchanged.
- `--start-mining` requires `--preset=miner`.
- It is rejected with `--no-start-daemon`, because the supervisor requires the
  bootstrapped daemon.
- It is rejected with `--follow`, because a followed bootstrap does not return
  to perform the mining handoff.
- Installer-managed handoff arguments cannot be overridden through
  `--mining-arg`. Datadir, config, chain, binary paths, wallet, and results
  directory continue to have a single source of truth, so the generated stop
  command cannot drift from the actual supervisor state directory.
- The handoff uses `subprocess.run(..., check=True)`. Bootstrap or supervisor
  startup failures therefore make the one-command operation fail closed.
- Apple Silicon continues to use the existing supervisor defaults for strict
  Metal selection, required Metal availability, GPU inputs, and zero allowed
  backend fallbacks.
- Repeated execution retains the existing mining helper's PID-file
  idempotency.

## Documentation

The one-command flow and its constraints are documented in:

- `contrib/faststart/README.md`;
- `contrib/mining/README.md`; and
- `doc/btx-download-and-go.md`.

## Tests

Added unit coverage verifies:

- bootstrap runs before the mining supervisor;
- wallet, results-directory, RPC, binary, datadir, config, and chain arguments
  are passed correctly;
- JSON mode keeps command output on stderr and reports
  `"mining_started": true`;
- incompatible modes are rejected before release assets are accessed; and
- generic mining arguments cannot replace installer-managed handoff values.

Commands run locally:

```text
python3 test/util/btx_agent_setup_test.py
    Ran 23 tests in 0.307s
    OK

ruff 0.5.5 check \
    contrib/faststart/btx-agent-setup.py \
    test/util/btx_agent_setup_test.py
    All checks passed!

python3 -m py_compile \
    contrib/faststart/btx-agent-setup.py \
    test/util/btx_agent_setup_test.py
    PASS

python3 test/lint/lint-python-utf8-encoding.py
    PASS

git diff --check
    PASS
```

`python3 test/lint/lint-files.py` was also run. It reports nine pre-existing
executable-bit mismatches in unrelated tracked scripts. This PR does not modify
those files or any file modes.
