### PR TITLE
fix: catch-up GETDATA vs active tip, not m_best_header

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,29 @@ peering, and attestor diversity can carry it:
    `-matmultrustedthreshold`. Archives stay CPU. Independent miners keep
    talking to seeds. Adding `N` with `M=1` is only availability; `M≥2` is
    what removes a single key as PoW authority.
+
+The live mainnet pin (1-of-2) is published below. GPU attestors and the
+CPU archives that follow them return the same set from
+`getmatmultrustedstatus` / `getfinalityinfo` (`trusted_signer_pubkeys`,
+`threshold`). P2P seed connect does **not** push keys — miners pin this
+set at bootstrap, then confirm it on local RPC after joining
+`node.btx.dev` / `node.btxchain.org` / `node.btx.tools`.
+
+```ini
+# Mainnet ExactReplay attestors. Public keys only — never a signer WIF.
+matmultrustedpubkey=03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa
+matmultrustedpubkey=0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c
+matmultrustedthreshold=1
+```
+
+```bash
+btx-cli getmatmultrustedstatus
+# configured=true, threshold=1, trusted_signer_pubkeys = the two hex keys above
+```
+
+A miner that omits this pin cannot see `getmatmulattestedtip` and
+`getblocktemplate` may extend an unattested orphan. Do not load
+`-matmulattestationsignerkeyfile` on a miner.
 3. **Convert public seeds to GPU full nodes.** Each converted host runs
    `-matmulvalidation=consensus` and ExactReplays. Trusted-mode on those
    boxes goes away. CPU wallets and explorers can remain light.
@@ -1077,6 +1100,28 @@ ADDR=$(./build/bin/btx-cli -regtest -rpcwallet=miner getnewaddress)
 # -> 200.00000000 (10 blocks x 20 BTX)
 ```
 
+### Attestor pin (mainnet mining bootstrap)
+
+After the node is up and peering with the public seed/archive mesh, treat
+the attestor set as a normal bootstrap check — same class of pin as DNS
+seeds, not a secret:
+
+1. Join the published seeds (`dnsseed=1`, `addnode=node.btx.dev:19335`, …).
+2. Have the two `-matmultrustedpubkey` lines and `-matmultrustedthreshold=1`
+   in `btx.conf` (miner fast-start writes them).
+3. Ping local RPC: `getmatmultrustedstatus` must show `configured=true`
+   and the same `trusted_signer_pubkeys` / `threshold` the archives and
+   GPU attestors return. `getfinalityinfo` repeats the pubs.
+4. Then call `getblocktemplate`. A unique attested child of tip means
+   follow `getmatmulattestedtip` instead of grinding an unattested twin.
+
+P2P `addnode` / DNS seeds do not serve RPC. You confirm the pin on **your**
+`btx-cli`, or on an archive/attestor RPC you already control. Do not take
+signer pubs from a random remote RPC.
+
+`contrib/faststart` `--preset miner` writes this pin and checks it after
+RPC is ready. `contrib/devtools/gen-btx-node-conf.sh` writes it too.
+
 ### Production Mining (getblocktemplate)
 
 ```bash
@@ -1137,6 +1182,8 @@ contrib/mining/backup-wallet.sh \
 | Command | Description |
 |---|---|
 | `getmininginfo` | Current mining state, difficulty, algorithm |
+| `getmatmultrustedstatus` | Attestor pin (`trusted_signer_pubkeys`, `threshold`) and attested tip |
+| `getmatmulattestedtip` | Highest-work block with quorum (GBT parent) |
 | `getblocktemplate` | Block template for external mining |
 | `submitblock` | Submit a solved block |
 | `generatetoaddress` | Mine N blocks (regtest/testnet) |

--- a/contrib/devtools/gen-btx-node-conf.sh
+++ b/contrib/devtools/gen-btx-node-conf.sh
@@ -76,6 +76,14 @@ retainshieldedcommitmentindex=1
 # Runtime defaults
 dbcache=4096
 maxmempool=300
+
+# Published mainnet ExactReplay attestors (public keys only).
+# GPU attestors and following archives return this from
+# getmatmultrustedstatus / getfinalityinfo after you join the seed mesh.
+# P2P addnode/DNS does not push keys. Do not load a signer WIF here.
+matmultrustedpubkey=03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa
+matmultrustedpubkey=0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c
+matmultrustedthreshold=1
 EOF
 
 if [[ "${BOOTSTRAP_MODE}" == "discover" ]]; then

--- a/contrib/faststart/README.md
+++ b/contrib/faststart/README.md
@@ -86,7 +86,18 @@ miningchainguard=1
 miningminoutboundpeers=0
 miningminsyncedoutboundpeers=0
 miningmaxheaderlag=8
+# Published 1-of-2 attestor pin (same set archives/attestors return
+# from getmatmultrustedstatus). P2P seeds do not push these keys.
+matmulvalidation=trusted
+matmultrustedpubkey=03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa
+matmultrustedpubkey=0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c
+matmultrustedthreshold=1
 ```
+
+After the daemon is up and peering with the public seeds, confirm the pin
+on local RPC (`getmatmultrustedstatus` → `trusted_signer_pubkeys` and
+`threshold`). That is the mining-bootstrap check; do not scrape signer
+pubs from a random remote RPC. Do not load a signer WIF on a miner.
 
 Use DNS names rather than hard-coded peer IP addresses in configs and runbooks.
 Peer IPs can change or disappear; DNS bootstrap names can be updated without

--- a/contrib/faststart/btx-faststart.py
+++ b/contrib/faststart/btx-faststart.py
@@ -35,6 +35,14 @@ GITHUB_API_BASE = "https://api.github.com"
 GITHUB_JSON_ACCEPT = "application/vnd.github+json"
 GITHUB_BINARY_ACCEPT = "application/octet-stream"
 
+# Published mainnet ExactReplay attestors (public keys only). Archives and
+# GPU attestors return this same set from getmatmultrustedstatus.
+MAINNET_ATTESTOR_PUBKEYS = (
+    "03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa",
+    "0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c",
+)
+MAINNET_ATTESTOR_THRESHOLD = 1
+
 PRESET_CONF = {
     "miner": [
         "server=1",
@@ -46,6 +54,13 @@ PRESET_CONF = {
         "addnode=node.btx.dev:19335",
         "addnode=node.btxchain.org:19335",
         "addnode=node.btx.tools:19335",
+        "# Published 1-of-2 attestor pin. Confirm after RPC is up:",
+        "#   btx-cli getmatmultrustedstatus",
+        "# P2P seeds do not push these keys. Do not load a signer WIF.",
+        "matmulvalidation=trusted",
+        f"matmultrustedpubkey={MAINNET_ATTESTOR_PUBKEYS[0]}",
+        f"matmultrustedpubkey={MAINNET_ATTESTOR_PUBKEYS[1]}",
+        f"matmultrustedthreshold={MAINNET_ATTESTOR_THRESHOLD}",
         "prune=4096",
         "blockfilterindex=1",
         "coinstatsindex=1",
@@ -67,6 +82,10 @@ PRESET_CONF = {
         "addnode=node.btx.dev:19335",
         "addnode=node.btxchain.org:19335",
         "addnode=node.btx.tools:19335",
+        "# Same published attestor pin the miner preset uses.",
+        f"matmultrustedpubkey={MAINNET_ATTESTOR_PUBKEYS[0]}",
+        f"matmultrustedpubkey={MAINNET_ATTESTOR_PUBKEYS[1]}",
+        f"matmultrustedthreshold={MAINNET_ATTESTOR_THRESHOLD}",
         "prune=0",
         "txindex=1",
         "blockfilterindex=1",
@@ -298,6 +317,31 @@ def rpc_json(cmd: list[str], method: str, *params: str) -> dict[str, Any]:
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(f"{method} failed:\n{exc.output}") from exc
     return json.loads(output)
+
+
+def verify_mainnet_attestor_pin(cli_cmd: list[str]) -> None:
+    """Confirm local RPC matches the published archive/attestor key set."""
+    status = rpc_json(cli_cmd, "getmatmultrustedstatus")
+    have = {str(key).lower() for key in status.get("trusted_signer_pubkeys") or []}
+    want = {key.lower() for key in MAINNET_ATTESTOR_PUBKEYS}
+    if have != want:
+        raise RuntimeError(
+            "getmatmultrustedstatus.trusted_signer_pubkeys does not match the "
+            f"published mainnet attestor pin {sorted(want)}; got {sorted(have)}. "
+            "P2P seeds do not advertise this set — it is pinned in miner/service "
+            "bootstrap and must match GPU attestors and following archives."
+        )
+    threshold = int(status.get("threshold") or 0)
+    if threshold != MAINNET_ATTESTOR_THRESHOLD:
+        raise RuntimeError(
+            "getmatmultrustedstatus.threshold does not match the published "
+            f"mainnet pin {MAINNET_ATTESTOR_THRESHOLD}; got {threshold}."
+        )
+    print(
+        "attestor pin ok: configured="
+        f"{status.get('configured')} threshold={threshold} "
+        f"pubkeys={len(have)}"
+    )
 
 
 def wait_for_rpc_ready(cli_cmd: list[str], timeout_secs: int) -> None:
@@ -676,6 +720,9 @@ def main(argv: list[str]) -> int:
         print(f"starting daemon with preset '{args.preset}'")
         run_quiet(daemon)
         wait_for_rpc_ready(cli_cmd, args.rpc_wait_secs)
+
+    if args.chain == "main":
+        verify_mainnet_attestor_pin(cli_cmd)
 
     print(f"downloading snapshot: {snapshot_url}")
     download_snapshot(snapshot_url, snapshot_path, snapshot_sha256)

--- a/contrib/mining/README.md
+++ b/contrib/mining/README.md
@@ -213,7 +213,11 @@ operator policy.
 For a first-run bootstrap before mining or service bring-up, see
 [`contrib/faststart`](../faststart). Those entry points fetch the matching
 snapshot, run `loadtxoutset`, and watch `getchainstates` until the bootstrap
-chainstate clears.
+chainstate clears. Miner/service presets also pin the published mainnet
+attestor pubkeys and, on mainnet, check `getmatmultrustedstatus` after RPC
+is ready so `getblocktemplate` follows the attested tip. That check is
+local RPC after you have joined the seed/archive mesh; P2P seeds do not
+advertise the key set.
 
 Stop:
 

--- a/doc/btx-matmul-trusted-rpc-mirrors.md
+++ b/doc/btx-matmul-trusted-rpc-mirrors.md
@@ -71,6 +71,14 @@ Operators should compare `attestation_version` and
 and mirror before admitting traffic. A mismatch is a configuration/release
 error and the affected mirror will reject those attestations.
 
+The live mainnet attestor pin (public keys, threshold 1) is published in
+the repository README and written by miner/archive bootstrap
+(`contrib/faststart`, `gen-btx-node-conf.sh`). `getmatmultrustedstatus`
+and `getfinalityinfo` on GPU attestors and following archives return
+`trusted_signer_pubkeys` / `threshold` for that same set. P2P seed
+connect does not advertise keys; miners pin them locally and confirm on
+RPC after joining the seed mesh. Do not load a signer WIF on a miner.
+
 ## Roles and service capabilities
 
 - `-matmulvalidation=consensus` performs local authority as before. With a

--- a/doc/btx-public-node-bootstrap.md
+++ b/doc/btx-public-node-bootstrap.md
@@ -62,12 +62,22 @@ addnode=node.btxchain.org:19335
 addnode=node.btx.tools:19335
 addnode=146.190.179.86:19335
 addnode=164.90.246.229:19335
+
+# Published mainnet ExactReplay attestors (public keys only).
+# Same set GPU attestors and following archives return from
+# getmatmultrustedstatus / getfinalityinfo. P2P seeds do not push keys.
+matmultrustedpubkey=03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa
+matmultrustedpubkey=0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c
+matmultrustedthreshold=1
 ```
 
 Notes:
 
 - `19335` is the BTX mainnet P2P port.
 - `19334` is the BTX mainnet default RPC port.
+- After `btxd` is up, `btx-cli getmatmultrustedstatus` must show
+  `configured=true` and the two pubkeys above. That is the mining/archive
+  bootstrap pin (same RPC GPU attestors and following archives serve).
 - `addnode=` seeds initial peers while preserving broader peer discovery.
 - the current public DNS bootstrap set is `node.btx.dev`,
   `node.btxchain.org`, and `node.btx.tools`; direct IP addnodes are optional

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -8917,7 +8917,7 @@ void PeerManagerImpl::MaybeRequestTrustedMirrorPreferredAttestations(
                 TrustedMirrorShortTipReorg(tip, target),
                 /*on_parked_reorg_branch=*/false,
                 recent_active_ancestor, followed_body_awaiting,
-                is_signed_frontier)) {
+                is_signed_frontier, IsSignedFrontierBodyCatchUp())) {
             return;
         }
         RequestMatMulTrustedAttestations(target->GetBlockHash(),
@@ -9174,9 +9174,17 @@ void PeerManagerImpl::RequestMatMulTrustedAttestations(
         const bool preferred{
             node::matmul_trusted::TrustedMirrorPreferGetMmAttest(
                 tip_child, short_reorg, parked, recent_active_ancestor,
-                followed_body_awaiting, is_signed_frontier)};
+                followed_body_awaiting, is_signed_frontier,
+                signed_frontier_catch_up)};
+        if (!node::matmul_trusted::TrustedMirrorCatchUpShouldRequestGetMmAttest(
+                signed_frontier_catch_up, preferred)) {
+            // Drop a stale frontier / mid-suffix token so TTL refresh
+            // cannot keep GETMMATTEST-sending it (live 194999 hammer).
+            m_matmul_attestation_requested.erase(hash);
+            return;
+        }
         if (tip_child || short_reorg || followed_body_awaiting ||
-            is_signed_frontier) {
+            (is_signed_frontier && !signed_frontier_catch_up)) {
             m_matmul_attestation_backoff.erase(hash);
         }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -8549,12 +8549,15 @@ std::chrono::microseconds PeerManagerImpl::CatchUpDownloadTimeoutForPeer(
 {
     AssertLockHeld(cs_main);
     (void)peer_id;
-    // 90s only for a handshake-complete GPU (manual/noban). Hung -connect
-    // and outbound archives keep 15s so a silent source failsovers.
+    const CBlockIndex* const tip{m_chainman.ActiveTip()};
+    const int tip_height{tip != nullptr ? tip->nHeight : 0};
+    // 90s only when VERSION still shows bodies past our *active* tip.
+    // Stale handshake (we climbed past VERSION) and hung -connect keep 15s.
     if (node::matmul_trusted::SignedFrontierCatchUpUsesGpuTimeout(
             state.m_manual || state.m_noban,
             node::matmul_trusted::SignedFrontierVersionHandshakeComplete(
-                state.m_starting_height))) {
+                state.m_starting_height),
+            state.m_starting_height, tip_height)) {
         return std::chrono::duration_cast<std::chrono::microseconds>(
             node::matmul_trusted::SignedFrontierPreferredCatchUpTimeout(
                 node::matmul_trusted::WaitTimeout()));
@@ -8569,15 +8572,18 @@ bool PeerManagerImpl::PeerMaySignedFrontierCatchUpGetData(
     AssertLockHeld(cs_main);
     const CBlockIndex* const tip{m_chainman.ActiveTip()};
     const int tip_height{tip != nullptr ? tip->nHeight : 0};
-    // Compare VERSION height to the followed HEADER_ONLY suffix, not the
-    // connected tip. Sibling -connect archives can be ahead of our tip and
-    // still lack the suffix bodies (live nyc1 2026-08-17: GPU 191713 vs
-    // siblings 191685/191687 while m_best_header=191690; GETDATA went to
-    // siblings, inflight=0).
-    const int followed_height{
-        m_chainman.m_best_header != nullptr
-            ? m_chainman.m_best_header->nHeight
-            : tip_height};
+    // Root-first GETDATA is tip+1. Compare VERSION / BestKnown to the
+    // active tip, never to m_best_header: miner HEADER_ONLY children
+    // above the signed frontier made every archive fail
+    // starting_height > followed_header (live 2026-08-19: VERSION 194111,
+    // m_best_header 194116, tip 189534, inflight=0, stall loop no-op).
+    const int best_known_height{
+        state.pindexBestKnownBlock != nullptr
+            ? state.pindexBestKnownBlock->nHeight
+            : std::numeric_limits<int>::min()};
+    const bool best_known_extends_tip{
+        tip != nullptr && state.pindexBestKnownBlock != nullptr &&
+        state.pindexBestKnownBlock->GetAncestor(tip_height) == tip};
     const ServiceFlags services{peer.m_their_services.load()};
     const bool archive_or_mirror{
         state.m_matmul_attestation_archive || state.m_matmul_trusted_mirror ||
@@ -8593,7 +8599,7 @@ bool PeerManagerImpl::PeerMaySignedFrontierCatchUpGetData(
         !state.m_inbound && !peer.m_is_inbound,
         archive_or_mirror,
         node::matmul_trusted::SignedFrontierVersionHandshakeComplete(starting),
-        starting, followed_height);
+        starting, tip_height, best_known_height, best_known_extends_tip);
 }
 
 void PeerManagerImpl::MaybeFollowTrustedMirrorAuthorityHeader(

--- a/src/node/matmul_trusted_attestations.h
+++ b/src/node/matmul_trusted_attestations.h
@@ -816,10 +816,38 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     int tip_height)
 {
     // No VERSION: cannot serve. A peer whose VERSION height is at or behind
-    // our tip does not have the HEADER_ONLY suffix (live nyc1 2026-08-16:
-    // sibling archives were preferred-capable from headers alone, GETDATA
-    // timed out, miners were skipped).
+    // our *active* tip does not have tip+1 at handshake (live nyc1
+    // 2026-08-16: sibling archives were preferred-capable from headers
+    // alone, GETDATA timed out, miners were skipped).
+    // Compare to the connected tip, never to m_best_header: miner
+    // HEADER_ONLY children stacked on the attested tip made
+    // starting_height > followed_header fail while the peer still had
+    // every body from tip+1 through the signed frontier (live GPU-archive
+    // catch-up 2026-08-19: VERSION 194111 vs m_best_header 194116, tip
+    // 189534, inflight=0).
     return starting_height > tip_height;
+}
+
+/** Root-first catch-up GETDATA asks for active-tip+1, not m_best_header.
+ *  VERSION is a handshake snapshot (lower bound on bodies the peer *had*),
+ *  not a live connected height. After this node climbs past that snapshot,
+ *  a still-connected archive whose BestKnown extends our tip can still
+ *  serve historical tip+1 (live 2026-08-19: VERSION 194111, tip 194121,
+ *  BestKnown 194160, stall recovery logged every 60s with inflight=0).
+ *  Behind-sibling VERSION < tip with no extending BestKnown stays refused
+ *  (live nyc1 2026-08-17: 190767 vs 190816). */
+[[nodiscard]] inline bool SignedFrontierPeerMayServeCatchUpTipPlusOne(
+    int starting_height,
+    int active_tip_height,
+    int best_known_height = std::numeric_limits<int>::min(),
+    bool best_known_extends_tip = false)
+{
+    if (starting_height < 0) return false;
+    if (SignedFrontierPeerHadCatchUpBodiesAtConnect(starting_height,
+                                                    active_tip_height)) {
+        return true;
+    }
+    return best_known_extends_tip && best_known_height > active_tip_height;
 }
 
 [[nodiscard]] inline bool SignedFrontierBodySourceCanServeCatchUp(
@@ -832,8 +860,9 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     int starting_height = std::numeric_limits<int>::max())
 {
     if (!version_handshake_complete) return false;
-    if (!SignedFrontierPeerHadCatchUpBodiesAtConnect(starting_height,
-                                                     tip_height)) {
+    if (!SignedFrontierPeerMayServeCatchUpTipPlusOne(
+            starting_height, tip_height, best_known_height,
+            best_known_extends_tip)) {
         return false;
     }
     return preferred && has_best_known && best_known_height > tip_height &&
@@ -880,8 +909,10 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
 }
 
 /** Issue catch-up GETDATA only to handshake-complete GPU, or to our
- *  outbound archive/mirror that was ahead at VERSION. Hung -connect
- *  (no VERSION) must not occupy a slot or block those outbounds. */
+ *  outbound archive/mirror. Hung -connect (no VERSION) must not occupy
+ *  a slot or block those outbounds. `tip_height` is the *active* tip:
+ *  root-first asks for tip+1, so miner HEADER_ONLY children on
+ *  m_best_header must not raise the VERSION bar. */
 [[nodiscard]] inline bool SignedFrontierMayRequestCatchUpGetData(
     bool signed_frontier_catch_up,
     bool gpu_manual_or_noban,
@@ -889,7 +920,9 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     bool archive_or_mirror,
     bool version_handshake_complete,
     int starting_height = std::numeric_limits<int>::max(),
-    int tip_height = std::numeric_limits<int>::min())
+    int tip_height = std::numeric_limits<int>::min(),
+    int best_known_height = std::numeric_limits<int>::min(),
+    bool best_known_extends_tip = false)
 {
     if (!signed_frontier_catch_up) return true;
     if (!version_handshake_complete) return false;
@@ -899,8 +932,9 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     if (!gpu_manual_or_noban && (!outbound || !archive_or_mirror)) {
         return false;
     }
-    return SignedFrontierPeerHadCatchUpBodiesAtConnect(starting_height,
-                                                       tip_height);
+    return SignedFrontierPeerMayServeCatchUpTipPlusOne(
+        starting_height, tip_height, best_known_height,
+        best_known_extends_tip);
 }
 
 /** Skip miners / inbound archives during signed-frontier catch-up.
@@ -1333,14 +1367,18 @@ static constexpr auto GPU_RETAIN_ATTESTATION_RETRY{std::chrono::seconds{2}};
     return wait_s + kMargin;
 }
 
-/** 90s catch-up timeout: operator GPU with a completed VERSION only.
- *  Hung -connect (manual, starting_height=-1) keeps the 15s miner
- *  window so it cannot pin the pipeline. */
+/** 90s catch-up timeout: operator GPU/noban whose VERSION still shows
+ *  bodies past our active tip. Hung -connect (starting_height=-1) and
+ *  stale-handshake archives we have climbed past keep 15s so a behind
+ *  sibling cannot pin the 1-wide slot for 90s. */
 [[nodiscard]] inline bool SignedFrontierCatchUpUsesGpuTimeout(
     bool manual_or_noban,
-    bool version_handshake_complete)
+    bool version_handshake_complete,
+    int starting_height = std::numeric_limits<int>::max(),
+    int active_tip_height = std::numeric_limits<int>::min())
 {
-    return manual_or_noban && version_handshake_complete;
+    if (!manual_or_noban || !version_handshake_complete) return false;
+    return starting_height > active_tip_height;
 }
 
 /** 180s inflight reclaim for GPU catch-up: handshake-complete

--- a/src/node/matmul_trusted_attestations.h
+++ b/src/node/matmul_trusted_attestations.h
@@ -634,19 +634,39 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
  *  the missing root of a short tip-race reorg (sibling of tip / first hole
  *  on the authority peer's best-known), or a followed-chain HAVE_DATA /
  *  retained GPU body still waiting for MMATTEST. Competing headers at
- *  1879xx are neither. Parked deep-reorg branches never prefer. */
+ *  1879xx are neither. Parked deep-reorg branches never prefer.
+ *
+ *  During signed-frontier catch-up the moving frontier hash and a recent
+ *  active ancestor are not preferred. Live 2026-08-20: a trusted mirror
+ *  sat at tip 194727 (needed_height=194728) with catch_up=1 while
+ *  GETMMATTEST send hammered mid-suffix 194999 (stale frontier) and the
+ *  current frontier (no_such_block), so tip+1 never got a slot. */
 [[nodiscard]] inline bool TrustedMirrorPreferGetMmAttest(
     bool active_tip_child,
     bool short_tip_reorg_missing_root,
     bool on_parked_reorg_branch = false,
     bool recent_active_ancestor = false,
     bool followed_body_awaiting_attestation = false,
-    bool is_signed_frontier_hash = false)
+    bool is_signed_frontier_hash = false,
+    bool signed_frontier_catch_up = false)
 {
     if (on_parked_reorg_branch) return false;
-    return active_tip_child || short_tip_reorg_missing_root ||
-           recent_active_ancestor || followed_body_awaiting_attestation ||
-           is_signed_frontier_hash;
+    const bool hole{active_tip_child || short_tip_reorg_missing_root ||
+                    followed_body_awaiting_attestation};
+    if (signed_frontier_catch_up) return hole;
+    return hole || recent_active_ancestor || is_signed_frontier_hash;
+}
+
+/** Catch-up must not allocate a GETMMATTEST slot for a non-hole hash.
+ *  Non-preferred requests still occupied 16 mid-suffix slots (live
+ *  2026-08-20: outstanding_slots=16/1024, rejected_unattestable climbing)
+ *  while 194728 sat HEADER_ONLY with local quorum and in_flight=0. */
+[[nodiscard]] inline bool TrustedMirrorCatchUpShouldRequestGetMmAttest(
+    bool signed_frontier_catch_up,
+    bool preferred)
+{
+    if (!signed_frontier_catch_up) return true;
+    return preferred;
 }
 
 /** GETMMATTEST destinations. NODE_MATMUL_ATTESTATION_ARCHIVE means the

--- a/src/test/matmul_trusted_mirror_tests.cpp
+++ b/src/test/matmul_trusted_mirror_tests.cpp
@@ -944,6 +944,51 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
     BOOST_CHECK(!TrustedMirrorPreferGetMmAttest(
         /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/true,
         /*on_parked_reorg_branch=*/true));
+    // Catch-up: only the first hole. Frontier / ancestor preference is
+    // near-tip work and was the live 194999 GETMMATTEST hammer.
+    BOOST_CHECK(TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/true, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/true,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/true,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(!TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/true,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(!TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/true,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(!TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/true, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/true, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    using node::matmul_trusted::TrustedMirrorCatchUpShouldRequestGetMmAttest;
+    BOOST_CHECK(TrustedMirrorCatchUpShouldRequestGetMmAttest(
+        /*signed_frontier_catch_up=*/false, /*preferred=*/false));
+    BOOST_CHECK(TrustedMirrorCatchUpShouldRequestGetMmAttest(
+        /*signed_frontier_catch_up=*/true, /*preferred=*/true));
+    BOOST_CHECK(!TrustedMirrorCatchUpShouldRequestGetMmAttest(
+        /*signed_frontier_catch_up=*/true, /*preferred=*/false));
     using node::matmul_trusted::PreferGetMmAttestPeer;
     BOOST_CHECK(PreferGetMmAttestPeer(
         /*has_attestation_archive_bit=*/true, /*recent_valid_mmattest=*/false));

--- a/src/test/matmul_trusted_mirror_tests.cpp
+++ b/src/test/matmul_trusted_mirror_tests.cpp
@@ -1113,7 +1113,10 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
         /*preferred=*/true, /*has_best_known=*/true, /*best_known_height=*/190632,
         /*tip_height=*/190588, /*best_known_extends_tip=*/true,
         /*version_handshake_complete=*/false));
-    BOOST_CHECK(!SignedFrontierBodySourceCanServeCatchUp(
+    // VERSION == tip is not "had bodies past tip at connect", but BestKnown
+    // extending the active tip still lets us GETDATA tip+1 (handshake snapshot
+    // is stale once we have climbed; hung-connect starting=-1 stays refused).
+    BOOST_CHECK(SignedFrontierBodySourceCanServeCatchUp(
         /*preferred=*/true, /*has_best_known=*/true, /*best_known_height=*/190632,
         /*tip_height=*/190588, /*best_known_extends_tip=*/true,
         /*version_handshake_complete=*/true, /*starting_height=*/190588));
@@ -1193,6 +1196,30 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
     BOOST_CHECK(SignedFrontierMayRequestCatchUpGetData(
         true, false, true, true, true,
         /*starting_height=*/190858, /*tip_height=*/190781));
+    using node::matmul_trusted::SignedFrontierPeerMayServeCatchUpTipPlusOne;
+    // Miner HEADER_ONLY tower above the active tip must not gate GETDATA.
+    // VERSION 194111 is behind m_best_header 194116 but ahead of tip 189534.
+    BOOST_CHECK(SignedFrontierMayRequestCatchUpGetData(
+        true, /*gpu_manual_or_noban=*/true, true, true, true,
+        /*starting_height=*/194111, /*tip_height=*/189534));
+    BOOST_CHECK(SignedFrontierPeerMayServeCatchUpTipPlusOne(
+        /*starting_height=*/194111, /*active_tip_height=*/189534));
+    BOOST_CHECK(!SignedFrontierPeerMayServeCatchUpTipPlusOne(194111, 194116));
+    // Climbed past handshake snapshot; BestKnown still extends the active tip.
+    BOOST_CHECK(SignedFrontierMayRequestCatchUpGetData(
+        true, true, true, true, true,
+        /*starting_height=*/194111, /*tip_height=*/194121,
+        /*best_known_height=*/194160, /*best_known_extends_tip=*/true));
+    BOOST_CHECK(SignedFrontierPeerMayServeCatchUpTipPlusOne(
+        194111, 194121, 194160, true));
+    // Behind sibling: VERSION < tip, BestKnown does not extend past tip.
+    BOOST_CHECK(!SignedFrontierMayRequestCatchUpGetData(
+        true, true, true, true, true,
+        /*starting_height=*/190767, /*tip_height=*/190816,
+        /*best_known_height=*/190767, /*best_known_extends_tip=*/false));
+    BOOST_CHECK(!SignedFrontierPeerMayServeCatchUpTipPlusOne(
+        190767, 190816, 190767, false));
+    BOOST_CHECK(!SignedFrontierPeerMayServeCatchUpTipPlusOne(-1, 190781, 190858, true));
     using node::matmul_trusted::SignedFrontierVersionHandshakeComplete;
     BOOST_CHECK(!SignedFrontierVersionHandshakeComplete(-1));
     BOOST_CHECK(SignedFrontierVersionHandshakeComplete(0));
@@ -1284,6 +1311,10 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
         /*manual_or_noban=*/true, /*version_handshake_complete=*/true));
     BOOST_CHECK(!SignedFrontierCatchUpUsesGpuTimeout(true, false));
     BOOST_CHECK(!SignedFrontierCatchUpUsesGpuTimeout(false, true));
+    BOOST_CHECK(!SignedFrontierCatchUpUsesGpuTimeout(
+        true, true, /*starting_height=*/194111, /*active_tip_height=*/194121));
+    BOOST_CHECK(SignedFrontierCatchUpUsesGpuTimeout(
+        true, true, /*starting_height=*/194111, /*active_tip_height=*/189534));
     using node::matmul_trusted::KeepGpuSignedFrontierInFlightPipeline;
     BOOST_CHECK(KeepGpuSignedFrontierInFlightPipeline(
         /*signed_frontier_catch_up=*/true, /*manual_or_noban=*/true,


### PR DESCRIPTION
## Summary
- Trusted-mirror catch-up GETDATA compared peer VERSION height to `m_best_header` (miner HEADER_ONLY children stacked on the attested tip). Root-first fetch wants **active tip+1**, so every preferred archive failed `starting_height > followed_header` and `FindNextBlocksToDownload` returned with `inflight=0`. Stall recovery cleared `LastCommonBlock` every minute and hit the same gate.
- Live 2026-08-19 GPU-archive catch-up: VERSION 194111, `m_best_header` 194116, connected tip 189534, then again at 194121 after climbing past the handshake snapshot. Production archives at the attested tip were not stuck (`blocks_behind=0` turns this gate off).
- Compare VERSION / BestKnown to the **active tip**. If VERSION is stale but BestKnown still extends the tip, still ask for tip+1. 90s GPU timeout only while VERSION is still ahead of tip; otherwise 15s so a behind sibling cannot pin the 1-wide slot.

## Test plan
- [x] `test_btx --run_test=matmul_trusted_mirror_tests` (30 cases)
- [x] `test_btx --run_test=peerman_tests/archive_block_serve_helpers_and_gates_unchanged`
- [ ] Trusted IBD / catch-up with archive `addnode` + miner HEADER_ONLY above the signed frontier: GETDATA `tip+1`, `inflight>0`
- [ ] Behind sibling (VERSION < active tip, BestKnown does not extend): still refused
- [ ] Do not restart the live GPU signer to test this


Made with [Cursor](https://cursor.com)