### PR TITLE
doc: record the bootstrap order a new trusted mirror needs

### DIFF
--- a/doc/btx-matmul-trusted-rpc-mirrors.md
+++ b/doc/btx-matmul-trusted-rpc-mirrors.md
@@ -216,6 +216,52 @@ archive signers and configure the mirrors with all three public keys, keeping
 2-of-3 one provider being offline no longer stalls the mirrors, and one key
 being compromised still does not independently decide a verdict.
 
+## Bootstrapping a new mirror
+
+**Obtain the header chain and load the AssumeUTXO snapshot before running the
+node as a trusted mirror.** Starting a fresh datadir directly in
+`-matmulvalidation=trusted` leaves it parked at height 0.
+
+A mirror follows the signed frontier, and with an empty datadir there is no
+frontier to follow. It cannot raise one by asking peers either, because a
+peer's advertised height is replaced by the local signed-frontier height when
+its best-known block is seeded. On a fresh mainnet datadir that produces one
+header batch and then a permanent stall, logged once a minute:
+
+```text
+Seeded GPU peer=7 best-known to signed frontier height=2000 (tip=0 HEADER_ONLY catch-up)
+Block fetch stall detected: tip=0 best_header_ahead=2000 peer_best_ahead=2000 in_flight=0 peers_downloading=0
+```
+
+`peer_best_ahead` equals `best_header_ahead` even when connected peers are
+advertising a tip tens of thousands of blocks higher.
+
+`loadtxoutset` cannot break the tie, because it requires the snapshot's base
+block header to already be in the index:
+
+```text
+Unable to load UTXO snapshot: The base block header (<hash>) must appear in
+the headers chain. Make sure all headers are syncing, and call loadtxoutset
+again.
+```
+
+Header supply is the part that surprises operators. A fresh mirror only
+requests headers from, and only accepts headers from, peers it treats as
+authority. In a field test on 2026-08-26 against mainnet, with fourteen peers
+connected, every peer advertising `NODE_MATMUL_ATTESTATION_ARCHIVE` answered
+`getheaders` with zero bytes, including one that also advertised
+`NODE_MATMUL_CONSENSUS`. The only peers that answered advertised
+`NODE_MATMUL_CONSENSUS` and no archive bit, and their headers were then
+dropped as non-authority. Plan a mirror's bootstrap around an archive you
+control, as in the `connect=` example above, rather than around public peer
+discovery.
+
+Switching `-matmulvalidation` between `consensus` and `trusted` does not by
+itself change the persisted replay authority context, so it does not trigger
+the reindex path described under **Persistence and key rotation**. That context
+follows the configured signer set: measured byte-identical in both modes for
+the same three keys on v0.33.4.2. Changing the signer set still does change it.
+
 ## Lifecycle
 
 1. The archive runs authoritative local ExactReplay.


### PR DESCRIPTION
Field note from bringing a fresh node up on v0.33.4.2 (tag commit `c892f1a7`, clean tree) on 2026-08-26. Documentation only. No code, no consensus surface.

## What happened

A fresh datadir started directly in `-matmulvalidation=trusted` with a valid pin parks at height 0 and does not recover. With fourteen peers connected:

* `getheaders` went out to all of them.
* Every peer advertising `NODE_MATMUL_ATTESTATION_ARCHIVE` answered with **zero** header bytes, including one that also advertised `NODE_MATMUL_CONSENSUS`.
* The only peers that answered advertised `NODE_MATMUL_CONSENSUS` and no archive bit, one 2000 header batch each, and those headers were then dropped as non-authority.

The node then logs this once a minute, indefinitely:

```text
Seeded GPU peer=7 best-known to signed frontier height=2000 (tip=0 HEADER_ONLY catch-up)
Block fetch stall detected: tip=0 best_header_ahead=2000 peer_best_ahead=2000 in_flight=0 peers_downloading=0
```

`peer_best_ahead` stays equal to `best_header_ahead` even though connected peers were advertising 199300 and above, because `state.pindexBestKnownBlock = seed` replaces a peer's real best-known block with the local signed-frontier height. With no attestations the frontier equals the one header batch already held, so the target never rises.

`loadtxoutset` cannot break the tie, since it needs the base header in the index first:

```text
Unable to load UTXO snapshot: The base block header
(f12a27d01a4b5a1710efa4497adf6f4c7da311d1c7b4f6a79cbf80f0b3110ec5)
must appear in the headers chain.
```

## What this PR changes

One new section in `doc/btx-matmul-trusted-rpc-mirrors.md`, **Bootstrapping a new mirror**. It states the working order (header chain and AssumeUTXO snapshot first, then start as a trusted mirror), shows the two log signatures so operators can recognise the state, and records the header-supply observation so a mirror is bootstrapped against an archive the operator controls rather than against public peer discovery. The existing `connect=` example already points that way; this makes the reason explicit.

It also records one measurement that may save someone an unnecessary rebootstrap: switching `-matmulvalidation` between `consensus` and `trusted` does not by itself move the persisted replay authority context, because that context follows the configured signer set. Measured byte-identical in both modes with the same three keys on v0.33.4.2. Changing the signer set still moves it.

## Not claimed

* I could not observe the remote side, so I do not assert **why** the archive peers returned nothing. The section records only what was sent and what came back.
* No IP addresses, operator hostnames, or keys are included.
* Targeted at `main`. Happy to retarget or rewrite against the 0.34 line in #123 if that is easier during the freeze, or to drop it entirely if this is already covered somewhere I did not find.

Context: we ship easyNode and easyBTX for macOS and run Apple Silicon nodes in the field. A separate M5 observation is in #123 rather than here, since it concerns the golden corpus being resealed there.
