### PR TITLE
fix(matmul): declare PermLayout::End() constexpr (GCC build fix for #97)

### DIFF
--- a/src/matmul/matmul_v4_rc_air_recurse.h
+++ b/src/matmul/matmul_v4_rc_air_recurse.h
@@ -132,7 +132,7 @@ struct PermLayout {
     [[nodiscard]] uint32_t InputCol(uint32_t lane) const { return base + lane; }
     [[nodiscard]] uint32_t SboxCol(uint32_t s) const { return base + kPermInputCells + s; }
     /** One past the last column of the block: base + 130. */
-    [[nodiscard]] uint32_t End() const { return base + kPermCellsPerPerm; }
+    [[nodiscard]] constexpr uint32_t End() const { return base + kPermCellsPerPerm; }
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Testing #97 per the call. The branch does not compile on Linux with GCC (tested 11.4.0):

```
src/matmul/matmul_v4_rc_stage3_recursive_parent_air.h:66:31: error: call to
non-'constexpr' function 'uint32_t matmul::v4::rc::air_recurse::PermLayout::End() const'
```

(also reached via `matmul_v4_rc_stage3_recursive_fixedpoint.h:279` and `:1591`.)

`PermLayout::End()` in `matmul_v4_rc_air_recurse.h` is called from constexpr functions that are constant-evaluated; a constant-evaluated call to a non-constexpr function is ill-formed. AppleClang accepts the current form, which is why Metal-side builds did not catch it.

One-line fix: declare `End()` constexpr (it is a trivial addition over constexpr members).

Verified on Linux x86_64 / GCC 11.4 / CUDA 13.3 / arch 120: full build completes (`btxd`, `test_btx`, `matmul-v4-rc-harness`) and `matmul_v4_rc_tests`, `matmul_verify_worker_tests`, `matmul_v4_lt_tests`, `matmul_v4_rc_coupled_tests`, `matmul_v4_rc_transcript_tests` all pass, including `rc_cuda_exact_replay_launch_abi_smoke` on CC 12.0 hardware. Full CUDA test report incoming on #97.

Suggest a Linux/GCC CI leg once workflows are re-enabled; this class of divergence is invisible to AppleClang-only builds.