### PR TITLE
net: bound retained-body retry lifecycle

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1465,6 +1465,20 @@ public:
     {
         return HasMatMulRetainedBodyForTest(hash);
     }
+    void RetainMatMulBodyForTest(
+        const std::shared_ptr<const CBlock>& block) override
+    {
+        node::MatMulBlockLifecycle::RetainedBody body;
+        body.block = block;
+        body.bytes = 1;
+        m_matmul_block_lifecycle.Retain(block->GetHash(), std::move(body));
+    }
+    void SimulateBlockConnectedForTest(
+        const std::shared_ptr<const CBlock>& block,
+        const CBlockIndex* pindex) override
+    {
+        BlockConnected(ChainstateRole::NORMAL, block, pindex);
+    }
     void RetryMatMulDeferredBodiesForTest() override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_main, !NetEventsInterface::g_msgproc_mutex)
     {
@@ -8077,7 +8091,20 @@ void PeerManagerImpl::BlockConnected(
     // terminal. This also cancels a live generation, preventing a late
     // callback or idle retry from re-admitting an already-connected body.
     if (role != ChainstateRole::BACKGROUND) {
-        m_matmul_block_lifecycle.TerminalConnected(pindex->GetBlockHash());
+        // #130 review fix: BlockConnected is drained asynchronously, so a reorg
+        // may have disconnected this block before this callback runs. Erasing by
+        // hash unconditionally would delete a *fresh* lifecycle generation that
+        // was re-retained for the same hash on the new active chain (cancelling
+        // live valid work). Only terminate when the block is still on the active
+        // chain at the moment the callback actually runs.
+        bool still_active{false};
+        {
+            LOCK(cs_main);
+            still_active = m_chainman.ActiveChain().Contains(pindex);
+        }
+        if (still_active) {
+            m_matmul_block_lifecycle.TerminalConnected(pindex->GetBlockHash());
+        }
     }
 
     // In case the dynamic timeout was doubled once or more, reduce it slowly back to

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -8073,6 +8073,13 @@ void PeerManagerImpl::BlockConnected(
     // helping us do background IBD as having a stale tip.
     m_last_tip_update = GetTime<std::chrono::seconds>();
 
+    // Once a block is active, retained verification state for that hash is
+    // terminal. This also cancels a live generation, preventing a late
+    // callback or idle retry from re-admitting an already-connected body.
+    if (role != ChainstateRole::BACKGROUND) {
+        m_matmul_block_lifecycle.TerminalConnected(pindex->GetBlockHash());
+    }
+
     // In case the dynamic timeout was doubled once or more, reduce it slowly back to
     // its current phase floor.
     const auto phase_floor = MinBlockStallingTimeoutForTip(pindex, m_chainparams.GetConsensus());

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -8102,7 +8102,19 @@ void PeerManagerImpl::BlockConnected(
         // after Contains() but before TerminalConnected() and recreate the race.
         LOCK(cs_main);
         if (m_chainman.ActiveChain().Contains(pindex)) {
-            m_matmul_block_lifecycle.TerminalConnected(pindex->GetBlockHash());
+            const uint256 connected_hash{pindex->GetBlockHash()};
+            // Terminal-cancel any in-flight verify worker job so a body-holding
+            // ExactReplay for this now-connected block stops (it ignores
+            // speculative cancellation). TerminalCancel only raises the signal
+            // and wakes the worker -- no waiting or callbacks -- so it is safe
+            // under cs_main. Its result tells the lifecycle whether a worker
+            // will acknowledge (and release the held lease); if none will, the
+            // lifecycle completes cleanup immediately so nothing sticks.
+            const bool worker_will_ack{
+                m_matmul_verify_worker &&
+                m_matmul_verify_worker->TerminalCancel(connected_hash)};
+            m_matmul_block_lifecycle.TerminalConnected(
+                connected_hash, worker_will_ack);
         }
     }
 
@@ -13602,6 +13614,8 @@ void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlo
                     matmul_admission.lifecycle_token};
                 auto lifecycle_cancelled{
                     std::make_shared<std::atomic_bool>(false)};
+                auto lifecycle_terminated{
+                    std::make_shared<std::atomic_bool>(false)};
                 // Transfer source attribution ownership into the same
                 // generation as the pending slot. Callback captures may use
                 // this object, but they no longer decide its lifetime alone.
@@ -13620,7 +13634,9 @@ void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlo
                             ? std::static_pointer_cast<void>(slot)
                             : std::shared_ptr<void>{},
                         lifecycle_cancelled,
-                        std::move(lifecycle_resources))) {
+                        std::move(lifecycle_resources),
+                        std::chrono::steady_clock::now(),
+                        lifecycle_terminated)) {
                     if (handing_off_header) {
                         rollback_handoff_admission();
                     } else {
@@ -13754,6 +13770,25 @@ void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlo
                     },
                     .priority = priority,
                     .cancelled = lifecycle_cancelled,
+                    .terminal_cancelled = lifecycle_terminated,
+                    .on_terminal_cancelled =
+                    [this, hash, lifecycle_token, source_pin_weak,
+                     post = post_process]() mutable {
+                        // Block connected: TERMINAL acknowledgement. Release
+                        // delivery bookkeeping with a terminal lifecycle erase
+                        // (releases the held pending lease exactly once) -- no
+                        // verdict, retry, cache, completion, or re-admission.
+                        ClearMatMulRCBodyDeferred(hash);
+                        if (post) post();
+                        if (auto source_pin{source_pin_weak.lock()}) {
+                            source_pin->Release();
+                        }
+                        if (lifecycle_token) {
+                            m_matmul_block_lifecycle.Terminal(*lifecycle_token);
+                        } else {
+                            UnmarkMatMulAsyncVerification(hash);
+                        }
+                    },
                     .rc_pending_lease = nullptr,
                     .retained_body_bytes =
                         ::GetSerializeSize(TX_WITH_WITNESS(*block)),

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -8097,12 +8097,11 @@ void PeerManagerImpl::BlockConnected(
         // was re-retained for the same hash on the new active chain (cancelling
         // live valid work). Only terminate when the block is still on the active
         // chain at the moment the callback actually runs.
-        bool still_active{false};
-        {
-            LOCK(cs_main);
-            still_active = m_chainman.ActiveChain().Contains(pindex);
-        }
-        if (still_active) {
+        // Keep the membership check and lifecycle erase atomic with respect to
+        // reorg-driven retention for this hash. Otherwise a reorg can occur
+        // after Contains() but before TerminalConnected() and recreate the race.
+        LOCK(cs_main);
+        if (m_chainman.ActiveChain().Contains(pindex)) {
             m_matmul_block_lifecycle.TerminalConnected(pindex->GetBlockHash());
         }
     }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -316,6 +316,15 @@ public:
     /** True while a complete body is held for scheduler re-admission. */
     [[nodiscard]] virtual bool HasMatMulRetainedBodyForTest(const uint256& hash) const = 0;
     [[nodiscard]] virtual bool UnitTestHasMatMulRetainedBody(const uint256& hash) const = 0;
+    /** Issue #130 regression: retain a MatMul lifecycle body directly, bypassing
+     *  the ExactReplay deferral path so the guard is testable in CUDA-off builds. */
+    virtual void RetainMatMulBodyForTest(
+        const std::shared_ptr<const CBlock>& block) = 0;
+    /** Issue #130 regression: invoke the real BlockConnected callback with a
+     *  chosen block index, to simulate a stale async callback after a reorg. */
+    virtual void SimulateBlockConnectedForTest(
+        const std::shared_ptr<const CBlock>& block,
+        const CBlockIndex* pindex) = 0;
     /** Drive scheduler re-admission of a HAVE_DATA followed tip-child.
      *  Production calls this from CScheduler, never from SendMessages
      *  (g_msgproc_mutex). Tests must not hold that mutex. */

--- a/src/node/matmul_block_lifecycle.h
+++ b/src/node/matmul_block_lifecycle.h
@@ -541,7 +541,18 @@ public:
         if (entry.terminated) {
             entry.terminated->store(true, std::memory_order_relaxed);
         }
-        if (worker_will_ack && IsActive(entry.state)) {
+        // Only a state where the verify worker owns THIS generation's attempt
+        // (and will therefore acknowledge) may hold. ADMISSION_PENDING has no
+        // lease yet and its body attempt has not been handed to the worker, so
+        // a same-hash header-first worker must never be mistaken for an
+        // acknowledger; treat it (and any non-owned state) as no-ack and clean
+        // up now so a TERMINATING hold cannot stick.
+        const bool worker_owns_generation{
+            entry.state == State::QUEUED ||
+            entry.state == State::RUNNING ||
+            entry.state == State::AWAITING_QUORUM ||
+            entry.state == State::COMPLETING};
+        if (worker_will_ack && worker_owns_generation) {
             // Hold the lease + retained resources until the worker's terminal
             // acknowledgement releases them exactly once. Do NOT reset
             // pending_lease / owned_resources here.

--- a/src/node/matmul_block_lifecycle.h
+++ b/src/node/matmul_block_lifecycle.h
@@ -143,6 +143,7 @@ public:
         entry.updated_at = now;
         entry.pending_lease.reset();
         entry.cancelled = std::make_shared<std::atomic_bool>(false);
+        entry.terminated.reset();
         entry.generation = NextGeneration();
         return Token{hash, entry.generation};
     }
@@ -336,13 +337,15 @@ public:
     bool Queue(const Token& token, std::shared_ptr<void> pending_lease,
                const std::shared_ptr<std::atomic_bool>& cancelled,
                std::vector<std::shared_ptr<void>> owned_resources = {},
-               Clock::time_point now = Clock::now())
+               Clock::time_point now = Clock::now(),
+               const std::shared_ptr<std::atomic_bool>& terminated = {})
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         Entry* entry{Find(token)};
         if (!entry || entry->state != State::ADMISSION_PENDING) return false;
         entry->pending_lease = std::move(pending_lease);
         entry->cancelled = cancelled;
+        entry->terminated = terminated;
         entry->owned_resources = std::move(owned_resources);
         entry->state = State::QUEUED;
         entry->updated_at = now;
@@ -402,9 +405,12 @@ public:
             ++m_progress.verify_completed;
         }
         entry->pending_lease.reset();
+        const bool terminated{
+            entry->terminated &&
+            entry->terminated->load(std::memory_order_relaxed)};
         entry->cancelled.reset();
         entry->owned_resources.clear();
-        if (!entry->body) {
+        if (!entry->body || terminated) {
             m_entries.erase(token.hash);
             return true;
         }
@@ -512,14 +518,36 @@ public:
 
     /**
      * Active-chain connection is terminal for every lifecycle generation.
-     * Cancel live work and release the retained body so a late callback or
-     * retry scan cannot re-admit an already-connected block.
+     * Raise terminal cancellation for the live generation (a body-holding
+     * ExactReplay honours this even though it ignores speculative `cancelled`).
+     *
+     * When a verify worker still owns the attempt (worker_will_ack), the
+     * pending lease and retained resources are HELD here and released only when
+     * the worker acknowledges termination via its terminal callback, so compute
+     * capacity is never released out from under an in-flight replay. When no
+     * worker can acknowledge (no live device work, ADMISSION_PENDING before the
+     * job is enqueued, or the worker already relinquished the job), cleanup
+     * completes immediately so a held (TERMINATING) lease cannot stick.
      */
-    void TerminalConnected(const uint256& hash)
+    void TerminalConnected(const uint256& hash, bool worker_will_ack = false)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         const auto it{m_entries.find(hash)};
-        if (it != m_entries.end()) EraseEntry(it);
+        if (it == m_entries.end()) return;
+        Entry& entry{it->second};
+        if (entry.cancelled) {
+            entry.cancelled->store(true, std::memory_order_relaxed);
+        }
+        if (entry.terminated) {
+            entry.terminated->store(true, std::memory_order_relaxed);
+        }
+        if (worker_will_ack && IsActive(entry.state)) {
+            // Hold the lease + retained resources until the worker's terminal
+            // acknowledgement releases them exactly once. Do NOT reset
+            // pending_lease / owned_resources here.
+            return;
+        }
+        EraseEntry(it);
     }
 
     void Terminal(const Token& token)
@@ -552,6 +580,22 @@ public:
         return m_retained_bytes;
     }
 
+    bool TerminatedFlagSetForTest(const uint256& hash) const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        const auto it{m_entries.find(hash)};
+        return it != m_entries.end() && it->second.terminated &&
+               it->second.terminated->load(std::memory_order_relaxed);
+    }
+
+    bool PendingLeaseHeldForTest(const uint256& hash) const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        const auto it{m_entries.find(hash)};
+        return it != m_entries.end() &&
+               static_cast<bool>(it->second.pending_lease);
+    }
+
     size_t RetainedCountForSourceForTest(uint64_t netgroup) const
     {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -566,6 +610,10 @@ private:
         std::optional<RetainedBody> body;
         std::shared_ptr<void> pending_lease;
         std::shared_ptr<std::atomic_bool> cancelled;
+        //! Terminal (block-connected) cancellation shared with the verify
+        //! worker Job. Distinct from `cancelled` (speculative): a body-holding
+        //! ExactReplay ignores `cancelled` but MUST abort on terminal.
+        std::shared_ptr<std::atomic_bool> terminated;
         std::vector<std::shared_ptr<void>> owned_resources;
     };
 
@@ -712,6 +760,9 @@ private:
     {
         if (it->second.cancelled) {
             it->second.cancelled->store(true, std::memory_order_relaxed);
+        }
+        if (it->second.terminated) {
+            it->second.terminated->store(true, std::memory_order_relaxed);
         }
         if (it->second.body) {
             AccountSourceRemove(it->second.body->source_netgroup,

--- a/src/node/matmul_block_lifecycle.h
+++ b/src/node/matmul_block_lifecycle.h
@@ -510,6 +510,18 @@ public:
         }
     }
 
+    /**
+     * Active-chain connection is terminal for every lifecycle generation.
+     * Cancel live work and release the retained body so a late callback or
+     * retry scan cannot re-admit an already-connected block.
+     */
+    void TerminalConnected(const uint256& hash)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        const auto it{m_entries.find(hash)};
+        if (it != m_entries.end()) EraseEntry(it);
+    }
+
     void Terminal(const Token& token)
     {
         std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/node/matmul_verify_worker.cpp
+++ b/src/node/matmul_verify_worker.cpp
@@ -287,6 +287,31 @@ bool MatMulVerifyWorker::CanHandoffAuthenticatedTip(
     return false;
 }
 
+bool MatMulVerifyWorker::TerminalCancel(const uint256& hash)
+{
+    // Terminal (block-connected) cancellation. Unlike Cancel(), this overrides
+    // ProtectsBodyReplay: a body-holding ExactReplay for an already-connected
+    // block MUST stop. It only raises the terminal signal and wakes the loop /
+    // in-flight replay; it performs no waiting and runs no callbacks, so it is
+    // safe under cs_main. The worker thread performs teardown and the terminal
+    // lifecycle acknowledgement; awaiting-quorum jobs are drained by
+    // TakeExpiredAwaitingQuorum once cancelled is raised.
+    std::lock_guard<std::mutex> lock(m_mutex);
+    const auto it{m_pending.find(hash)};
+    if (it == m_pending.end()) return false;
+    const auto pending{it->second};
+    if (pending->job.terminal_cancelled) {
+        pending->job.terminal_cancelled->store(
+            true, std::memory_order_relaxed);
+    }
+    if (pending->job.cancelled) {
+        pending->job.cancelled->store(true, std::memory_order_relaxed);
+    }
+    matmul::v4::rc::GetRCAcceleratorScheduler().NotifyCancellation();
+    m_cv.notify_all();
+    return true;
+}
+
 bool MatMulVerifyWorker::Cancel(const uint256& hash)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -629,10 +654,18 @@ void MatMulVerifyWorker::FinishRetryablePending(
     const std::shared_ptr<Pending>& pending)
 {
     std::vector<std::function<void()>> callbacks;
+    const bool terminal{
+        pending->job.terminal_cancelled &&
+        pending->job.terminal_cancelled->load(std::memory_order_relaxed)};
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        ArmCancelRetryBackoff(pending->job.GetHeader().GetHash());
-        if (pending->job.retryable_failure) {
+        if (!terminal) {
+            ArmCancelRetryBackoff(pending->job.GetHeader().GetHash());
+        }
+        if (terminal && pending->job.on_terminal_cancelled) {
+            callbacks.push_back(
+                std::move(pending->job.on_terminal_cancelled));
+        } else if (pending->job.retryable_failure) {
             callbacks.push_back(std::move(pending->job.retryable_failure));
         }
         std::move(pending->follower_retryable_failures.begin(),
@@ -712,10 +745,16 @@ void MatMulVerifyWorker::WorkerLoop()
         if (job.on_started) job.on_started();
         const auto finish_retryable_without_verdict = [&] {
             std::vector<std::function<void()>> callbacks;
+            const bool terminal{
+                job.terminal_cancelled &&
+                job.terminal_cancelled->load(std::memory_order_relaxed)};
             {
                 std::lock_guard<std::mutex> lock(m_mutex);
-                ArmCancelRetryBackoff(hash);
-                if (job.retryable_failure) {
+                if (!terminal) ArmCancelRetryBackoff(hash);
+                if (terminal && job.on_terminal_cancelled) {
+                    callbacks.push_back(
+                        std::move(job.on_terminal_cancelled));
+                } else if (job.retryable_failure) {
                     callbacks.push_back(
                         std::move(job.retryable_failure));
                 }
@@ -735,8 +774,12 @@ void MatMulVerifyWorker::WorkerLoop()
         bool local_execution_failure{false};
         const bool shutting_down{
             m_shutdown.load(std::memory_order_acquire)};
-        if (job.cancelled->load(std::memory_order_relaxed) &&
-            (!ProtectsBodyReplay(*pending) || shutting_down)) {
+        const bool terminal_now{
+            job.terminal_cancelled &&
+            job.terminal_cancelled->load(std::memory_order_relaxed)};
+        if (terminal_now ||
+            (job.cancelled->load(std::memory_order_relaxed) &&
+             (!ProtectsBodyReplay(*pending) || shutting_down))) {
             finish_retryable_without_verdict();
             continue;
         }
@@ -803,7 +846,9 @@ void MatMulVerifyWorker::WorkerLoop()
                 matmul::v4::rc::GetRCAcceleratorScheduler().Acquire(
                     device_priority,
                     (protect_body_replay && !shutting_down)
-                        ? nullptr
+                        ? (job.terminal_cancelled
+                               ? job.terminal_cancelled.get()
+                               : nullptr)
                         : job.cancelled.get(),
                     strprintf("verify:%s:%d", hash.ToString(),
                               job.height),
@@ -828,8 +873,10 @@ void MatMulVerifyWorker::WorkerLoop()
                 accelerator_lease.QueueWaitSeconds());
         }
         matmul::v4::rc::ScopedExactReplayCancellation cancellation_scope{
-            (protect_body_replay && !shutting_down) ? nullptr
-                                                   : job.cancelled.get()};
+            (protect_body_replay && !shutting_down)
+                ? (job.terminal_cancelled ? job.terminal_cancelled.get()
+                                          : nullptr)
+                : job.cancelled.get()};
         if (verify_override) {
             if (job.block) {
                 ok = verify_override(
@@ -1000,7 +1047,10 @@ void MatMulVerifyWorker::WorkerLoop()
             const auto suppress_verdict{[&] {
                 return local_execution_failure ||
                        (job.cancelled->load(std::memory_order_relaxed) &&
-                        (!ProtectsBodyReplay(*pending) || shutting_down));
+                        (!ProtectsBodyReplay(*pending) || shutting_down)) ||
+                       (job.terminal_cancelled &&
+                        job.terminal_cancelled->load(
+                            std::memory_order_relaxed));
             }};
             if (sf.IsLeader()) {
                 ok = verify_pure();
@@ -1032,22 +1082,31 @@ complete:
         {
             std::lock_guard<std::mutex> lock(m_mutex);
             m_pending.erase(hash);
+            const bool terminal{
+                job.terminal_cancelled &&
+                job.terminal_cancelled->load(std::memory_order_relaxed)};
             const bool cancelled_header_only{
                 job.cancelled->load(std::memory_order_relaxed) &&
                 (!ProtectsBodyReplay(*pending) ||
-                 (m_shutdown.load(std::memory_order_acquire) && !ok))};
+                 (m_shutdown.load(std::memory_order_acquire) && !ok) ||
+                 terminal)};
             const bool retryable_without_verdict{
                 local_execution_failure || cancelled_header_only};
             if (retryable_without_verdict) {
-                ArmCancelRetryBackoff(hash);
-                if (job.retryable_failure) {
+                if (terminal && job.on_terminal_cancelled) {
                     retryable_failures.push_back(
-                        std::move(job.retryable_failure));
+                        std::move(job.on_terminal_cancelled));
+                } else {
+                    ArmCancelRetryBackoff(hash);
+                    if (job.retryable_failure) {
+                        retryable_failures.push_back(
+                            std::move(job.retryable_failure));
+                    }
+                    std::move(
+                        pending->follower_retryable_failures.begin(),
+                        pending->follower_retryable_failures.end(),
+                        std::back_inserter(retryable_failures));
                 }
-                std::move(
-                    pending->follower_retryable_failures.begin(),
-                    pending->follower_retryable_failures.end(),
-                    std::back_inserter(retryable_failures));
             } else if (!cancelled_header_only) {
                 ClearCancelRetryBackoff(hash);
                 if (job.completion) {

--- a/src/node/matmul_verify_worker.cpp
+++ b/src/node/matmul_verify_worker.cpp
@@ -84,6 +84,20 @@ MatMulVerifyWorker::EnqueueResult MatMulVerifyWorker::Enqueue(
                 it->second->job.retained_body_bytes =
                     std::max(it->second->job.retained_body_bytes,
                              job.retained_body_bytes);
+                // The joined job is now body-holding (ProtectsBodyReplay) and
+                // can only be stopped by terminal cancellation. Carry the
+                // body's terminal signal + acknowledgement onto the pending
+                // job so BlockConnected can still abort it and release the
+                // lease; otherwise the merged job would be protected with no
+                // way to terminate, and its terminal ack would be discarded.
+                if (job.terminal_cancelled) {
+                    it->second->job.terminal_cancelled =
+                        std::move(job.terminal_cancelled);
+                }
+                if (job.on_terminal_cancelled) {
+                    it->second->job.on_terminal_cancelled =
+                        std::move(job.on_terminal_cancelled);
+                }
             }
             if (static_cast<uint8_t>(job.priority) >
                 static_cast<uint8_t>(it->second->job.priority)) {

--- a/src/node/matmul_verify_worker.h
+++ b/src/node/matmul_verify_worker.h
@@ -137,6 +137,16 @@ public:
         std::shared_ptr<const CBlockHeader> header;
         Priority priority{Priority::Background};
         std::shared_ptr<std::atomic_bool> cancelled;
+        //! Terminal (block-connected) cancellation, distinct from speculative
+        //! `cancelled`. A body-holding ExactReplay ignores `cancelled` but MUST
+        //! abort on terminal, exactly as it does on global shutdown. Shared
+        //! with the lifecycle entry so BlockConnected can raise it.
+        std::shared_ptr<std::atomic_bool> terminal_cancelled;
+        //! Runs instead of retryable_failure when the attempt is terminated
+        //! because its block connected: a TERMINAL acknowledgement releasing
+        //! delivery bookkeeping with no verdict, retry, cache, completion, or
+        //! re-admission.
+        std::function<void()> on_terminal_cancelled;
         //! One cap-one RC pending-work reservation. Header-first admission
         //! stores it outside `completion` so one bounded equal-priority
         //! handoff can transfer ownership without opening a second slot.
@@ -209,6 +219,15 @@ public:
 
     /** Cancel queued/running speculative work for one header hash. */
     bool Cancel(const uint256& hash);
+
+    //! Terminal (block-connected) cancellation: overrides ProtectsBodyReplay so
+    //! a body-holding ExactReplay for an already-connected block stops. Only
+    //! raises the terminal signal and wakes the loop/replay; runs no callbacks
+    //! and never waits, so it is safe to call while holding cs_main. Returns
+    //! true iff a worker job for the hash exists (and will therefore
+    //! acknowledge, releasing the lifecycle lease); false lets the caller finish
+    //! cleanup so a held (TERMINATING) lease cannot stick without an acknowledger.
+    [[nodiscard]] bool TerminalCancel(const uint256& hash);
 
     /** Cancel every job selected by a tip/reorg-aware predicate. */
     size_t CancelIf(const std::function<bool(const CBlockHeader&, int32_t)>& predicate);

--- a/src/test/matmul_block_lifecycle_tests.cpp
+++ b/src/test/matmul_block_lifecycle_tests.cpp
@@ -526,6 +526,28 @@ BOOST_AUTO_TEST_CASE(terminal_connected_admission_pending_erases_and_blocks_queu
     BOOST_CHECK(!lifecycle.Queue(*token, lease, cancelled, {}, now, terminated));
 }
 
+BOOST_AUTO_TEST_CASE(terminal_connected_admission_pending_no_ack_with_same_hash_worker)
+{
+    // worker_will_ack is hash-keyed: a same-hash header-first worker returns
+    // true even though it does not own this generation's body attempt.
+    // ADMISSION_PENDING (no lease, body attempt not yet handed to the worker)
+    // must be treated as no-ack and cleaned up immediately, never held.
+    node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};
+    const auto now{node::MatMulBlockLifecycle::Clock::now()};
+    const uint256 hash{BlockWithNonce(27)->GetHash()};
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(27, 50, now), now));
+    const auto token{lifecycle.Begin(hash, now)}; // ADMISSION_PENDING
+    BOOST_REQUIRE(token);
+
+    lifecycle.TerminalConnected(hash, /*worker_will_ack=*/true);
+    BOOST_CHECK(!lifecycle.StateForTest(hash));            // erased immediately
+    BOOST_CHECK(!lifecycle.PendingLeaseHeldForTest(hash)); // nothing held
+    // The pending body Queue then fails (entry gone) -> caller rolls back.
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    BOOST_CHECK(!lifecycle.Queue(*token, nullptr, cancelled, {}, now, terminated));
+}
+
 BOOST_AUTO_TEST_CASE(terminal_retry_erases_body_no_readmission)
 {
     node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};

--- a/src/test/matmul_block_lifecycle_tests.cpp
+++ b/src/test/matmul_block_lifecycle_tests.cpp
@@ -209,6 +209,33 @@ BOOST_AUTO_TEST_CASE(park_releases_cap_and_terminal_frees_bytes)
     BOOST_CHECK_EQUAL(lifecycle.RetainedCountForTest(), 0U);
 }
 
+BOOST_AUTO_TEST_CASE(connected_block_clears_live_lifecycle_generation)
+{
+    node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};
+    const auto now{node::MatMulBlockLifecycle::Clock::now()};
+    const auto block{BlockWithNonce(14)};
+    const uint256 hash{block->GetHash()};
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(14, 75, now), now));
+    const auto token{lifecycle.Begin(hash, now)};
+    BOOST_REQUIRE(token);
+    auto lease{std::make_shared<int>(1)};
+    std::weak_ptr<int> weak_lease{lease};
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    BOOST_REQUIRE(lifecycle.Queue(*token, lease, cancelled, {}, now));
+    lease.reset();
+    BOOST_REQUIRE(lifecycle.Start(*token, now));
+
+    lifecycle.TerminalConnected(hash);
+    BOOST_CHECK(cancelled->load());
+    BOOST_CHECK(weak_lease.expired());
+    BOOST_CHECK(!lifecycle.StateForTest(hash));
+    BOOST_CHECK(!lifecycle.HasRetainedBody(hash));
+    BOOST_CHECK_EQUAL(lifecycle.RetainedBytesForTest(), 0U);
+
+    lifecycle.Terminal(*token); // late completion is a harmless no-op
+    BOOST_CHECK(!lifecycle.StateForTest(hash));
+}
+
 BOOST_AUTO_TEST_CASE(async_pending_without_body_does_not_block_download)
 {
     // FindNextBlocks invariant: async-pending is a VERIFY state. A marker

--- a/src/test/matmul_block_lifecycle_tests.cpp
+++ b/src/test/matmul_block_lifecycle_tests.cpp
@@ -402,4 +402,182 @@ BOOST_AUTO_TEST_CASE(per_source_caps_cannot_starve_other_netgroup)
     BOOST_CHECK_LE(lifecycle.RetainedCountForTest(), 8U);
 }
 
+// --- PR #132 P1: terminal (block-connected) cancellation holds the admission
+// --- lease until the worker acknowledges, then releases it exactly once with
+// --- no re-admission; preserves the generation-race fix.
+
+namespace {
+//! Model of the RC admission lease/counter (ScopedMatMulPendingVerification):
+//! occupied while a shared_ptr<void> lease is held, released exactly once when
+//! the lifecycle drops it.
+std::shared_ptr<void> MakeCountedLease(std::atomic<int>& counter)
+{
+    counter.fetch_add(1);
+    return std::shared_ptr<void>(reinterpret_cast<void*>(0x1),
+                                 [&counter](void*) { counter.fetch_sub(1); });
+}
+} // namespace
+
+BOOST_AUTO_TEST_CASE(terminal_connected_holds_running_lease_until_worker_ack)
+{
+    node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};
+    const auto now{node::MatMulBlockLifecycle::Clock::now()};
+    const uint256 hash{BlockWithNonce(21)->GetHash()};
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(21, 50, now), now));
+    const auto token{lifecycle.Begin(hash, now)};
+    BOOST_REQUIRE(token);
+    std::atomic<int> counter{0};
+    auto lease{MakeCountedLease(counter)};
+    std::weak_ptr<void> weak_lease{lease};
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    BOOST_REQUIRE(lifecycle.Queue(*token, lease, cancelled, {}, now, terminated));
+    lease.reset(); // only the lifecycle entry holds the lease now
+    BOOST_REQUIRE(lifecycle.Start(*token, now)); // RUNNING
+    BOOST_CHECK_EQUAL(counter.load(), 1);
+    BOOST_CHECK(!weak_lease.expired());
+
+    // Block connects; a worker owns the running replay and will acknowledge.
+    lifecycle.TerminalConnected(hash, /*worker_will_ack=*/true);
+    BOOST_CHECK(terminated->load());   // terminal signal raised
+    BOOST_CHECK(cancelled->load());
+    BOOST_CHECK(lifecycle.PendingLeaseHeldForTest(hash)); // HELD, not released
+    BOOST_CHECK_EQUAL(counter.load(), 1);
+    BOOST_CHECK(!weak_lease.expired());
+    BOOST_CHECK(lifecycle.StateForTest(hash).has_value());
+
+    // Worker acknowledges via the terminal path (lifecycle.Terminal).
+    lifecycle.Terminal(*token);
+    BOOST_CHECK_EQUAL(counter.load(), 0);   // released exactly once
+    BOOST_CHECK(weak_lease.expired());
+    BOOST_CHECK(!lifecycle.StateForTest(hash));
+    BOOST_CHECK(!lifecycle.HasRetainedBody(hash)); // no retained body -> no re-admission
+    BOOST_CHECK(!lifecycle.NextRetry(uint256{}, now + 20min).has_value());
+}
+
+BOOST_AUTO_TEST_CASE(terminal_connected_holds_queued_lease_until_worker_ack)
+{
+    node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};
+    const auto now{node::MatMulBlockLifecycle::Clock::now()};
+    const uint256 hash{BlockWithNonce(22)->GetHash()};
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(22, 50, now), now));
+    const auto token{lifecycle.Begin(hash, now)};
+    BOOST_REQUIRE(token);
+    std::atomic<int> counter{0};
+    auto lease{MakeCountedLease(counter)};
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    BOOST_REQUIRE(lifecycle.Queue(*token, lease, cancelled, {}, now, terminated));
+    lease.reset(); // QUEUED (not started); only the entry holds the lease
+    BOOST_CHECK_EQUAL(counter.load(), 1);
+
+    lifecycle.TerminalConnected(hash, /*worker_will_ack=*/true);
+    BOOST_CHECK(terminated->load());
+    BOOST_CHECK(lifecycle.PendingLeaseHeldForTest(hash)); // held until ack
+    BOOST_CHECK_EQUAL(counter.load(), 1);
+
+    lifecycle.Terminal(*token);
+    BOOST_CHECK_EQUAL(counter.load(), 0);
+    BOOST_CHECK(!lifecycle.StateForTest(hash));
+    BOOST_CHECK(!lifecycle.HasRetainedBody(hash));
+}
+
+BOOST_AUTO_TEST_CASE(terminal_connected_no_worker_ack_releases_immediately)
+{
+    node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};
+    const auto now{node::MatMulBlockLifecycle::Clock::now()};
+    const uint256 hash{BlockWithNonce(23)->GetHash()};
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(23, 50, now), now));
+    const auto token{lifecycle.Begin(hash, now)};
+    BOOST_REQUIRE(token);
+    std::atomic<int> counter{0};
+    auto lease{MakeCountedLease(counter)};
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    BOOST_REQUIRE(lifecycle.Queue(*token, lease, cancelled, {}, now, terminated));
+    lease.reset();
+    BOOST_REQUIRE(lifecycle.Start(*token, now));
+    BOOST_CHECK_EQUAL(counter.load(), 1);
+
+    // No worker can acknowledge: cleanup completes immediately (no stick).
+    lifecycle.TerminalConnected(hash, /*worker_will_ack=*/false);
+    BOOST_CHECK(terminated->load());
+    BOOST_CHECK_EQUAL(counter.load(), 0);   // released now, exactly once
+    BOOST_CHECK(!lifecycle.StateForTest(hash));
+    BOOST_CHECK(!lifecycle.HasRetainedBody(hash));
+}
+
+BOOST_AUTO_TEST_CASE(terminal_connected_admission_pending_erases_and_blocks_queue)
+{
+    node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};
+    const auto now{node::MatMulBlockLifecycle::Clock::now()};
+    const uint256 hash{BlockWithNonce(24)->GetHash()};
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(24, 50, now), now));
+    const auto token{lifecycle.Begin(hash, now)}; // ADMISSION_PENDING, no lease yet
+    BOOST_REQUIRE(token);
+
+    // No worker job exists yet -> immediate cleanup; the pending Queue then fails.
+    lifecycle.TerminalConnected(hash, /*worker_will_ack=*/false);
+    BOOST_CHECK(!lifecycle.StateForTest(hash));
+    std::atomic<int> counter{0};
+    auto lease{MakeCountedLease(counter)};
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    BOOST_CHECK(!lifecycle.Queue(*token, lease, cancelled, {}, now, terminated));
+}
+
+BOOST_AUTO_TEST_CASE(terminal_retry_erases_body_no_readmission)
+{
+    node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};
+    const auto now{node::MatMulBlockLifecycle::Clock::now()};
+    const uint256 hash{BlockWithNonce(25)->GetHash()};
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(25, 50, now), now));
+    const auto token{lifecycle.Begin(hash, now)};
+    BOOST_REQUIRE(token);
+    std::atomic<int> counter{0};
+    auto lease{MakeCountedLease(counter)};
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    BOOST_REQUIRE(lifecycle.Queue(*token, lease, cancelled, {}, now, terminated));
+    lease.reset();
+    BOOST_REQUIRE(lifecycle.Start(*token, now));
+
+    lifecycle.TerminalConnected(hash, /*worker_will_ack=*/true); // terminated + held
+    BOOST_CHECK(lifecycle.PendingLeaseHeldForTest(hash));
+
+    // Defense-in-depth: even if the worker acks via the retryable path, a
+    // terminated entry is erased (its body is NOT kept retryable).
+    BOOST_REQUIRE(lifecycle.Retry(*token, 60s, now));
+    BOOST_CHECK_EQUAL(counter.load(), 0);
+    BOOST_CHECK(!lifecycle.StateForTest(hash));
+    BOOST_CHECK(!lifecycle.HasRetainedBody(hash));
+    BOOST_CHECK(!lifecycle.NextRetry(uint256{}, now + 20min).has_value());
+}
+
+BOOST_AUTO_TEST_CASE(terminal_ack_is_generation_scoped)
+{
+    node::MatMulBlockLifecycle lifecycle{1, 100, 10min, 10min};
+    const auto now{node::MatMulBlockLifecycle::Clock::now()};
+    const uint256 hash{BlockWithNonce(26)->GetHash()};
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(26, 50, now), now));
+    const auto token1{lifecycle.Begin(hash, now)};
+    BOOST_REQUIRE(token1);
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    BOOST_REQUIRE(lifecycle.Queue(*token1, nullptr, cancelled, {}, now, terminated));
+    BOOST_REQUIRE(lifecycle.Start(*token1, now));
+    lifecycle.TerminalConnected(hash, /*worker_will_ack=*/true);
+    lifecycle.Terminal(*token1); // gen1 acknowledged + erased
+
+    // A reorg re-retains and starts a FRESH generation for the same hash.
+    BOOST_REQUIRE(lifecycle.Retain(hash, Body(26, 50, now), now));
+    const auto token2{lifecycle.Begin(hash, now)};
+    BOOST_REQUIRE(token2);
+    BOOST_CHECK(token2->generation != token1->generation);
+
+    // A late/stale acknowledgement for gen1 must NOT erase gen2 (generation-race fix).
+    lifecycle.Terminal(*token1);
+    BOOST_CHECK(lifecycle.StateForTest(hash).has_value());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/matmul_verify_worker_tests.cpp
+++ b/src/test/matmul_verify_worker_tests.cpp
@@ -2773,4 +2773,65 @@ BOOST_AUTO_TEST_CASE(body_job_without_terminal_keeps_verdict)
 }
 
 
+
+// --- PR #132 P1 (review): when a full body joins a header-first pending job it
+// --- becomes body-holding (ProtectsBodyReplay). The body's terminal_cancelled
+// --- and on_terminal_cancelled must transfer onto the joined job so it can
+// --- still be terminally stopped; the returning verdict is then discarded via
+// --- the transferred terminal ack (exactly once), with no completion.
+BOOST_AUTO_TEST_CASE(body_join_transfers_terminal_cancellation_and_discards_verdict)
+{
+    const Consensus::Params& params = Params().GetConsensus();
+    BlockingVerify gate;
+    std::atomic<int> completions{0};
+    std::atomic<int> terminal_acks{0};
+    MatMulVerifyWorker worker{
+        params, /*max_threads=*/1,
+        [&](const CBlock&, int32_t, std::optional<int64_t>) { return gate.Run(); }};
+
+    const auto block{MakeBlock(150)};
+    auto header{std::make_shared<CBlockHeader>(block->GetBlockHeader())};
+    const uint256 hash{block->GetHash()};
+
+    // Header-first job runs first (carries no terminal machinery).
+    MatMulVerifyWorker::Job header_job{
+        .height = 100,
+        .completion = [&](bool) { ++completions; },
+        .header = header,
+        .priority = MatMulVerifyWorker::Priority::CompetingBranch,
+    };
+    BOOST_REQUIRE(worker.Enqueue(header_job) ==
+                  MatMulVerifyWorker::EnqueueResult::Enqueued);
+    BOOST_REQUIRE(WaitFor([&] { return gate.running.load() == 1; }));
+
+    // A full body joins, carrying the terminal signal + acknowledgement.
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    MatMulVerifyWorker::Job body_job{
+        .block = block,
+        .height = 100,
+        .completion = [&](bool) { ++completions; },
+        .priority = MatMulVerifyWorker::Priority::AuthenticatedTipChild,
+        .terminal_cancelled = terminated,
+        .on_terminal_cancelled = [&] { ++terminal_acks; },
+    };
+    BOOST_REQUIRE(worker.Enqueue(body_job,
+                                 MatMulVerifyWorker::EnqueueMode::JoinOnly) ==
+                  MatMulVerifyWorker::EnqueueResult::Joined);
+
+    // Now body-holding: ordinary Cancel refused, terminal accepted.
+    BOOST_CHECK(!worker.Cancel(hash));
+    BOOST_CHECK(worker.TerminalCancel(hash));
+    BOOST_CHECK(terminated->load());
+
+    // The returning verdict is discarded via the TRANSFERRED terminal ack
+    // (exactly once); neither the header nor the body completion runs. Without
+    // the transfer, terminal_cancelled would be null on the joined job and the
+    // verdict would be kept instead.
+    gate.Release();
+    BOOST_REQUIRE(WaitFor([&] { return terminal_acks.load() == 1; }));
+    BOOST_CHECK_EQUAL(completions.load(), 0);
+    BOOST_CHECK_EQUAL(terminal_acks.load(), 1);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/matmul_verify_worker_tests.cpp
+++ b/src/test/matmul_verify_worker_tests.cpp
@@ -2691,4 +2691,86 @@ BOOST_AUTO_TEST_CASE(trusted_mirror_above_frontier_does_not_consume_park_slot)
     node::matmul_trusted::ResetForTest();
 }
 
+
+// --- PR #132 P1: terminal (block-connected) cancellation overrides
+// --- ProtectsBodyReplay. Ordinary Cancel() refuses a body-holding job;
+// --- TerminalCancel() is accepted and the returning verdict is DISCARDED via
+// --- on_terminal_cancelled (no verdict/completion for the connected block).
+BOOST_AUTO_TEST_CASE(terminal_cancel_overrides_body_replay_and_discards_verdict)
+{
+    const Consensus::Params& params = Params().GetConsensus();
+    BlockingVerify gate;
+    MatMulVerifyWorker worker{
+        params, /*max_threads=*/1,
+        [&](const CBlock&, int32_t, std::optional<int64_t>) { return gate.Run(); }};
+
+    std::atomic<int> completions{0};
+    std::atomic<int> terminal_acks{0};
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    const auto block{MakeBlock(140)};
+    const uint256 hash{block->GetHash()};
+
+    MatMulVerifyWorker::Job job{
+        .block = block,
+        .height = 100,
+        .parent_median_time_past = std::nullopt,
+        .completion = [&](bool) { ++completions; },
+        .cancelled = cancelled,
+        .terminal_cancelled = terminated,
+        .on_terminal_cancelled = [&] { ++terminal_acks; },
+    };
+    BOOST_REQUIRE(EnqueueAccepted(worker.Enqueue(job)));
+    BOOST_REQUIRE(WaitFor([&] { return gate.running.load() == 1; }));
+
+    // Ordinary Cancel refuses a body-holding (ProtectsBodyReplay) job.
+    BOOST_CHECK(!worker.Cancel(hash));
+    // Terminal cancel is accepted and raises the terminal signal.
+    BOOST_CHECK(worker.TerminalCancel(hash));
+    BOOST_CHECK(terminated->load());
+
+    // Let the now-terminal verify return: its verdict must be DISCARDED.
+    gate.Release();
+    BOOST_REQUIRE(WaitFor([&] { return terminal_acks.load() == 1; }));
+    BOOST_CHECK_EQUAL(completions.load(), 0); // no verdict / completion
+}
+
+// Contrast: without terminal cancellation, a body-holding job keeps its verdict.
+BOOST_AUTO_TEST_CASE(body_job_without_terminal_keeps_verdict)
+{
+    const Consensus::Params& params = Params().GetConsensus();
+    BlockingVerify gate;
+    MatMulVerifyWorker worker{
+        params, /*max_threads=*/1,
+        [&](const CBlock&, int32_t, std::optional<int64_t>) { return gate.Run(); }};
+
+    std::atomic<int> completions{0};
+    std::atomic<int> terminal_acks{0};
+    auto cancelled{std::make_shared<std::atomic_bool>(false)};
+    auto terminated{std::make_shared<std::atomic_bool>(false)};
+    const auto block{MakeBlock(141)};
+    const uint256 hash{block->GetHash()};
+
+    MatMulVerifyWorker::Job job{
+        .block = block,
+        .height = 100,
+        .parent_median_time_past = std::nullopt,
+        .completion = [&](bool) { ++completions; },
+        .cancelled = cancelled,
+        .terminal_cancelled = terminated,
+        .on_terminal_cancelled = [&] { ++terminal_acks; },
+    };
+    BOOST_REQUIRE(EnqueueAccepted(worker.Enqueue(job)));
+    BOOST_REQUIRE(WaitFor([&] { return gate.running.load() == 1; }));
+
+    // Speculative cancellation alone does NOT abort a body replay.
+    cancelled->store(true, std::memory_order_relaxed);
+    BOOST_CHECK(!worker.Cancel(hash));
+
+    gate.Release();
+    BOOST_REQUIRE(WaitFor([&] { return completions.load() == 1; }));
+    BOOST_CHECK_EQUAL(terminal_acks.load(), 0); // verdict kept, no terminal ack
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -10446,4 +10446,40 @@ BOOST_AUTO_TEST_CASE(fresh_mirror_deadlock_empty_archive_consensus_headers_and_r
     peerman.ResetMatMulVerifyAdmissionForTest();
 }
 
+BOOST_AUTO_TEST_CASE(block_connected_terminate_skips_reorged_away_body)
+{
+    // Issue #130 regression: BlockConnected is drained asynchronously, so a stale
+    // callback for a block that a reorg has since disconnected must NOT erase a
+    // fresh retained lifecycle body re-retained for that hash on the new chain.
+    PeerManager& peerman{*Assert(m_node.peerman)};
+    peerman.ResetMatMulVerifyAdmissionForTest();
+
+    // A candidate block extending the tip, left UNCONNECTED (header-only) so it is
+    // not on the active chain -- i.e. the "reorged-away" block.
+    CBlock offchain{node::BlockAssembler{
+        m_node.chainman->ActiveChainstate(), nullptr, {}, m_node}
+        .CreateNewBlock()->block};
+    auto offchain_ptr{std::make_shared<const CBlock>(offchain)};
+    const uint256 offchain_hash{offchain_ptr->GetHash()};
+
+    const CBlockIndex* offchain_index{nullptr};
+    {
+        BlockValidationState state;
+        std::vector<CBlockHeader> headers{offchain_ptr->GetBlockHeader()};
+        BOOST_REQUIRE(m_node.chainman->ProcessNewBlockHeaders(
+            headers, /*min_pow_checked=*/true, state, &offchain_index));
+        BOOST_REQUIRE(offchain_index != nullptr);
+        LOCK(::cs_main);
+        BOOST_REQUIRE(!m_node.chainman->ActiveChain().Contains(offchain_index));
+    }
+
+    peerman.RetainMatMulBodyForTest(offchain_ptr);
+    BOOST_REQUIRE(peerman.HasMatMulRetainedBodyForTest(offchain_hash));
+
+    // Stale BlockConnected for the reorged-away block: the active-chain guard
+    // must skip TerminalConnected, so the fresh retained body survives.
+    peerman.SimulateBlockConnectedForTest(offchain_ptr, offchain_index);
+    BOOST_CHECK(peerman.HasMatMulRetainedBodyForTest(offchain_hash));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- replace the global idle retry-delay override with a per-body, one-shot bypass;
- preserve a consumed bypass across duplicate delivery of the same hash and disable it on every non-terminal retry/requeue path;
- terminally clear retained lifecycle state when a block connects to the active chain, cancelling live work and releasing retained resources;
- add regression coverage for retry pacing and connected-generation cleanup.

## Rationale

The idle catch-up escape added to prevent verification-budget stalls currently makes every retained body eligible regardless of `retry_not_before`. In practice, a body logged with a 60-second cooldown can be selected every message-handler cycle. Separately, an already-connected block can remain in the retained lifecycle because `BlockConnected()` does not terminate it.

Together these defects let obsolete work compete with the next missing root body and can leave active height behind the known header tip.

The new bypass remains available for the initial idle catch-up escape, but is consumed when used early. Once a block is active, `TerminalConnected()` removes any retained or live generation; generation-bound late callbacks remain harmless no-ops.

This does not bypass block validation, change chainwork comparison, or alter fork choice.

## Test coverage

- Built the full `test_btx` target from current `release/0.34.2` head `2f50a192` with GCC 13.3.
- Ran `test_btx --run_test=matmul_block_lifecycle_tests`.
- Result: all 15 lifecycle tests passed, including the three new regression paths.

Refs #130.
