### PR TITLE
net_processing: admit CONSENSUS-mode linear tip-child to the authenticated RC slot (fixes one-block-past-attestation deadlock)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -12627,11 +12627,22 @@ bool PeerManagerImpl::AdmitMatMulBlockVerification(
         {
             LOCK(cs_main);
             const CBlockIndex* active_tip{m_chainman.ActiveTip()};
+            // In CONSENSUS mode ExactReplay is the authority and signer
+            // attestations never advance nAuthenticatedChainWork, so a linear
+            // child of the active (ExactReplay-connected) tip must still qualify
+            // for the authenticated tip-child RC slot. Otherwise every consensus
+            // node deadlocks one block past the last attestation (competing path
+            // is reserved to zero slots via MATMUL_RESERVED_AUTHENTICATED_TIP_CHILD_SLOTS).
+            // TRUSTED mode is unchanged: attestation still gates there.
+            const bool consensus_mode_tip_authority{
+                m_chainman.GetMatMulValidationMode() ==
+                    kernel::MatMulValidationMode::CONSENSUS};
             direct_authenticated_tip_child =
                 active_tip != nullptr &&
                 block.hashPrevBlock == active_tip->GetBlockHash() &&
-                active_tip->nAuthenticatedChainWork ==
-                    active_tip->nChainWork;
+                (active_tip->nAuthenticatedChainWork ==
+                    active_tip->nChainWork ||
+                 consensus_mode_tip_authority);
         }
     }
     // RC admission tickets are an ephemeral near-tip anti-DoS policy, not


### PR DESCRIPTION
## Summary

CONSENSUS-mode nodes deadlock exactly one block past the last signer attestation, and the freeze survives restart. This lands the one-line classification fix that `v0.34.2` shipped without, confirmed by @numair in #125 (https://github.com/btxchain/btx/pull/125#issuecomment-5446828514): "your candidate is character-for-character what we need ... please do open the PR with the diff and functional test."

## Root cause

In `PeerManagerImpl::AdmitMatMulBlockVerification`, a linear child of the active (ExactReplay-connected) tip was classified as `direct_authenticated_tip_child` only when:

```cpp
active_tip->nAuthenticatedChainWork == active_tip->nChainWork
```

In **CONSENSUS** mode ExactReplay is the sole authority and signer attestations never advance `nAuthenticatedChainWork`, so with signers off that equality is never true. The genuine tip-child therefore fell through to the **competing-candidate** path, which reserves `MATMUL_RESERVED_AUTHENTICATED_TIP_CHILD_SLOTS` (= 1) away from the RC pending cap:

- `CanStartCompetingMatMulRCVerification` (`src/pow.cpp`): with the default `nMatMulRCMaxPendingVerifications == 1`, `cap <= MATMUL_RESERVED_AUTHENTICATED_TIP_CHILD_SLOTS` returns `false` unconditionally — the competing pool is **zero slots**.
- The authenticated-tip-child path (`CanStartMatMulRCVerification`) would have used the reserved slot (`pending 0 <= cap 1 - work 1`).

So `ReserveMatMulRCVerificationSlot(..., authenticated_tip_child=false)` fails on the only child that can extend the chain, the body is budget-deferred ("MatMul pending verification cap reached"), and the node wedges one block past the last attestation. A clean restart recovers to the same stuck-but-stable tip. (Note: `invalidateblock`/`reconsiderblock` on the unauthenticated suffix is actively harmful here — it reorgs onto shorter competing forks; a clean restart is the correct recovery.)

## Fix

Let a linear child of the active tip qualify for the authenticated tip-child RC slot in CONSENSUS mode regardless of `nAuthenticatedChainWork`:

```cpp
const bool consensus_mode_tip_authority{
    m_chainman.GetMatMulValidationMode() ==
        kernel::MatMulValidationMode::CONSENSUS};
direct_authenticated_tip_child =
    active_tip != nullptr &&
    block.hashPrevBlock == active_tip->GetBlockHash() &&
    (active_tip->nAuthenticatedChainWork ==
        active_tip->nChainWork ||
     consensus_mode_tip_authority);
```

- **TRUSTED mode is unchanged** — attestation still gates the slot there.
- The **twin-flood DoS reservation is preserved** — a competing sibling at the same height is still reserved to zero slots; only the linear child of the active tip is admitted.

## Test coverage (deferred — guidance requested)

I did not include a functional test in this push because, after tracing the admission path, I found a naive test is **non-discriminating** — it passes on both the patched and unpatched trees for two reasons, and I want to confirm the preferred fixture before landing it:

1. **Cap unthrottle vs. the real default.** On regtest, `nMatMulRCMaxPendingVerifications` is forced to `max()` when RC is active at chainparams construction. At `cap == max()`, `CanStartCompetingMatMulRCVerification` delegates to `CanStartMatMulRCVerification`, so the competing and authenticated paths are identical and the classification is invisible. A discriminating test must pin `consensus.nMatMulRCMaxPendingVerifications = 1` (the production default) so the reserved-slot arithmetic is the deciding factor.
2. **Header-first precharged early-return.** When a `HEADERS` message drives a header-first ExactReplay, the subsequent body hits the `m_matmul_verify_worker->Contains(block_hash)` early-return (RECOMPUTE_HEADER_PRECHARGED) *before* the `direct_authenticated_tip_child` computation. So the existing `signer_free_consensus_exactreplays_followed_tip_child` case cannot detect this bug — the slot was already claimed by the header-first attempt. The regression test must ensure the body reaches the classification branch (or, better, assert the header-first ExactReplay itself is admitted at `cap == 1`, which is the exact production deadlock).

Proposed fixture (extends the existing `signer_free_consensus_exactreplays_followed_tip_child` shape): CONSENSUS mode + signer-free config (so `nAuthenticatedChainWork < nChainWork` at the tip), `nMatMulRCMaxPendingVerifications` pinned to 1, one linear tip-child, no competing sibling — assert the child is **admitted / connects** rather than budget-deferred ("MatMul pending verification cap reached"). This is dixonping's exact shape from #125: one linear tip-child, no sibling, `nAuthenticatedChainWork < nChainWork`.

@numair — could you confirm which fixture you'd prefer (extend `signer_free_consensus_exactreplays_followed_tip_child`, or a fresh case modeled on `rc_pending_cap_still_retains_for_retry` with cap pinned to 1 and CONSENSUS/signer-free set)? I'll add the test in a follow-up commit to this PR once confirmed, so the diff can land immediately if that's preferable.

## Base

Opened against `release/0.34.2` (the release-dev tip, a strict superset of `main`, carrying the EncDr re-anchor withdrawal) since #125 states the fix ships in `v0.34.3`. Happy to retarget `main` if you'd rather it flow through there first.
