### PR TITLE
0.33.4: carry signed-frontier catch-up from #112/#113

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,29 @@ peering, and attestor diversity can carry it:
    `-matmultrustedthreshold`. Archives stay CPU. Independent miners keep
    talking to seeds. Adding `N` with `M=1` is only availability; `M≥2` is
    what removes a single key as PoW authority.
+
+The live mainnet pin (1-of-2) is published below. GPU attestors and the
+CPU archives that follow them return the same set from
+`getmatmultrustedstatus` / `getfinalityinfo` (`trusted_signer_pubkeys`,
+`threshold`). P2P seed connect does **not** push keys — miners pin this
+set at bootstrap, then confirm it on local RPC after joining
+`node.btx.dev` / `node.btxchain.org` / `node.btx.tools`.
+
+```ini
+# Mainnet ExactReplay attestors. Public keys only — never a signer WIF.
+matmultrustedpubkey=03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa
+matmultrustedpubkey=0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c
+matmultrustedthreshold=1
+```
+
+```bash
+btx-cli getmatmultrustedstatus
+# configured=true, threshold=1, trusted_signer_pubkeys = the two hex keys above
+```
+
+A miner that omits this pin cannot see `getmatmulattestedtip` and
+`getblocktemplate` may extend an unattested orphan. Do not load
+`-matmulattestationsignerkeyfile` on a miner.
 3. **Convert public seeds to GPU full nodes.** Each converted host runs
    `-matmulvalidation=consensus` and ExactReplays. Trusted-mode on those
    boxes goes away. CPU wallets and explorers can remain light.
@@ -1077,6 +1100,28 @@ ADDR=$(./build/bin/btx-cli -regtest -rpcwallet=miner getnewaddress)
 # -> 200.00000000 (10 blocks x 20 BTX)
 ```
 
+### Attestor pin (mainnet mining bootstrap)
+
+After the node is up and peering with the public seed/archive mesh, treat
+the attestor set as a normal bootstrap check — same class of pin as DNS
+seeds, not a secret:
+
+1. Join the published seeds (`dnsseed=1`, `addnode=node.btx.dev:19335`, …).
+2. Have the two `-matmultrustedpubkey` lines and `-matmultrustedthreshold=1`
+   in `btx.conf` (miner fast-start writes them).
+3. Ping local RPC: `getmatmultrustedstatus` must show `configured=true`
+   and the same `trusted_signer_pubkeys` / `threshold` the archives and
+   GPU attestors return. `getfinalityinfo` repeats the pubs.
+4. Then call `getblocktemplate`. A unique attested child of tip means
+   follow `getmatmulattestedtip` instead of grinding an unattested twin.
+
+P2P `addnode` / DNS seeds do not serve RPC. You confirm the pin on **your**
+`btx-cli`, or on an archive/attestor RPC you already control. Do not take
+signer pubs from a random remote RPC.
+
+`contrib/faststart` `--preset miner` writes this pin and checks it after
+RPC is ready. `contrib/devtools/gen-btx-node-conf.sh` writes it too.
+
 ### Production Mining (getblocktemplate)
 
 ```bash
@@ -1137,6 +1182,8 @@ contrib/mining/backup-wallet.sh \
 | Command | Description |
 |---|---|
 | `getmininginfo` | Current mining state, difficulty, algorithm |
+| `getmatmultrustedstatus` | Attestor pin (`trusted_signer_pubkeys`, `threshold`) and attested tip |
+| `getmatmulattestedtip` | Highest-work block with quorum (GBT parent) |
 | `getblocktemplate` | Block template for external mining |
 | `submitblock` | Submit a solved block |
 | `generatetoaddress` | Mine N blocks (regtest/testnet) |

--- a/contrib/devtools/gen-btx-node-conf.sh
+++ b/contrib/devtools/gen-btx-node-conf.sh
@@ -76,6 +76,14 @@ retainshieldedcommitmentindex=1
 # Runtime defaults
 dbcache=4096
 maxmempool=300
+
+# Published mainnet ExactReplay attestors (public keys only).
+# GPU attestors and following archives return this from
+# getmatmultrustedstatus / getfinalityinfo after you join the seed mesh.
+# P2P addnode/DNS does not push keys. Do not load a signer WIF here.
+matmultrustedpubkey=03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa
+matmultrustedpubkey=0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c
+matmultrustedthreshold=1
 EOF
 
 if [[ "${BOOTSTRAP_MODE}" == "discover" ]]; then

--- a/contrib/faststart/README.md
+++ b/contrib/faststart/README.md
@@ -86,7 +86,18 @@ miningchainguard=1
 miningminoutboundpeers=0
 miningminsyncedoutboundpeers=0
 miningmaxheaderlag=8
+# Published 1-of-2 attestor pin (same set archives/attestors return
+# from getmatmultrustedstatus). P2P seeds do not push these keys.
+matmulvalidation=trusted
+matmultrustedpubkey=03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa
+matmultrustedpubkey=0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c
+matmultrustedthreshold=1
 ```
+
+After the daemon is up and peering with the public seeds, confirm the pin
+on local RPC (`getmatmultrustedstatus` → `trusted_signer_pubkeys` and
+`threshold`). That is the mining-bootstrap check; do not scrape signer
+pubs from a random remote RPC. Do not load a signer WIF on a miner.
 
 Use DNS names rather than hard-coded peer IP addresses in configs and runbooks.
 Peer IPs can change or disappear; DNS bootstrap names can be updated without

--- a/contrib/faststart/btx-faststart.py
+++ b/contrib/faststart/btx-faststart.py
@@ -35,6 +35,14 @@ GITHUB_API_BASE = "https://api.github.com"
 GITHUB_JSON_ACCEPT = "application/vnd.github+json"
 GITHUB_BINARY_ACCEPT = "application/octet-stream"
 
+# Published mainnet ExactReplay attestors (public keys only). Archives and
+# GPU attestors return this same set from getmatmultrustedstatus.
+MAINNET_ATTESTOR_PUBKEYS = (
+    "03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa",
+    "0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c",
+)
+MAINNET_ATTESTOR_THRESHOLD = 1
+
 PRESET_CONF = {
     "miner": [
         "server=1",
@@ -46,6 +54,13 @@ PRESET_CONF = {
         "addnode=node.btx.dev:19335",
         "addnode=node.btxchain.org:19335",
         "addnode=node.btx.tools:19335",
+        "# Published 1-of-2 attestor pin. Confirm after RPC is up:",
+        "#   btx-cli getmatmultrustedstatus",
+        "# P2P seeds do not push these keys. Do not load a signer WIF.",
+        "matmulvalidation=trusted",
+        f"matmultrustedpubkey={MAINNET_ATTESTOR_PUBKEYS[0]}",
+        f"matmultrustedpubkey={MAINNET_ATTESTOR_PUBKEYS[1]}",
+        f"matmultrustedthreshold={MAINNET_ATTESTOR_THRESHOLD}",
         "prune=4096",
         "blockfilterindex=1",
         "coinstatsindex=1",
@@ -67,6 +82,10 @@ PRESET_CONF = {
         "addnode=node.btx.dev:19335",
         "addnode=node.btxchain.org:19335",
         "addnode=node.btx.tools:19335",
+        "# Same published attestor pin the miner preset uses.",
+        f"matmultrustedpubkey={MAINNET_ATTESTOR_PUBKEYS[0]}",
+        f"matmultrustedpubkey={MAINNET_ATTESTOR_PUBKEYS[1]}",
+        f"matmultrustedthreshold={MAINNET_ATTESTOR_THRESHOLD}",
         "prune=0",
         "txindex=1",
         "blockfilterindex=1",
@@ -298,6 +317,31 @@ def rpc_json(cmd: list[str], method: str, *params: str) -> dict[str, Any]:
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(f"{method} failed:\n{exc.output}") from exc
     return json.loads(output)
+
+
+def verify_mainnet_attestor_pin(cli_cmd: list[str]) -> None:
+    """Confirm local RPC matches the published archive/attestor key set."""
+    status = rpc_json(cli_cmd, "getmatmultrustedstatus")
+    have = {str(key).lower() for key in status.get("trusted_signer_pubkeys") or []}
+    want = {key.lower() for key in MAINNET_ATTESTOR_PUBKEYS}
+    if have != want:
+        raise RuntimeError(
+            "getmatmultrustedstatus.trusted_signer_pubkeys does not match the "
+            f"published mainnet attestor pin {sorted(want)}; got {sorted(have)}. "
+            "P2P seeds do not advertise this set — it is pinned in miner/service "
+            "bootstrap and must match GPU attestors and following archives."
+        )
+    threshold = int(status.get("threshold") or 0)
+    if threshold != MAINNET_ATTESTOR_THRESHOLD:
+        raise RuntimeError(
+            "getmatmultrustedstatus.threshold does not match the published "
+            f"mainnet pin {MAINNET_ATTESTOR_THRESHOLD}; got {threshold}."
+        )
+    print(
+        "attestor pin ok: configured="
+        f"{status.get('configured')} threshold={threshold} "
+        f"pubkeys={len(have)}"
+    )
 
 
 def wait_for_rpc_ready(cli_cmd: list[str], timeout_secs: int) -> None:
@@ -676,6 +720,9 @@ def main(argv: list[str]) -> int:
         print(f"starting daemon with preset '{args.preset}'")
         run_quiet(daemon)
         wait_for_rpc_ready(cli_cmd, args.rpc_wait_secs)
+
+    if args.chain == "main":
+        verify_mainnet_attestor_pin(cli_cmd)
 
     print(f"downloading snapshot: {snapshot_url}")
     download_snapshot(snapshot_url, snapshot_path, snapshot_sha256)

--- a/contrib/mining/README.md
+++ b/contrib/mining/README.md
@@ -213,7 +213,11 @@ operator policy.
 For a first-run bootstrap before mining or service bring-up, see
 [`contrib/faststart`](../faststart). Those entry points fetch the matching
 snapshot, run `loadtxoutset`, and watch `getchainstates` until the bootstrap
-chainstate clears.
+chainstate clears. Miner/service presets also pin the published mainnet
+attestor pubkeys and, on mainnet, check `getmatmultrustedstatus` after RPC
+is ready so `getblocktemplate` follows the attested tip. That check is
+local RPC after you have joined the seed/archive mesh; P2P seeds do not
+advertise the key set.
 
 Stop:
 

--- a/doc/btx-matmul-trusted-rpc-mirrors.md
+++ b/doc/btx-matmul-trusted-rpc-mirrors.md
@@ -71,6 +71,14 @@ Operators should compare `attestation_version` and
 and mirror before admitting traffic. A mismatch is a configuration/release
 error and the affected mirror will reject those attestations.
 
+The live mainnet attestor pin (public keys, threshold 1) is published in
+the repository README and written by miner/archive bootstrap
+(`contrib/faststart`, `gen-btx-node-conf.sh`). `getmatmultrustedstatus`
+and `getfinalityinfo` on GPU attestors and following archives return
+`trusted_signer_pubkeys` / `threshold` for that same set. P2P seed
+connect does not advertise keys; miners pin them locally and confirm on
+RPC after joining the seed mesh. Do not load a signer WIF on a miner.
+
 ## Roles and service capabilities
 
 - `-matmulvalidation=consensus` performs local authority as before. With a

--- a/doc/btx-public-node-bootstrap.md
+++ b/doc/btx-public-node-bootstrap.md
@@ -62,12 +62,22 @@ addnode=node.btxchain.org:19335
 addnode=node.btx.tools:19335
 addnode=146.190.179.86:19335
 addnode=164.90.246.229:19335
+
+# Published mainnet ExactReplay attestors (public keys only).
+# Same set GPU attestors and following archives return from
+# getmatmultrustedstatus / getfinalityinfo. P2P seeds do not push keys.
+matmultrustedpubkey=03d90c148db37da28ce47ce15bade88a177728d663da4bc9ba765943b7d4e4f0aa
+matmultrustedpubkey=0224e80df33697385b54b3c69bae1f097f533c0c43e93c29f73ee97319d4a5e04c
+matmultrustedthreshold=1
 ```
 
 Notes:
 
 - `19335` is the BTX mainnet P2P port.
 - `19334` is the BTX mainnet default RPC port.
+- After `btxd` is up, `btx-cli getmatmultrustedstatus` must show
+  `configured=true` and the two pubkeys above. That is the mining/archive
+  bootstrap pin (same RPC GPU attestors and following archives serve).
 - `addnode=` seeds initial peers while preserving broader peer discovery.
 - the current public DNS bootstrap set is `node.btx.dev`,
   `node.btxchain.org`, and `node.btx.tools`; direct IP addnodes are optional

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4269,6 +4269,28 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     // hung -connect with no VERSION.
     const bool this_peer_frontier_source{
         PeerIsSignedFrontierBodySource(peer.m_id, *state, &peer)};
+    const bool this_peer_gpu{PeerIsGpuAuthority(peer.m_id, *state)};
+    const int32_t attestor_park{node::matmul_trusted::AttestorDriftYieldDepth(
+        m_chainman.m_options.max_reorg_depth_park.value_or(
+            kernel::GetReorgProtectionProfileSettings(
+                m_chainman.m_options.reorg_protection_profile)
+                .park_depth))};
+    const auto signed_frontier{m_chainman.GetSignedFrontierStatus()};
+    const bool yield_to_this_peer{
+        node::matmul_trusted::AttestorShouldYieldToPeerAttestedChain(
+            node::matmul_trusted::HasLocalSigner(),
+            this_peer_gpu,
+            static_cast<int32_t>(tip_height),
+            state->pindexBestKnownBlock != nullptr
+                ? state->pindexBestKnownBlock->nHeight
+                : -1,
+            attestor_park)};
+    const bool yield_to_frontier{
+        node::matmul_trusted::AttestorShouldYieldToSignedFrontier(
+            node::matmul_trusted::HasLocalSigner(),
+            signed_frontier.blocks_behind,
+            attestor_park)};
+    const bool attestor_yielding{yield_to_this_peer || yield_to_frontier};
     if (node::matmul_trusted::SkipNonPreferredSignedFrontierBodyPeer(
             IsSignedFrontierBodyCatchUp(),
             this_peer_frontier_source,
@@ -4337,7 +4359,8 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     // node-wide freeze and prevents the active branch from making progress.
     if (recovery.phase == ChainRecoveryPhase::PARKED_NEEDS_OPERATOR &&
         state->pindexBestKnownBlock != nullptr &&
-        m_chainman.IsOnParkedReorgBranch(state->pindexBestKnownBlock)) {
+        m_chainman.IsOnParkedReorgBranch(state->pindexBestKnownBlock) &&
+        !yield_to_this_peer) {
         log_skip(recovery.reason);
         return;
     }
@@ -4371,7 +4394,8 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
                         state->pindexBestKnownBlock),
                     tip,
                     state->pindexBestKnownBlock)};
-            if (!recovery_target && !configured_attested_race) {
+            if (!recovery_target && !configured_attested_race &&
+                !yield_to_this_peer) {
                 log_skip("competing_not_active_tip_chain");
                 return;
             }
@@ -4471,7 +4495,8 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
             m_need_activate_best_chain = true;
             m_last_unconnected_abc_kick = now_kick;
         }
-        if (this_peer_frontier_source) {
+        if (this_peer_frontier_source ||
+            (attestor_yielding && this_peer_gpu)) {
             RequestMatMulTrustedAttestations(
                 state->pindexLastCommonBlock->GetBlockHash(), peer.m_id);
         }
@@ -4556,20 +4581,47 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
             return;
         }
     }
-    if (root_first.lowest_missing != nullptr &&
-        m_matmul_block_lifecycle.HasRetainedBody(
-            root_first.lowest_missing->GetBlockHash())) {
-        // Same stall as HAVE_DATA-unconnected: the followed-chain body is
-        // already in the lifecycle store (pending-cap / budget / ticketless
-        // retry). Re-getdata of this hash or its successors cannot connect
-        // until the scheduler re-admits. GETMMATTEST the retained hash so
-        // quorum can lift ConnectTip without waiting for the 1s retry loop.
-        if (this_peer_frontier_source) {
-            RequestMatMulTrustedAttestations(
-                root_first.lowest_missing->GetBlockHash(), peer.m_id);
+    if (root_first.lowest_missing != nullptr) {
+        const uint256 missing_hash{root_first.lowest_missing->GetBlockHash()};
+        const bool on_winner{
+            m_chainman.IndexIsOnSignedFrontierChain(
+                root_first.lowest_missing) ||
+            m_chainman.IndexLeadsToSignedFrontier(
+                root_first.lowest_missing) ||
+            (state->pindexBestKnownBlock != nullptr &&
+             state->pindexBestKnownBlock->GetAncestor(
+                 root_first.lowest_missing->nHeight) ==
+                 root_first.lowest_missing)};
+        const bool header_failed{
+            (root_first.lowest_missing->nStatus & BLOCK_FAILED_MASK) != 0};
+        const bool catch_up_target{
+            node::matmul_trusted::AttestorYieldHashIsCatchUpTarget(
+                attestor_yielding, on_winner, header_failed)};
+        if (catch_up_target) {
+            m_header_only_competing.erase(missing_hash);
+            m_header_only_followed_skip.erase(missing_hash);
         }
-        log_skip("root_retained_body");
-        return;
+        if (m_matmul_block_lifecycle.HasRetainedBody(missing_hash)) {
+            // Same stall as HAVE_DATA-unconnected: the followed-chain body is
+            // already in the lifecycle store (pending-cap / budget / ticketless
+            // retry). Re-getdata of this hash or its successors cannot connect
+            // until the scheduler re-admits. GETMMATTEST the retained hash so
+            // quorum can lift ConnectTip without waiting for the 1s retry loop.
+            // Local signers never arm signed-frontier catch-up, so also
+            // RefreshRetry(0) when yielding to the longer attested GPU.
+            if (node::matmul_trusted::AttestorYieldMustReadmitRetainedBody(
+                    attestor_yielding, true, catch_up_target)) {
+                (void)m_matmul_block_lifecycle.RefreshRetry(
+                    missing_hash, std::chrono::seconds{0});
+                m_need_activate_best_chain = true;
+            }
+            if (this_peer_frontier_source ||
+                (attestor_yielding && this_peer_gpu && catch_up_target)) {
+                RequestMatMulTrustedAttestations(missing_hash, peer.m_id);
+            }
+            log_skip("root_retained_body");
+            return;
+        }
     }
 
     const CBlockIndex *pindexWalk = state->pindexLastCommonBlock;
@@ -9127,6 +9179,7 @@ void PeerManagerImpl::RequestMatMulTrustedAttestations(
     bool request{false};
     bool asked_preferred_round{false};
     bool signed_frontier_catch_up{false};
+    bool attestor_yielding{false};
     {
         LOCK(cs_main);
         signed_frontier_catch_up = IsSignedFrontierBodyCatchUp();
@@ -9139,14 +9192,63 @@ void PeerManagerImpl::RequestMatMulTrustedAttestations(
         const CBlockIndex* index{
             m_chainman.m_blockman.LookupBlockIndex(hash)};
         const int32_t height{index ? index->nHeight : -1};
+        const int32_t attestor_park{
+            node::matmul_trusted::AttestorDriftYieldDepth(
+                m_chainman.m_options.max_reorg_depth_park.value_or(
+                    kernel::GetReorgProtectionProfileSettings(
+                        m_chainman.m_options.reorg_protection_profile)
+                        .park_depth))};
+        const auto frontier_status_yield{m_chainman.GetSignedFrontierStatus()};
+        bool source_gpu{false};
+        int32_t source_best_h{-1};
+        if (const CNodeState* src_state{State(source)}; src_state != nullptr) {
+            source_gpu = PeerIsGpuAuthority(source, *src_state);
+            if (src_state->pindexBestKnownBlock != nullptr) {
+                source_best_h = src_state->pindexBestKnownBlock->nHeight;
+            }
+        }
+        attestor_yielding =
+            node::matmul_trusted::AttestorShouldYieldToSignedFrontier(
+                node::matmul_trusted::HasLocalSigner(),
+                frontier_status_yield.blocks_behind,
+                attestor_park) ||
+            node::matmul_trusted::AttestorShouldYieldToPeerAttestedChain(
+                node::matmul_trusted::HasLocalSigner(),
+                source_gpu, tip_height, source_best_h, attestor_park);
+        bool on_winner_or_frontier{false};
+        if (index != nullptr) {
+            on_winner_or_frontier =
+                m_chainman.IndexIsOnSignedFrontierChain(index) ||
+                m_chainman.IndexLeadsToSignedFrontier(index);
+            if (!on_winner_or_frontier && source_best_h >= 0) {
+                if (const CNodeState* src_state{State(source)};
+                    src_state != nullptr &&
+                    src_state->pindexBestKnownBlock != nullptr &&
+                    src_state->pindexBestKnownBlock->GetAncestor(
+                        index->nHeight) == index) {
+                    on_winner_or_frontier = true;
+                }
+            }
+        }
+        if (!node::matmul_trusted::AttestorYieldShouldRequestGetMmAttest(
+                attestor_yielding, on_winner_or_frontier)) {
+            return;
+        }
+        if (attestor_yielding && on_winner_or_frontier) {
+            m_matmul_attestation_backoff.erase(hash);
+        }
         // Already-quorum hashes must not occupy GETMMATTEST tokens. Lookback
         // of the active tip, plus header-first skip-GPU, used to re-request
         // the same hash after MMATTEST cleared the in-flight map and drain
         // the archive's 16-token burst so the deferred child was rate-limited
         // forever (qualifier linear-chain stall at the next height).
+        // RefreshRetry(0) so a retained body that already has authority is
+        // re-admitted instead of sitting in root_retained_body.
         if (index != nullptr &&
             m_chainman.IndexHasTrustedMatMulAuthority(index)) {
             m_matmul_attestation_requested.erase(hash);
+            (void)m_matmul_block_lifecycle.RefreshRetry(
+                hash, std::chrono::seconds{0});
             return;
         }
         const bool parked{
@@ -9394,6 +9496,10 @@ void PeerManagerImpl::RequestMatMulTrustedAttestations(
             NODE_MATMUL_TRUSTED_MIRROR};
         const bool consensus_node{
             (services & NODE_MATMUL_CONSENSUS) == NODE_MATMUL_CONSENSUS};
+        if (!node::matmul_trusted::AttestorYieldPreferGetMmAttestPeer(
+                attestor_yielding, gpu_peers.count(id) != 0)) {
+            return;
+        }
         if (!node::matmul_trusted::PreferGetMmAttestPeer(
                 archive, recent_success, trusted_mirror, consensus_node,
                 signed_frontier_catch_up, gpu_peers.count(id) != 0)) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -12204,6 +12204,13 @@ void PeerManagerImpl::ProcessBlockSync(NodeId nodeid, CNode* node, const std::sh
             index->IsValid(BLOCK_VALID_SCRIPTS);
         terminal_failure = index != nullptr &&
             (index->nStatus & BLOCK_FAILED_MASK) != 0;
+        if (node::matmul_trusted::ShouldAdvanceBestKnownFromPeerBody(
+                index != nullptr, terminal_failure,
+                index != nullptr &&
+                    (index->nStatus & BLOCK_HAVE_DATA) != 0) &&
+            State(nodeid) != nullptr) {
+            UpdateBlockAvailability(nodeid, hash);
+        }
         // Persist-or-skip-fetch: a delivered followed-chain body that still
         // lacks HAVE_DATA must not re-enter FindNextBlocks until the tip
         // moves. True anti-DoS HEADER_ONLY never reaches ProcessNewBlock.
@@ -16006,6 +16013,17 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             const auto result{
                 node::matmul_trusted::Add(
                     attestation, hash, expected_height)};
+            // Per-connection BestKnown: MMATTEST is how 1-of-2 attestors
+            // prove the live tip after they stop announcing headers at
+            // each other.
+            if (node::matmul_trusted::ShouldAdvanceBestKnownFromMmAttest(
+                    known_profile1, /*header_failed=*/false, result)) {
+                LOCK(cs_main);
+                if (State(pfrom.GetId()) != nullptr) {
+                    UpdateBlockAvailability(pfrom.GetId(), hash);
+                }
+                wake_block_fetch = true;
+            }
             if (result ==
                 matmul::trusted::AddResult::Accepted) {
                 relay.push_back(attestation);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -8549,12 +8549,15 @@ std::chrono::microseconds PeerManagerImpl::CatchUpDownloadTimeoutForPeer(
 {
     AssertLockHeld(cs_main);
     (void)peer_id;
-    // 90s only for a handshake-complete GPU (manual/noban). Hung -connect
-    // and outbound archives keep 15s so a silent source failsovers.
+    const CBlockIndex* const tip{m_chainman.ActiveTip()};
+    const int tip_height{tip != nullptr ? tip->nHeight : 0};
+    // 90s only when VERSION still shows bodies past our *active* tip.
+    // Stale handshake (we climbed past VERSION) and hung -connect keep 15s.
     if (node::matmul_trusted::SignedFrontierCatchUpUsesGpuTimeout(
             state.m_manual || state.m_noban,
             node::matmul_trusted::SignedFrontierVersionHandshakeComplete(
-                state.m_starting_height))) {
+                state.m_starting_height),
+            state.m_starting_height, tip_height)) {
         return std::chrono::duration_cast<std::chrono::microseconds>(
             node::matmul_trusted::SignedFrontierPreferredCatchUpTimeout(
                 node::matmul_trusted::WaitTimeout()));
@@ -8569,15 +8572,18 @@ bool PeerManagerImpl::PeerMaySignedFrontierCatchUpGetData(
     AssertLockHeld(cs_main);
     const CBlockIndex* const tip{m_chainman.ActiveTip()};
     const int tip_height{tip != nullptr ? tip->nHeight : 0};
-    // Compare VERSION height to the followed HEADER_ONLY suffix, not the
-    // connected tip. Sibling -connect archives can be ahead of our tip and
-    // still lack the suffix bodies (live nyc1 2026-08-17: GPU 191713 vs
-    // siblings 191685/191687 while m_best_header=191690; GETDATA went to
-    // siblings, inflight=0).
-    const int followed_height{
-        m_chainman.m_best_header != nullptr
-            ? m_chainman.m_best_header->nHeight
-            : tip_height};
+    // Root-first GETDATA is tip+1. Compare VERSION / BestKnown to the
+    // active tip, never to m_best_header: miner HEADER_ONLY children
+    // above the signed frontier made every archive fail
+    // starting_height > followed_header (live 2026-08-19: VERSION 194111,
+    // m_best_header 194116, tip 189534, inflight=0, stall loop no-op).
+    const int best_known_height{
+        state.pindexBestKnownBlock != nullptr
+            ? state.pindexBestKnownBlock->nHeight
+            : std::numeric_limits<int>::min()};
+    const bool best_known_extends_tip{
+        tip != nullptr && state.pindexBestKnownBlock != nullptr &&
+        state.pindexBestKnownBlock->GetAncestor(tip_height) == tip};
     const ServiceFlags services{peer.m_their_services.load()};
     const bool archive_or_mirror{
         state.m_matmul_attestation_archive || state.m_matmul_trusted_mirror ||
@@ -8593,7 +8599,7 @@ bool PeerManagerImpl::PeerMaySignedFrontierCatchUpGetData(
         !state.m_inbound && !peer.m_is_inbound,
         archive_or_mirror,
         node::matmul_trusted::SignedFrontierVersionHandshakeComplete(starting),
-        starting, followed_height);
+        starting, tip_height, best_known_height, best_known_extends_tip);
 }
 
 void PeerManagerImpl::MaybeFollowTrustedMirrorAuthorityHeader(

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -487,6 +487,9 @@ static constexpr auto MATMUL_ASYNC_VERIFY_STALE_AFTER{10min};
  *  maximum; runtime code shortens it to the actual remaining window whenever a
  *  peer/global RC budget already has a known refill time. */
 static constexpr auto MATMUL_BUDGET_DEFER_COOLDOWN{60s};
+/** Losing-twin fossils must not win NextRetry every cooldown while the
+ *  signed frontier is off-chain (live 2026-08-20, 45+ min wedge). */
+static constexpr auto MATMUL_FRONTIER_OFFCHAIN_FOSSIL_RETRY{10min};
 static constexpr auto MATMUL_BUDGET_DEFER_RETRY_FLOOR{1s};
 /** Pending-work saturation is capacity pressure, not a rate-window miss. */
 static constexpr auto MATMUL_PENDING_RETRY_COOLDOWN{1s};
@@ -2922,6 +2925,16 @@ void PeerManagerImpl::RefreshMatMulDeferredBodyRetry(
     const CBlockIndex* index)
     EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+[[nodiscard]] static bool IndexIsShortReorgAttestedForkChild(
+    const ChainstateManager& chainman,
+    const CBlockIndex* tip,
+    const CBlockIndex* index)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+[[nodiscard]] static const CBlockIndex* FindShortReorgAttestedForkChild(
+    const ChainstateManager& chainman)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 void PeerManagerImpl::RetryMatMulDeferredBodies()
 {
     AssertLockNotHeld(cs_main);
@@ -2997,6 +3010,32 @@ void PeerManagerImpl::RetryMatMulDeferredBodies()
                     if (!m_chainman.m_blockman.ReadBlock(*replay_block, *child)) {
                         replay_block.reset();
                     }
+            } else if (const CBlockIndex* const fork_child{
+                           FindShortReorgAttestedForkChild(m_chainman)};
+                       fork_child != nullptr &&
+                       (fork_child->nStatus & BLOCK_HAVE_DATA) != 0 &&
+                       (fork_child->nStatus & BLOCK_FAILED_MASK) == 0) {
+                    // Live 2026-08-20: m_best_header stayed on the unattested
+                    // equal-work twin so the followed tip-child path never
+                    // fired. Re-admit the attested sibling (LCA+1).
+                    if (m_chainman.IsOnParkedReorgBranch(fork_child)) {
+                        (void)m_chainman.UnparkReorgBranchContainingBlock(
+                            fork_child);
+                    }
+                    (void)m_chainman.NormalizeReorgRecovery(tip);
+                    reverify_hash = fork_child->GetBlockHash();
+                    reverify_height = fork_child->nHeight;
+                    reverify_header = fork_child->GetBlockHeader();
+                    need_exact_replay =
+                        (fork_child->nStatus & BLOCK_EXACT_REPLAY_VERIFIED) == 0 &&
+                        !node::matmul_trusted::SkipExactReplayForGpuAttestation(
+                            m_chainman.IndexHasTrustedMatMulAuthority(fork_child));
+                    m_chainman.ActiveChainstate().TryAddBlockIndexCandidate(
+                        const_cast<CBlockIndex*>(fork_child));
+                    replay_block = std::make_shared<CBlock>();
+                    if (!m_chainman.m_blockman.ReadBlock(*replay_block, *fork_child)) {
+                        replay_block.reset();
+                    }
             }
         }
         static std::atomic<int64_t> g_followed_tip_child_replay_at{0};
@@ -3043,10 +3082,24 @@ void PeerManagerImpl::RetryMatMulDeferredBodies()
     // unresponsive, and nothing is logged. Observed on a live archive
     // 2026-08-11: 65 threads, 59 in futex wait, no log output for 28 minutes,
     // requiring SIGKILL. Never hold the store mutex while acquiring cs_main.
-    const uint256 wanted{WITH_LOCK(cs_main,
-        return m_chainman.ActiveChain().Tip()
-                   ? m_chainman.ActiveChain().Tip()->GetBlockHash()
-                   : uint256{})};
+    uint256 wanted{};
+    uint256 fork_child_hash{};
+    bool frontier_off_chain{false};
+    {
+        LOCK(cs_main);
+        const CBlockIndex* const tip{m_chainman.ActiveChain().Tip()};
+        if (tip != nullptr) wanted = tip->GetBlockHash();
+        const auto frontier{m_chainman.GetSignedFrontierStatus()};
+        frontier_off_chain = frontier.available && !frontier.on_active_chain;
+        if (const CBlockIndex* const fork{
+                FindShortReorgAttestedForkChild(m_chainman)};
+            fork != nullptr && fork->pprev != nullptr) {
+            // NextRetry matches hashPrevBlock. The attested sibling's
+            // parent is the LCA, not the losing tip (live 195603).
+            wanted = fork->pprev->GetBlockHash();
+            fork_child_hash = fork->GetBlockHash();
+        }
+    }
     const bool idle_catchup{
         m_matmul_pending_verifications.load(std::memory_order_relaxed) == 0 &&
         m_matmul_rc_pending_verifications.load(std::memory_order_relaxed) == 0};
@@ -3056,6 +3109,30 @@ void PeerManagerImpl::RetryMatMulDeferredBodies()
     candidate_hash = retry->first;
     candidate = retry->second;
     if (!candidate.block) return;
+    if (frontier_off_chain && candidate_hash != fork_child_hash) {
+        bool allow{false};
+        {
+            LOCK(cs_main);
+            const CBlockIndex* const tip{m_chainman.ActiveTip()};
+            const CBlockIndex* const idx{
+                m_chainman.m_blockman.LookupBlockIndex(candidate_hash)};
+            allow = node::matmul_trusted::ShouldRetryBudgetDeferredWhileFrontierOffChain(
+                /*frontier_off_active_chain=*/true,
+                IndexIsShortReorgAttestedForkChild(m_chainman, tip, idx),
+                m_chainman.IndexIsOnSignedFrontierChain(idx),
+                IndexIsFollowedTipChild(m_chainman, tip, idx));
+        }
+        if (!allow) {
+            if (m_matmul_block_lifecycle.RefreshRetry(
+                    candidate_hash, MATMUL_FRONTIER_OFFCHAIN_FOSSIL_RETRY)) {
+                LogDebug(BCLog::NET,
+                         "Deferring off-frontier budget-deferred fossil %s "
+                         "while signed frontier is off the active chain\n",
+                         candidate_hash.ToString());
+            }
+            return;
+        }
+    }
 
     // Prefer the original source so permission, address and keyed-netgroup
     // accounting stay charged. If that peer is gone, replay locally: waiting
@@ -3827,6 +3904,60 @@ static bool TrustedMirrorMayDownloadIndex(
 //! clear only on ActiveTipChange. Live 2026-08-15 09:14Z: signer tip
 //! 189834, followed 189835 child skipped (`root_header_only_skip`),
 //! GBT kept templating 189835, and no newer attestation was signed.
+[[nodiscard]] static bool IndexIsShortReorgAttestedForkChild(
+    const ChainstateManager& chainman,
+    const CBlockIndex* tip,
+    const CBlockIndex* index)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    if (tip == nullptr || index == nullptr || index == tip) return false;
+    if ((index->nStatus & BLOCK_FAILED_MASK) != 0) return false;
+    if (chainman.IsOnParkedReorgBranch(index)) return false;
+    const bool on_active{
+        index->nHeight <= tip->nHeight &&
+        tip->GetAncestor(index->nHeight) == index};
+    if (on_active) return false;
+    const CBlockIndex* const lca{LastCommonAncestor(tip, index)};
+    if (lca == nullptr || index->pprev != lca) return false;
+    const bool covered{
+        chainman.IndexIsOnSignedFrontierChain(index) ||
+        chainman.IndexHasTrustedMatMulAuthority(index)};
+    return node::matmul_trusted::ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        node::matmul_trusted::IsConfigured(),
+        chainman.IndexHasTrustedMatMulAuthority(tip),
+        covered,
+        /*index_is_tip=*/false,
+        tip->nHeight - lca->nHeight,
+        /*is_immediate_fork_child=*/true,
+        /*index_on_active_chain=*/false,
+        node::matmul_trusted::HasCompetingQuorum(
+            index->GetBlockHash(), index->nHeight),
+        /*on_parked=*/false);
+}
+
+[[nodiscard]] static const CBlockIndex* FindShortReorgAttestedForkChild(
+    const ChainstateManager& chainman)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    const CBlockIndex* const tip{chainman.ActiveTip()};
+    if (tip == nullptr) return nullptr;
+    const auto frontier{chainman.GetSignedFrontierStatus()};
+    if (!frontier.available || !frontier.hash_known || frontier.on_active_chain) {
+        return nullptr;
+    }
+    const CBlockIndex* const frontier_index{
+        chainman.m_blockman.LookupBlockIndex(frontier.hash)};
+    if (frontier_index == nullptr) return nullptr;
+    const CBlockIndex* const lca{LastCommonAncestor(tip, frontier_index)};
+    if (lca == nullptr) return nullptr;
+    const CBlockIndex* const fork_child{
+        frontier_index->GetAncestor(lca->nHeight + 1)};
+    if (!IndexIsShortReorgAttestedForkChild(chainman, tip, fork_child)) {
+        return nullptr;
+    }
+    return fork_child;
+}
+
 [[nodiscard]] static bool IsHeaderOnlyFetchSuppressed(
     const ChainstateManager& chainman,
     const CBlockIndex* tip,
@@ -3836,6 +3967,7 @@ static bool TrustedMirrorMayDownloadIndex(
     EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (index == nullptr) return false;
+    if (IndexIsShortReorgAttestedForkChild(chainman, tip, index)) return false;
     if (chainman.IndexHasTrustedMatMulAuthority(index)) return false;
     if (chainman.IndexIsOnSignedFrontierChain(index)) return false;
     if (chainman.IndexIsAttestedChainTipChild(tip, index)) return false;
@@ -3970,6 +4102,13 @@ static uint256 g_configured_claimed_tip_child{};
 {
     if (tip == nullptr || index == nullptr) return false;
     if (node::matmul_trusted::IsTrustedMirror()) return false;
+    // Live 2026-08-20: local-signer ExactReplay required pprev==tip, so the
+    // attested equal-work sibling (LCA+1) was HEADER_ONLY-skipped and the
+    // node sat inflight=0 / GPU 0% for 45+ minutes.
+    if (IndexIsShortReorgAttestedForkChild(chainman, tip, index)) {
+        g_configured_claimed_tip_child = index->GetBlockHash();
+        return true;
+    }
     if (node::matmul_trusted::HasLocalSigner()) {
         // Unique attested tip-child toward the signed frontier: catch-up
         // ExactReplay / re-admit even when a competing unattested sibling
@@ -8969,7 +9108,7 @@ void PeerManagerImpl::MaybeRequestTrustedMirrorPreferredAttestations(
                 TrustedMirrorShortTipReorg(tip, target),
                 /*on_parked_reorg_branch=*/false,
                 recent_active_ancestor, followed_body_awaiting,
-                is_signed_frontier)) {
+                is_signed_frontier, IsSignedFrontierBodyCatchUp())) {
             return;
         }
         RequestMatMulTrustedAttestations(target->GetBlockHash(),
@@ -9276,9 +9415,17 @@ void PeerManagerImpl::RequestMatMulTrustedAttestations(
         const bool preferred{
             node::matmul_trusted::TrustedMirrorPreferGetMmAttest(
                 tip_child, short_reorg, parked, recent_active_ancestor,
-                followed_body_awaiting, is_signed_frontier)};
+                followed_body_awaiting, is_signed_frontier,
+                signed_frontier_catch_up)};
+        if (!node::matmul_trusted::TrustedMirrorCatchUpShouldRequestGetMmAttest(
+                signed_frontier_catch_up, preferred)) {
+            // Drop a stale frontier / mid-suffix token so TTL refresh
+            // cannot keep GETMMATTEST-sending it (sfo3 a3e41371@194999).
+            m_matmul_attestation_requested.erase(hash);
+            return;
+        }
         if (tip_child || short_reorg || followed_body_awaiting ||
-            is_signed_frontier) {
+            (is_signed_frontier && !signed_frontier_catch_up)) {
             m_matmul_attestation_backoff.erase(hash);
         }
 

--- a/src/node/matmul_trusted_attestations.h
+++ b/src/node/matmul_trusted_attestations.h
@@ -850,6 +850,34 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     return best_known_extends_tip && best_known_height > active_tip_height;
 }
 
+/** A valid Accepted/Duplicate MMATTEST for a known non-failed Profile-1
+ *  header proves the peer has that hash. BestKnown used to move only on
+ *  INV/HEADERS/CMPCTBLOCK, so a 1-of-2 attestor that only relayed
+ *  attestations and bodies stayed pinned at the last header announcement.
+ *  That made FindNextBlocks skip the peer, CHAIN_SYNC_TIMEOUT treat it as
+ *  an old chain, and catch-up GETDATA/GETMMATTEST use a stale pointer.
+ *  Rejected / unknown / failed headers must not advance it (competing
+ *  HEADER_ONLY towers stay untrusted). */
+[[nodiscard]] inline bool ShouldAdvanceBestKnownFromMmAttest(
+    bool known_profile1,
+    bool header_failed,
+    matmul::trusted::AddResult result)
+{
+    if (!known_profile1 || header_failed) return false;
+    return result == matmul::trusted::AddResult::Accepted ||
+           result == matmul::trusted::AddResult::Duplicate;
+}
+
+/** A connected, non-failed body also proves availability. HEADER_ONLY,
+ *  deferred, mutated, or failed deliveries must not move BestKnown. */
+[[nodiscard]] inline bool ShouldAdvanceBestKnownFromPeerBody(
+    bool have_index,
+    bool header_failed,
+    bool have_data)
+{
+    return have_index && !header_failed && have_data;
+}
+
 [[nodiscard]] inline bool SignedFrontierBodySourceCanServeCatchUp(
     bool preferred,
     bool has_best_known,

--- a/src/node/matmul_trusted_attestations.h
+++ b/src/node/matmul_trusted_attestations.h
@@ -878,6 +878,100 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     return have_index && !header_failed && have_data;
 }
 
+/**
+ * Attestor↔attestor drift yield (1-of-2 / M-of-N GPU signers).
+ *
+ * Local signers are not trusted mirrors, so IsSignedFrontierCatchUp never
+ * arms on them. After two GPUs sit on the same tip they also stop
+ * announcing headers; even with BestKnown advancing from MMATTEST/body,
+ * the loser can sit on root_retained_body with in_flight=0 while GETMMATTEST
+ * tokens go to competing HEADER_ONLY twins (live 2026-08-20: tip 194828,
+ * canonical 194829 retained, peer BestKnown 194851, rejected_unattestable
+ * 239). Once the gap reaches the operator park depth the longer attested
+ * / BestKnown side wins. The loser immediately re-admits the retained
+ * canonical body and GETMMATTEST/GETDATA that suffix from the winning GPU
+ * only. Public / miner peers and failed / off-path hashes stay refused.
+ */
+static constexpr int32_t ATTESTOR_DRIFT_YIELD_DEPTH{6};
+
+/** Resolve the yield threshold. Disabled / unset park uses the EMERGENCY
+ *  default of 6 so a 1-block race does not force a yield. */
+[[nodiscard]] inline int32_t AttestorDriftYieldDepth(uint32_t configured_park)
+{
+    if (configured_park == 0 ||
+        configured_park == std::numeric_limits<uint32_t>::max()) {
+        return ATTESTOR_DRIFT_YIELD_DEPTH;
+    }
+    if (configured_park > static_cast<uint32_t>(
+            std::numeric_limits<int32_t>::max())) {
+        return ATTESTOR_DRIFT_YIELD_DEPTH;
+    }
+    return static_cast<int32_t>(configured_park);
+}
+
+/** This GPU peer is at least `park_depth` ahead of our tip. */
+[[nodiscard]] inline bool AttestorShouldYieldToPeerAttestedChain(
+    bool local_signer,
+    bool peer_is_gpu_attestor,
+    int32_t local_tip_height,
+    int32_t peer_known_height,
+    int32_t park_depth)
+{
+    if (!local_signer || !peer_is_gpu_attestor) return false;
+    if (park_depth <= 0 || local_tip_height < 0 || peer_known_height < 0) {
+        return false;
+    }
+    return peer_known_height >= local_tip_height + park_depth;
+}
+
+/** Signed frontier (any stored quorum) has pulled ahead by park depth. */
+[[nodiscard]] inline bool AttestorShouldYieldToSignedFrontier(
+    bool local_signer,
+    int32_t blocks_behind,
+    int32_t park_depth)
+{
+    if (!local_signer || park_depth <= 0 || blocks_behind < 0) return false;
+    return blocks_behind >= park_depth;
+}
+
+/** Canonical hole on the winner / signed-frontier chain. Competing
+ *  same-height HEADER_ONLY twins are not this. */
+[[nodiscard]] inline bool AttestorYieldHashIsCatchUpTarget(
+    bool yielding,
+    bool on_winner_or_signed_frontier_chain,
+    bool header_failed)
+{
+    return yielding && on_winner_or_signed_frontier_chain && !header_failed;
+}
+
+/** GETMMATTEST destinations while yielding: GPU attestors only. */
+[[nodiscard]] inline bool AttestorYieldPreferGetMmAttestPeer(
+    bool yielding,
+    bool gpu_attestor)
+{
+    if (!yielding) return true;
+    return gpu_attestor;
+}
+
+/** While yielding, request only the winner's attested suffix. */
+[[nodiscard]] inline bool AttestorYieldShouldRequestGetMmAttest(
+    bool yielding,
+    bool on_winner_or_signed_frontier_chain)
+{
+    if (!yielding) return true;
+    return on_winner_or_signed_frontier_chain;
+}
+
+/** Re-admit the retained canonical body now (retry delay 0) instead of
+ *  sitting in root_retained_body while the winner walks away. */
+[[nodiscard]] inline bool AttestorYieldMustReadmitRetainedBody(
+    bool yielding,
+    bool have_retained_body,
+    bool hash_is_catch_up_target)
+{
+    return yielding && have_retained_body && hash_is_catch_up_target;
+}
+
 [[nodiscard]] inline bool SignedFrontierBodySourceCanServeCatchUp(
     bool preferred,
     bool has_best_known,

--- a/src/node/matmul_trusted_attestations.h
+++ b/src/node/matmul_trusted_attestations.h
@@ -372,6 +372,48 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     return false;
 }
 
+/** Equal-work lost twin (live 2026-08-20 consensus node): unattested tip
+ *  at H, attested sibling at H, signed frontier HEADER_ONLY at H+N.
+ *  The winner's pprev is the LCA, not the current tip, so the local-signer
+ *  ExactReplay gate (pprev==tip) HEADER_ONLY-skipped it forever. Spend GPU
+ *  only for the immediate attested fork-child of a short reorg (depth 1–6)
+ *  while the tip itself has no quorum. Dual-attested same-height twins,
+ *  parked branches, fossils, and already-canonical ancestors stay off. */
+[[nodiscard]] inline bool ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+    bool configured,
+    bool tip_has_quorum,
+    bool index_covered_by_attestation,
+    bool index_is_tip,
+    int lca_depth,
+    bool is_immediate_fork_child,
+    bool index_on_active_chain,
+    bool has_competing_quorum,
+    bool on_parked)
+{
+    if (!configured || index_is_tip || on_parked || index_on_active_chain) {
+        return false;
+    }
+    if (tip_has_quorum || has_competing_quorum) return false;
+    if (!index_covered_by_attestation || !is_immediate_fork_child) return false;
+    return TrustedMirrorIsShortTipReorg(lca_depth);
+}
+
+/** While the signed frontier is off the active chain, budget-deferred
+ *  retry may only re-admit the attested fork-child / frontier path.
+ *  Historical losing twins (live 195579/195599/195601) occupied admission
+ *  every 20s–2min with GPU at 0% and inflight=0. */
+[[nodiscard]] inline bool ShouldRetryBudgetDeferredWhileFrontierOffChain(
+    bool frontier_off_active_chain,
+    bool hash_is_short_reorg_attested_fork_child,
+    bool hash_on_signed_frontier_chain,
+    bool hash_is_followed_tip_child)
+{
+    if (!frontier_off_active_chain) return true;
+    return hash_is_short_reorg_attested_fork_child ||
+           hash_on_signed_frontier_chain ||
+           hash_is_followed_tip_child;
+}
+
 /** Skip FindUniqueCompetingAttestedIndex's HEADER_ONLY-hole pprev walk.
  *  If `idx` is already on the active chain, LastCommonAncestor(tip, idx)
  *  is `idx`. Walking `idx->pprev` until that LCA never hits `idx` and
@@ -634,19 +676,39 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
  *  the missing root of a short tip-race reorg (sibling of tip / first hole
  *  on the authority peer's best-known), or a followed-chain HAVE_DATA /
  *  retained GPU body still waiting for MMATTEST. Competing headers at
- *  1879xx are neither. Parked deep-reorg branches never prefer. */
+ *  1879xx are neither. Parked deep-reorg branches never prefer.
+ *
+ *  During signed-frontier catch-up the moving frontier hash and a recent
+ *  active ancestor are not preferred. Live sfo3 2026-08-20: catch_up=1,
+ *  needed_height=194728, GETMMATTEST send hammered mid-suffix 194999
+ *  (stale frontier) and the current frontier (no_such_block) so tip+1
+ *  never got a slot. */
 [[nodiscard]] inline bool TrustedMirrorPreferGetMmAttest(
     bool active_tip_child,
     bool short_tip_reorg_missing_root,
     bool on_parked_reorg_branch = false,
     bool recent_active_ancestor = false,
     bool followed_body_awaiting_attestation = false,
-    bool is_signed_frontier_hash = false)
+    bool is_signed_frontier_hash = false,
+    bool signed_frontier_catch_up = false)
 {
     if (on_parked_reorg_branch) return false;
-    return active_tip_child || short_tip_reorg_missing_root ||
-           recent_active_ancestor || followed_body_awaiting_attestation ||
-           is_signed_frontier_hash;
+    const bool hole{active_tip_child || short_tip_reorg_missing_root ||
+                    followed_body_awaiting_attestation};
+    if (signed_frontier_catch_up) return hole;
+    return hole || recent_active_ancestor || is_signed_frontier_hash;
+}
+
+/** Catch-up must not allocate a GETMMATTEST slot for a non-hole hash.
+ *  Non-preferred requests still occupied 16 mid-suffix slots on sfo3
+ *  (outstanding_slots=16/1024, rejected_unattestable climbing) while
+ *  194728 sat HEADER_ONLY with local quorum and in_flight=0. */
+[[nodiscard]] inline bool TrustedMirrorCatchUpShouldRequestGetMmAttest(
+    bool signed_frontier_catch_up,
+    bool preferred)
+{
+    if (!signed_frontier_catch_up) return true;
+    return preferred;
 }
 
 /** GETMMATTEST destinations. NODE_MATMUL_ATTESTATION_ARCHIVE means the

--- a/src/node/matmul_trusted_attestations.h
+++ b/src/node/matmul_trusted_attestations.h
@@ -816,10 +816,38 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     int tip_height)
 {
     // No VERSION: cannot serve. A peer whose VERSION height is at or behind
-    // our tip does not have the HEADER_ONLY suffix (live nyc1 2026-08-16:
-    // sibling archives were preferred-capable from headers alone, GETDATA
-    // timed out, miners were skipped).
+    // our *active* tip does not have tip+1 at handshake (live nyc1
+    // 2026-08-16: sibling archives were preferred-capable from headers
+    // alone, GETDATA timed out, miners were skipped).
+    // Compare to the connected tip, never to m_best_header: miner
+    // HEADER_ONLY children stacked on the attested tip made
+    // starting_height > followed_header fail while the peer still had
+    // every body from tip+1 through the signed frontier (live GPU-archive
+    // catch-up 2026-08-19: VERSION 194111 vs m_best_header 194116, tip
+    // 189534, inflight=0).
     return starting_height > tip_height;
+}
+
+/** Root-first catch-up GETDATA asks for active-tip+1, not m_best_header.
+ *  VERSION is a handshake snapshot (lower bound on bodies the peer *had*),
+ *  not a live connected height. After this node climbs past that snapshot,
+ *  a still-connected archive whose BestKnown extends our tip can still
+ *  serve historical tip+1 (live 2026-08-19: VERSION 194111, tip 194121,
+ *  BestKnown 194160, stall recovery logged every 60s with inflight=0).
+ *  Behind-sibling VERSION < tip with no extending BestKnown stays refused
+ *  (live nyc1 2026-08-17: 190767 vs 190816). */
+[[nodiscard]] inline bool SignedFrontierPeerMayServeCatchUpTipPlusOne(
+    int starting_height,
+    int active_tip_height,
+    int best_known_height = std::numeric_limits<int>::min(),
+    bool best_known_extends_tip = false)
+{
+    if (starting_height < 0) return false;
+    if (SignedFrontierPeerHadCatchUpBodiesAtConnect(starting_height,
+                                                    active_tip_height)) {
+        return true;
+    }
+    return best_known_extends_tip && best_known_height > active_tip_height;
 }
 
 [[nodiscard]] inline bool SignedFrontierBodySourceCanServeCatchUp(
@@ -832,8 +860,9 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     int starting_height = std::numeric_limits<int>::max())
 {
     if (!version_handshake_complete) return false;
-    if (!SignedFrontierPeerHadCatchUpBodiesAtConnect(starting_height,
-                                                     tip_height)) {
+    if (!SignedFrontierPeerMayServeCatchUpTipPlusOne(
+            starting_height, tip_height, best_known_height,
+            best_known_extends_tip)) {
         return false;
     }
     return preferred && has_best_known && best_known_height > tip_height &&
@@ -880,8 +909,10 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
 }
 
 /** Issue catch-up GETDATA only to handshake-complete GPU, or to our
- *  outbound archive/mirror that was ahead at VERSION. Hung -connect
- *  (no VERSION) must not occupy a slot or block those outbounds. */
+ *  outbound archive/mirror. Hung -connect (no VERSION) must not occupy
+ *  a slot or block those outbounds. `tip_height` is the *active* tip:
+ *  root-first asks for tip+1, so miner HEADER_ONLY children on
+ *  m_best_header must not raise the VERSION bar. */
 [[nodiscard]] inline bool SignedFrontierMayRequestCatchUpGetData(
     bool signed_frontier_catch_up,
     bool gpu_manual_or_noban,
@@ -889,7 +920,9 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     bool archive_or_mirror,
     bool version_handshake_complete,
     int starting_height = std::numeric_limits<int>::max(),
-    int tip_height = std::numeric_limits<int>::min())
+    int tip_height = std::numeric_limits<int>::min(),
+    int best_known_height = std::numeric_limits<int>::min(),
+    bool best_known_extends_tip = false)
 {
     if (!signed_frontier_catch_up) return true;
     if (!version_handshake_complete) return false;
@@ -899,8 +932,9 @@ static constexpr int GETMMATTEST_HAMMER_BAN_AFTER{32};
     if (!gpu_manual_or_noban && (!outbound || !archive_or_mirror)) {
         return false;
     }
-    return SignedFrontierPeerHadCatchUpBodiesAtConnect(starting_height,
-                                                       tip_height);
+    return SignedFrontierPeerMayServeCatchUpTipPlusOne(
+        starting_height, tip_height, best_known_height,
+        best_known_extends_tip);
 }
 
 /** Skip miners / inbound archives during signed-frontier catch-up.
@@ -1333,14 +1367,18 @@ static constexpr auto GPU_RETAIN_ATTESTATION_RETRY{std::chrono::seconds{2}};
     return wait_s + kMargin;
 }
 
-/** 90s catch-up timeout: operator GPU with a completed VERSION only.
- *  Hung -connect (manual, starting_height=-1) keeps the 15s miner
- *  window so it cannot pin the pipeline. */
+/** 90s catch-up timeout: operator GPU/noban whose VERSION still shows
+ *  bodies past our active tip. Hung -connect (starting_height=-1) and
+ *  stale-handshake archives we have climbed past keep 15s so a behind
+ *  sibling cannot pin the 1-wide slot for 90s. */
 [[nodiscard]] inline bool SignedFrontierCatchUpUsesGpuTimeout(
     bool manual_or_noban,
-    bool version_handshake_complete)
+    bool version_handshake_complete,
+    int starting_height = std::numeric_limits<int>::max(),
+    int active_tip_height = std::numeric_limits<int>::min())
 {
-    return manual_or_noban && version_handshake_complete;
+    if (!manual_or_noban || !version_handshake_complete) return false;
+    return starting_height > active_tip_height;
 }
 
 /** 180s inflight reclaim for GPU catch-up: handshake-complete

--- a/src/test/matmul_trusted_mirror_tests.cpp
+++ b/src/test/matmul_trusted_mirror_tests.cpp
@@ -24,6 +24,7 @@
 #include <util/translation.h>
 
 #include <array>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -1488,6 +1489,82 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
         true, /*from_gpu_attestor=*/false, false));
     BOOST_CHECK_EQUAL(
         node::matmul_trusted::GPU_RETAIN_ATTESTATION_RETRY.count(), 2);
+}
+
+BOOST_AUTO_TEST_CASE(attestor_drift_yield_follows_longer_attested_chain)
+{
+    using node::matmul_trusted::ATTESTOR_DRIFT_YIELD_DEPTH;
+    using node::matmul_trusted::AttestorDriftYieldDepth;
+    using node::matmul_trusted::AttestorShouldYieldToPeerAttestedChain;
+    using node::matmul_trusted::AttestorShouldYieldToSignedFrontier;
+    using node::matmul_trusted::AttestorYieldHashIsCatchUpTarget;
+    using node::matmul_trusted::AttestorYieldMustReadmitRetainedBody;
+    using node::matmul_trusted::AttestorYieldPreferGetMmAttestPeer;
+    using node::matmul_trusted::AttestorYieldShouldRequestGetMmAttest;
+
+    BOOST_CHECK_EQUAL(ATTESTOR_DRIFT_YIELD_DEPTH, 6);
+    BOOST_CHECK_EQUAL(AttestorDriftYieldDepth(6), 6);
+    BOOST_CHECK_EQUAL(AttestorDriftYieldDepth(12), 12);
+    BOOST_CHECK_EQUAL(AttestorDriftYieldDepth(0), ATTESTOR_DRIFT_YIELD_DEPTH);
+    BOOST_CHECK_EQUAL(
+        AttestorDriftYieldDepth(std::numeric_limits<uint32_t>::max()),
+        ATTESTOR_DRIFT_YIELD_DEPTH);
+
+    constexpr int32_t kPark{6};
+    // Live 2026-08-20: loser tip 194828, winner BestKnown 194851.
+    BOOST_CHECK(AttestorShouldYieldToPeerAttestedChain(
+        /*local_signer=*/true, /*peer_is_gpu_attestor=*/true,
+        /*local_tip_height=*/194828, /*peer_known_height=*/194851, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToPeerAttestedChain(
+        true, true, 194828, 194833, kPark));
+    BOOST_CHECK(AttestorShouldYieldToPeerAttestedChain(
+        true, true, 194828, 194834, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToPeerAttestedChain(
+        /*local_signer=*/false, true, 194828, 194851, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToPeerAttestedChain(
+        true, /*peer_is_gpu_attestor=*/false, 194828, 194851, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToPeerAttestedChain(
+        true, true, /*local_tip_height=*/-1, 194851, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToPeerAttestedChain(
+        true, true, 194828, /*peer_known_height=*/-1, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToPeerAttestedChain(
+        true, true, 194828, 194851, /*park_depth=*/0));
+
+    BOOST_CHECK(AttestorShouldYieldToSignedFrontier(
+        /*local_signer=*/true, /*blocks_behind=*/23, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToSignedFrontier(true, 5, kPark));
+    BOOST_CHECK(AttestorShouldYieldToSignedFrontier(true, 6, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToSignedFrontier(
+        /*local_signer=*/false, 23, kPark));
+    BOOST_CHECK(!AttestorShouldYieldToSignedFrontier(true, -1, kPark));
+
+    // Canonical 194829 on the winner chain: catch-up target.
+    BOOST_CHECK(AttestorYieldHashIsCatchUpTarget(
+        /*yielding=*/true, /*on_winner_or_signed_frontier_chain=*/true,
+        /*header_failed=*/false));
+    // Competing same-height HEADER_ONLY twin: not a target.
+    BOOST_CHECK(!AttestorYieldHashIsCatchUpTarget(true, false, false));
+    BOOST_CHECK(!AttestorYieldHashIsCatchUpTarget(
+        true, true, /*header_failed=*/true));
+    BOOST_CHECK(!AttestorYieldHashIsCatchUpTarget(
+        /*yielding=*/false, true, false));
+
+    BOOST_CHECK(AttestorYieldPreferGetMmAttestPeer(
+        /*yielding=*/false, /*gpu_attestor=*/false));
+    BOOST_CHECK(!AttestorYieldPreferGetMmAttestPeer(true, false));
+    BOOST_CHECK(AttestorYieldPreferGetMmAttestPeer(true, true));
+
+    BOOST_CHECK(AttestorYieldShouldRequestGetMmAttest(
+        /*yielding=*/false, /*on_winner_or_signed_frontier_chain=*/false));
+    BOOST_CHECK(!AttestorYieldShouldRequestGetMmAttest(true, false));
+    BOOST_CHECK(AttestorYieldShouldRequestGetMmAttest(true, true));
+
+    BOOST_CHECK(AttestorYieldMustReadmitRetainedBody(
+        /*yielding=*/true, /*have_retained_body=*/true,
+        /*hash_is_catch_up_target=*/true));
+    BOOST_CHECK(!AttestorYieldMustReadmitRetainedBody(false, true, true));
+    BOOST_CHECK(!AttestorYieldMustReadmitRetainedBody(true, false, true));
+    BOOST_CHECK(!AttestorYieldMustReadmitRetainedBody(true, true, false));
 }
 
 BOOST_AUTO_TEST_CASE(signer_getmmattest_historical_and_hammer_ban)

--- a/src/test/matmul_trusted_mirror_tests.cpp
+++ b/src/test/matmul_trusted_mirror_tests.cpp
@@ -1113,7 +1113,10 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
         /*preferred=*/true, /*has_best_known=*/true, /*best_known_height=*/190632,
         /*tip_height=*/190588, /*best_known_extends_tip=*/true,
         /*version_handshake_complete=*/false));
-    BOOST_CHECK(!SignedFrontierBodySourceCanServeCatchUp(
+    // VERSION == tip is not "had bodies past tip at connect", but BestKnown
+    // extending the active tip still lets us GETDATA tip+1 (handshake snapshot
+    // is stale once we have climbed; hung-connect starting=-1 stays refused).
+    BOOST_CHECK(SignedFrontierBodySourceCanServeCatchUp(
         /*preferred=*/true, /*has_best_known=*/true, /*best_known_height=*/190632,
         /*tip_height=*/190588, /*best_known_extends_tip=*/true,
         /*version_handshake_complete=*/true, /*starting_height=*/190588));
@@ -1193,6 +1196,30 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
     BOOST_CHECK(SignedFrontierMayRequestCatchUpGetData(
         true, false, true, true, true,
         /*starting_height=*/190858, /*tip_height=*/190781));
+    using node::matmul_trusted::SignedFrontierPeerMayServeCatchUpTipPlusOne;
+    // Miner HEADER_ONLY tower above the active tip must not gate GETDATA.
+    // VERSION 194111 is behind m_best_header 194116 but ahead of tip 189534.
+    BOOST_CHECK(SignedFrontierMayRequestCatchUpGetData(
+        true, /*gpu_manual_or_noban=*/true, true, true, true,
+        /*starting_height=*/194111, /*tip_height=*/189534));
+    BOOST_CHECK(SignedFrontierPeerMayServeCatchUpTipPlusOne(
+        /*starting_height=*/194111, /*active_tip_height=*/189534));
+    BOOST_CHECK(!SignedFrontierPeerMayServeCatchUpTipPlusOne(194111, 194116));
+    // Climbed past handshake snapshot; BestKnown still extends the active tip.
+    BOOST_CHECK(SignedFrontierMayRequestCatchUpGetData(
+        true, true, true, true, true,
+        /*starting_height=*/194111, /*tip_height=*/194121,
+        /*best_known_height=*/194160, /*best_known_extends_tip=*/true));
+    BOOST_CHECK(SignedFrontierPeerMayServeCatchUpTipPlusOne(
+        194111, 194121, 194160, true));
+    // Behind sibling: VERSION < tip, BestKnown does not extend past tip.
+    BOOST_CHECK(!SignedFrontierMayRequestCatchUpGetData(
+        true, true, true, true, true,
+        /*starting_height=*/190767, /*tip_height=*/190816,
+        /*best_known_height=*/190767, /*best_known_extends_tip=*/false));
+    BOOST_CHECK(!SignedFrontierPeerMayServeCatchUpTipPlusOne(
+        190767, 190816, 190767, false));
+    BOOST_CHECK(!SignedFrontierPeerMayServeCatchUpTipPlusOne(-1, 190781, 190858, true));
     using node::matmul_trusted::SignedFrontierVersionHandshakeComplete;
     BOOST_CHECK(!SignedFrontierVersionHandshakeComplete(-1));
     BOOST_CHECK(SignedFrontierVersionHandshakeComplete(0));
@@ -1284,6 +1311,10 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
         /*manual_or_noban=*/true, /*version_handshake_complete=*/true));
     BOOST_CHECK(!SignedFrontierCatchUpUsesGpuTimeout(true, false));
     BOOST_CHECK(!SignedFrontierCatchUpUsesGpuTimeout(false, true));
+    BOOST_CHECK(!SignedFrontierCatchUpUsesGpuTimeout(
+        true, true, /*starting_height=*/194111, /*active_tip_height=*/194121));
+    BOOST_CHECK(SignedFrontierCatchUpUsesGpuTimeout(
+        true, true, /*starting_height=*/194111, /*active_tip_height=*/189534));
     using node::matmul_trusted::KeepGpuSignedFrontierInFlightPipeline;
     BOOST_CHECK(KeepGpuSignedFrontierInFlightPipeline(
         /*signed_frontier_catch_up=*/true, /*manual_or_noban=*/true,

--- a/src/test/matmul_trusted_mirror_tests.cpp
+++ b/src/test/matmul_trusted_mirror_tests.cpp
@@ -1220,6 +1220,28 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
     BOOST_CHECK(!SignedFrontierPeerMayServeCatchUpTipPlusOne(
         190767, 190816, 190767, false));
     BOOST_CHECK(!SignedFrontierPeerMayServeCatchUpTipPlusOne(-1, 190781, 190858, true));
+    using node::matmul_trusted::ShouldAdvanceBestKnownFromMmAttest;
+    using node::matmul_trusted::ShouldAdvanceBestKnownFromPeerBody;
+    using matmul::trusted::AddResult;
+    BOOST_CHECK(ShouldAdvanceBestKnownFromMmAttest(
+        true, false, AddResult::Accepted));
+    BOOST_CHECK(ShouldAdvanceBestKnownFromMmAttest(
+        true, false, AddResult::Duplicate));
+    BOOST_CHECK(!ShouldAdvanceBestKnownFromMmAttest(
+        true, false, AddResult::Capacity));
+    BOOST_CHECK(!ShouldAdvanceBestKnownFromMmAttest(
+        true, false, AddResult::InvalidSignature));
+    BOOST_CHECK(!ShouldAdvanceBestKnownFromMmAttest(
+        true, false, AddResult::UntrustedSigner));
+    BOOST_CHECK(!ShouldAdvanceBestKnownFromMmAttest(
+        /*known_profile1=*/false, false, AddResult::Accepted));
+    BOOST_CHECK(!ShouldAdvanceBestKnownFromMmAttest(
+        true, /*header_failed=*/true, AddResult::Accepted));
+    BOOST_CHECK(ShouldAdvanceBestKnownFromPeerBody(
+        /*have_index=*/true, /*header_failed=*/false, /*have_data=*/true));
+    BOOST_CHECK(!ShouldAdvanceBestKnownFromPeerBody(true, true, true));
+    BOOST_CHECK(!ShouldAdvanceBestKnownFromPeerBody(true, false, false));
+    BOOST_CHECK(!ShouldAdvanceBestKnownFromPeerBody(false, false, true));
     using node::matmul_trusted::SignedFrontierVersionHandshakeComplete;
     BOOST_CHECK(!SignedFrontierVersionHandshakeComplete(-1));
     BOOST_CHECK(SignedFrontierVersionHandshakeComplete(0));

--- a/src/test/matmul_trusted_mirror_tests.cpp
+++ b/src/test/matmul_trusted_mirror_tests.cpp
@@ -945,6 +945,51 @@ BOOST_AUTO_TEST_CASE(above_frontier_and_parked_branch_do_not_admit)
     BOOST_CHECK(!TrustedMirrorPreferGetMmAttest(
         /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/true,
         /*on_parked_reorg_branch=*/true));
+    // Catch-up: only the first hole. Frontier / ancestor preference is
+    // near-tip work and was the live 194999 GETMMATTEST hammer.
+    BOOST_CHECK(TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/true, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/true,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/true,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(!TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/true,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(!TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/false, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/false, /*recent_active_ancestor=*/true,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    BOOST_CHECK(!TrustedMirrorPreferGetMmAttest(
+        /*active_tip_child=*/true, /*short_tip_reorg_missing_root=*/false,
+        /*on_parked_reorg_branch=*/true, /*recent_active_ancestor=*/false,
+        /*followed_body_awaiting_attestation=*/false,
+        /*is_signed_frontier_hash=*/false,
+        /*signed_frontier_catch_up=*/true));
+    using node::matmul_trusted::TrustedMirrorCatchUpShouldRequestGetMmAttest;
+    BOOST_CHECK(TrustedMirrorCatchUpShouldRequestGetMmAttest(
+        /*signed_frontier_catch_up=*/false, /*preferred=*/false));
+    BOOST_CHECK(TrustedMirrorCatchUpShouldRequestGetMmAttest(
+        /*signed_frontier_catch_up=*/true, /*preferred=*/true));
+    BOOST_CHECK(!TrustedMirrorCatchUpShouldRequestGetMmAttest(
+        /*signed_frontier_catch_up=*/true, /*preferred=*/false));
     using node::matmul_trusted::PreferGetMmAttestPeer;
     BOOST_CHECK(PreferGetMmAttestPeer(
         /*has_attestation_archive_bit=*/true, /*recent_valid_mmattest=*/false));
@@ -1705,6 +1750,51 @@ BOOST_AUTO_TEST_CASE(competing_attested_index_rejects_fossil_depth)
     BOOST_CHECK(IndependentConsensusMaySpendExactReplayGpu(
         false, false, 191323, 191323, kNearTip,
         /*covered_by_attestation=*/true));
+    using node::matmul_trusted::ConsensusMaySpendExactReplayGpuForShortReorgForkChild;
+    // Live 2026-08-20: unattested tip 195603 489884e4, attested sibling
+    // b8971871 (LCA depth 1), signed frontier 195635 HEADER_ONLY.
+    BOOST_CHECK(ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        /*configured=*/true, /*tip_has_quorum=*/false,
+        /*index_covered_by_attestation=*/true, /*index_is_tip=*/false,
+        /*lca_depth=*/1, /*is_immediate_fork_child=*/true,
+        /*index_on_active_chain=*/false, /*has_competing_quorum=*/false,
+        /*on_parked=*/false));
+    BOOST_CHECK(!ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        true, /*tip_has_quorum=*/true, true, false, 1, true, false, false,
+        false));
+    BOOST_CHECK(!ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        true, false, /*index_covered_by_attestation=*/false, false, 1, true,
+        false, false, false));
+    BOOST_CHECK(!ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        true, false, true, false, 1, /*is_immediate_fork_child=*/false,
+        false, false, false));
+    BOOST_CHECK(!ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        true, false, true, false, 1, true, /*index_on_active_chain=*/true,
+        false, false));
+    BOOST_CHECK(!ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        true, false, true, false, 1, true, false,
+        /*has_competing_quorum=*/true, false));
+    BOOST_CHECK(!ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        true, false, true, false, 1, true, false, false, /*on_parked=*/true));
+    BOOST_CHECK(!ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        true, false, true, false, /*lca_depth=*/0, true, false, false,
+        false));
+    BOOST_CHECK(!ConsensusMaySpendExactReplayGpuForShortReorgForkChild(
+        true, false, true, false, /*lca_depth=*/7, true, false, false,
+        false));
+    using node::matmul_trusted::ShouldRetryBudgetDeferredWhileFrontierOffChain;
+    BOOST_CHECK(ShouldRetryBudgetDeferredWhileFrontierOffChain(
+        /*frontier_off_active_chain=*/false, /*fork_child=*/false,
+        /*on_frontier=*/false, /*followed_tip_child=*/false));
+    BOOST_CHECK(ShouldRetryBudgetDeferredWhileFrontierOffChain(
+        true, /*hash_is_short_reorg_attested_fork_child=*/true, false, false));
+    BOOST_CHECK(ShouldRetryBudgetDeferredWhileFrontierOffChain(
+        true, false, /*hash_on_signed_frontier_chain=*/true, false));
+    BOOST_CHECK(ShouldRetryBudgetDeferredWhileFrontierOffChain(
+        true, false, false, /*hash_is_followed_tip_child=*/true));
+    // Historical losing twins 195579/195599/195601.
+    BOOST_CHECK(!ShouldRetryBudgetDeferredWhileFrontierOffChain(
+        true, false, false, false));
     using node::matmul_trusted::TrustedMirrorAttestedHintIsActiveAncestor;
     BOOST_CHECK(TrustedMirrorAttestedHintIsActiveAncestor(
         /*on_active_chain=*/true, /*lca_is_index=*/false));


### PR DESCRIPTION
## Summary

Carry the post-0.33.3 signed-frontier work onto `main` for **0.33.4**. This is **not** a consensus-parameter change (`F`, ASERT, `powLimit`, Epoch A, and the 191714 dump floor stay as in 0.33.3).

Includes the commits from:

- #112 — catch-up GETDATA vs the active tip; GETMMATTEST first hole (`b09aa8a1`, `68a4dd88` / `940b1bf9`, `1cd2b79c` via `59b78f5a`)
- #113 — BestKnown from MMATTEST (`fb9dcae3`), attestor yield (`dc2ca901`), lost-twin ExactReplay (`59b78f5a`)

#111 does not exist on this repo. #112 and #113 are closed in favor of this 0.33.4 line.

The version cut to **0.33.4rc1** is a follow-up PR on this same branch (`release/0.33.4-rc1`).

## Test plan

- [x] Private staging compile: incremental GCC-13 `test_btx`
- [x] `matmul_trusted_mirror_tests` + `lastcommon_root_first_tests` — no errors
- [ ] Operator final review before merge/tag


Made with [Cursor](https://cursor.com)