### PR TITLE
0.34.6: OTC escrow + wBTX bridge/HTLC hardening (tracks #135)

### DIFF
--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -607,8 +607,8 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = RECOMMENDED_MIN_CONF,
                       f"descriptor venue_pubkey={bond.venue_pubkey}; "
                       f"expected={expected_venue_pubkey}")
         elif expected_venue_pubkey is not None:
-            check("venue-key", True,
-                  f"expected_venue_pubkey ignored for tier {bond.tier} (no venue leg)")
+            check("venue-key", False,
+                  f"expected_venue_pubkey pins tier A but bond is tier {bond.tier}")
         if bond.tier == "A+":
             if expected_ctv_template_hash is None:
                 check("ctv-template", False,
@@ -622,9 +622,8 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = RECOMMENDED_MIN_CONF,
                       f"descriptor ctv_template_hash={bond.ctv_hash}; "
                       f"expected={expected_ctv_template_hash}")
         elif expected_ctv_template_hash is not None:
-            check("ctv-template", True,
-                  f"expected_ctv_template_hash ignored for tier {bond.tier} "
-                  f"(no CTV covenant leg)")
+            check("ctv-template", False,
+                  f"expected_ctv_template_hash pins tier A+ but bond is tier {bond.tier}")
     except Exception as e:  # noqa: BLE001
         check("descriptor-shape", False, str(e))
         return OfferVerification(False, tier, address, 0, expiry, checks)
@@ -839,7 +838,14 @@ def check_swap_timeout_asymmetry(btx_refund_height: int, other_leg_deadline_heig
     values are BTX block heights (convert an EVM unix timeout first, e.g.
     current_height + (evm_timeout_unix - now_unix)//block_seconds). This prevents
     claim-one-leg/refund-the-other theft and leaves reorg/censorship margin after
-    a preimage-revealing claim."""
+    a preimage-revealing claim.
+
+    NECESSARY BUT NOT SUFFICIENT: callers MUST also enforce the safe Model-B
+    assignment before funding:
+      - preimage-holder FUNDS the BTX/long leg, and
+      - preimage-holder CLAIMS the shorter/other leg first (the one that expires first).
+    If the preimage-holder instead claims the BTX/long leg, this inequality alone
+    does not prevent claim-one-leg/refund-the-other theft."""
     require_block_height_locktime(btx_refund_height, "btx_refund_height")
     require_block_height_locktime(other_leg_deadline_height, "other_leg_deadline_height")
     if (type(reorg_margin_blocks) is not int or isinstance(reorg_margin_blocks, bool) or
@@ -858,7 +864,12 @@ def check_swap_timeout_asymmetry(btx_refund_height: int, other_leg_deadline_heig
 
 def swap_vault_descriptor(preimage_hash160_hex: str, claimer_pubkey: str, refund_locktime: int,
                           sender_pubkey: str) -> str:
-    """Stage-2, two-leaf HTLC settlement vault (identical to the wBTX Model-B leg)."""
+    """Stage-2, two-leaf HTLC settlement vault (identical to the wBTX Model-B leg).
+
+    Before funding: validate HTLC refund-leaf timeout asymmetry with
+    check_swap_timeout_asymmetry(...) AND ensure preimage assignment follows the
+    safe flow (preimage-holder funds BTX/long leg and claims shorter/other leg first).
+    """
     # Same domain rule as the bond refund: the HTLC refund leaf's locktime must
     # be a block height so its relation to the offer/expiry is meaningful and it
     # is not immediately spendable as a past timestamp.
@@ -886,8 +897,10 @@ def build_swap_claim(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
     against unconfirmed or replaceable funding lets the counterparty replace that
     funding and reuse the now-public preimage to take the other (cross-chain) leg.
     The integrator MUST also validate cross-leg timeout asymmetry with
-    check_swap_timeout_asymmetry(...) before funding, per doc §5 and
-    WBTXAtomicSwapHTLC.sol.
+    check_swap_timeout_asymmetry(...) before funding, and MUST keep the safe flow:
+    preimage-holder funds the BTX/long leg and claims the shorter/other leg first.
+    Timeout ordering without that preimage-role assignment is insufficient, per
+    doc §5 and WBTXAtomicSwapHTLC.sol.
     """
     try:
         res = rpc_wallet("buildhtlcclaim", descriptor_with_checksum,
@@ -1019,6 +1032,32 @@ def selftest() -> None:
     # same offline parameter-validation stage (no node touched before it).
     vrep = verify_offer(None, {"version": 1, "terms": {}}, expected_ctv_template_hash="")
     assert any(c.name == "parameters" and not c.ok for c in vrep.checks)
+    # Pinned tier requirements fail closed when the descriptor is another tier.
+    tier_terms = {"version": 1, "amount_sats": MIN_BOND_SATS, "expiry_height": 100, "nonce": "11" * 16}
+    tier_b_desc = bind_bond_descriptor(soft_bond_descriptor(k1, 900, k2), tier_terms)
+
+    def _tier_selftest_rpc(method: str, *params):
+        if method == "getdescriptorinfo":
+            desc = params[0]
+            return {"checksum": hashlib.sha256(str(desc).encode("ascii")).hexdigest()[:8]}
+        if method == "deriveaddresses":
+            desc_ck = params[0]
+            return [f"btx_test_{hashlib.sha256(str(desc_ck).encode('ascii')).hexdigest()[:16]}"]
+        if method == "getblockcount":
+            return 1
+        raise AssertionError(f"unexpected rpc call in selftest: {method} {params!r}")
+
+    tier_bundle = {
+        "version": 1,
+        "terms": tier_terms,
+        "bond": {"descriptor": tier_b_desc, "tier": "B", "outpoints": []},
+    }
+    vrep = verify_offer(_tier_selftest_rpc, tier_bundle, expected_venue_pubkey=k3)
+    assert any(c.name == "venue-key" and not c.ok and
+               "pins tier A but bond is tier B" in c.detail for c in vrep.checks)
+    vrep = verify_offer(_tier_selftest_rpc, tier_bundle, expected_ctv_template_hash="22" * 32)
+    assert any(c.name == "ctv-template" and not c.ok and
+               "pins tier A+ but bond is tier B" in c.detail for c in vrep.checks)
 
     # Cross-leg timeout asymmetry helper: other+margin must be STRICTLY below BTX.
     check_swap_timeout_asymmetry(btx_refund_height=1000, other_leg_deadline_height=900)

--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -70,6 +70,10 @@ Rpc = Callable[..., object]
 
 COIN = 100_000_000
 COINBASE_MATURITY = 100
+RECOMMENDED_MIN_CONF = 20
+# Funding below this floor is practically unspendable with the default helper
+# fee (20_000 sats) once dust and script overhead are accounted for.
+MIN_BOND_SATS = 20_000 + 1_000
 
 # Protocol tag used by off-chain attestations and bundle formats. The on-chain
 # binding is a hidden P2MR `commit(sha256(terms))` leaf, not an OP_RETURN output.
@@ -114,6 +118,15 @@ def require_block_height_locktime(value: int, field: str) -> int:
 REQUIRED_TERMS_FIELDS = ("version", "amount_sats", "expiry_height", "nonce")
 
 
+def _no_dup_pairs(pairs):
+    seen = set()
+    for k, _ in pairs:
+        if k in seen:
+            raise ValueError(f"duplicate key in terms JSON: {k!r}")
+        seen.add(k)
+    return dict(pairs)
+
+
 def _reject_floats(value, path="terms"):
     """Floats are not allowed anywhere in offer terms — they do not canonicalize."""
     if isinstance(value, bool):
@@ -141,6 +154,11 @@ def validate_terms(terms: dict) -> None:
         raise ValueError("terms.version must be integer 1")
     if type(terms["amount_sats"]) is not int or terms["amount_sats"] <= 0:
         raise ValueError("terms.amount_sats must be a positive integer (satoshis)")
+    if terms["amount_sats"] < MIN_BOND_SATS:
+        raise ValueError(
+            f"terms.amount_sats must be >= {MIN_BOND_SATS} sats to cover "
+            "default settlement/refund spend fee and dust margin"
+        )
     if type(terms["expiry_height"]) is not int or terms["expiry_height"] <= 0:
         raise ValueError("terms.expiry_height must be a positive integer (block height)")
     # expiry_height is a block height; a value in the timestamp domain would
@@ -186,14 +204,14 @@ _TIER_B_RE = re.compile(
 _TIER_A_RE = re.compile(
     rf"^mr\(multi_pq\(2,({_KEY}),({_KEY})\),\{{refund\((\d+),({_KEY})\),commit\(({_HASH256})\)\}}\)$")
 _TIER_APLUS_RE = re.compile(
-    rf"^mr\(ctv_multi_pq\(({_HASH256}),1,({_KEY})\),\{{refund\((\d+),({_KEY})\),commit\(({_HASH256})\)\}}\)$")
+    rf"^mr\(ctv_pk\(({_HASH256}),({_KEY})\),\{{refund\((\d+),({_KEY})\),commit\(({_HASH256})\)\}}\)$")
 
 _TIER_B_UNBOUND_RE = re.compile(
     rf"^mr\(({_KEY}),\{{refund\((\d+),({_KEY})\)\}}\)$")
 _TIER_A_UNBOUND_RE = re.compile(
     rf"^mr\(multi_pq\(2,({_KEY}),({_KEY})\),\{{refund\((\d+),({_KEY})\)\}}\)$")
 _TIER_APLUS_UNBOUND_RE = re.compile(
-    rf"^mr\(ctv_multi_pq\(({_HASH256}),1,({_KEY})\),\{{refund\((\d+),({_KEY})\)\}}\)$")
+    rf"^mr\(ctv_pk\(({_HASH256}),({_KEY})\),\{{refund\((\d+),({_KEY})\)\}}\)$")
 
 
 def soft_bond_descriptor(settle_pubkey: str, refund_locktime: int, refund_pubkey: str) -> str:
@@ -217,7 +235,7 @@ def ctv_bond_descriptor(ctv_template_hash_hex: str, settle_pubkey: str,
     if (not isinstance(ctv_template_hash_hex, str) or
             not re.fullmatch(_HASH256, ctv_template_hash_hex)):
         raise ValueError("ctv_template_hash_hex must be 32 bytes of hex")
-    return (f"mr(ctv_multi_pq({ctv_template_hash_hex.lower()},1,{settle_pubkey}),"
+    return (f"mr(ctv_pk({ctv_template_hash_hex.lower()},{settle_pubkey}),"
             f"{{refund({refund_locktime},{refund_pubkey})}})")
 
 
@@ -292,7 +310,7 @@ def bind_bond_descriptor(descriptor: str, terms: dict) -> str:
 
     m = _TIER_APLUS_UNBOUND_RE.match(desc)
     if m:
-        return (f"mr(ctv_multi_pq({m.group(1)},1,{m.group(2)}),"
+        return (f"mr(ctv_pk({m.group(1)},{m.group(2)}),"
                 f"{{refund({m.group(3)},{m.group(4)}),commit({want})}})")
     m = _TIER_A_UNBOUND_RE.match(desc)
     if m:
@@ -479,7 +497,7 @@ class OfferVerification:
         }
 
 
-def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
+def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = RECOMMENDED_MIN_CONF,
                  require_attestation: bool = False,
                  expected_challenge: Optional[str] = None,
                  expected_venue_pubkey: Optional[str] = None,
@@ -504,6 +522,13 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
     if type(min_conf) is not int or min_conf < 0:
         check("parameters", False, "min_conf must be a non-negative integer")
         return OfferVerification(False, tier, address, 0, 0, checks)
+    if min_conf < RECOMMENDED_MIN_CONF:
+        check(
+            "min-conf-advisory",
+            True,
+            f"min_conf={min_conf} is below the recommended reorg-safe depth "
+            f"({RECOMMENDED_MIN_CONF})",
+        )
     if (expected_challenge is not None and
             (not isinstance(expected_challenge, str) or not expected_challenge)):
         check("parameters", False, "expected_challenge must be a non-empty string")
@@ -650,6 +675,44 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
                                  f"not the bond vault {address}") and all_utxos_ok
             continue
         confs = int(utxo.get("confirmations", 0))
+        # RBF only matters while the funding is UNCONFIRMED (it can then be
+        # fee-bump-replaced away after the buyer acts — the real T5 danger). Once
+        # confirmed, BIP125 signaling is moot (a mined tx cannot be replaced; only
+        # a reorg could undo it, which the confirmation-depth / min-conf-advisory
+        # checks cover). So only inspect the raw tx for a 0-conf outpoint — and a
+        # 0-conf tx is in the mempool, where getrawtransaction works WITHOUT
+        # -txindex, preserving the SDK's stock-node ("no txindex needed") promise.
+        if confs == 0:
+            rbf_note = ""
+            try:
+                tx_verbose = rpc("getrawtransaction", op["txid"], True)
+                if not isinstance(tx_verbose, dict):
+                    raise ValueError("getrawtransaction did not return a JSON object")
+                vin = tx_verbose.get("vin")
+                if not isinstance(vin, list):
+                    raise ValueError("getrawtransaction response has no vin array")
+                for i, txin in enumerate(vin):
+                    if not isinstance(txin, dict):
+                        raise ValueError(f"vin[{i}] is not a JSON object")
+                    sequence = txin.get("sequence")
+                    if type(sequence) is not int:
+                        raise ValueError(f"vin[{i}].sequence is missing or not an integer")
+                    if sequence < 0xFFFFFFFE:
+                        rbf_note = " and signals BIP125 replaceability"
+                        break
+            except Exception as e:  # noqa: BLE001
+                rbf_note = f" (BIP125 status undetermined: {e})"
+            all_utxos_ok = check(
+                "rbf-replaceable", False,
+                f"{op['txid']}:{op['vout']} is unconfirmed (0 conf){rbf_note}",
+            ) and all_utxos_ok
+            continue
+        # Confirmed: RBF is moot; do not fetch the raw tx (would need -txindex) and
+        # do not reject on the RBF flag (Core wallets signal RBF by default).
+        all_utxos_ok = check(
+            "rbf-replaceable", True,
+            f"{op['txid']}:{op['vout']} is confirmed (RBF moot post-confirmation)",
+        ) and all_utxos_ok
         if confs < min_conf:
             all_utxos_ok = check("outpoints", False,
                                  f"{op['txid']}:{op['vout']} has {confs} confirmations "
@@ -858,19 +921,32 @@ def build_swap_refund(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
 
 def selftest() -> None:
     """Offline sanity of the pure helpers (no node needed). Raises on failure."""
-    terms = {"version": 1, "amount_sats": 12345, "expiry_height": 100,
+    terms = {"version": 1, "amount_sats": MIN_BOND_SATS, "expiry_height": 100,
              "nonce": "00" * 16, "b": [1, {"a": "x"}]}
     # Canonicalization is order-insensitive and whitespace-free.
-    reordered = json.loads(json.dumps(terms)[::-1][::-1])
+    reordered = json.loads(json.dumps(terms)[::-1][::-1], object_pairs_hook=_no_dup_pairs)
     assert terms_hash(terms) == terms_hash(dict(reversed(list(reordered.items()))))
     assert canonical_terms_bytes(terms) == canonical_terms_bytes(reordered)
+    # Duplicate JSON keys are rejected at parse boundaries.
+    try:
+        json.loads('{"a":1,"a":2}', object_pairs_hook=_no_dup_pairs)
+        raise AssertionError("duplicate object keys must be rejected")
+    except ValueError:
+        pass
     # Floats are rejected.
     try:
-        terms_hash({"version": 1, "amount_sats": 1, "expiry_height": 1,
+        terms_hash({"version": 1, "amount_sats": MIN_BOND_SATS, "expiry_height": 1,
                     "nonce": "00", "price": 1.5})
         raise AssertionError("float in terms must be rejected")
     except ValueError:
         pass
+    # Bond amount floor rejects permanently unclaimable dust-level offers.
+    try:
+        validate_terms({"version": 1, "amount_sats": 1, "expiry_height": 1, "nonce": "x"})
+        raise AssertionError("sub-floor amount_sats must be rejected")
+    except ValueError:
+        pass
+    validate_terms({"version": 1, "amount_sats": MIN_BOND_SATS, "expiry_height": 1, "nonce": "x"})
     assert commitment_leaf_expr(terms) == f"commit({terms_hash_hex(terms)})"
     # Descriptor round-trips for all tiers. create_offer performs this binding
     # automatically before funding; the pure helper is pinned here.
@@ -883,6 +959,7 @@ def selftest() -> None:
     assert (a.tier, a.venue_pubkey, a.refund_locktime) == ("A", k3, 901)
     ap_desc = bind_bond_descriptor(ctv_bond_descriptor("11" * 32, k1, 902, k2), terms)
     ap = parse_bond_descriptor(ap_desc)
+    assert f"ctv_pk({'11' * 32},{k1})" in ap_desc
     assert (ap.tier, ap.ctv_hash, ap.refund_locktime) == ("A+", "11" * 32, 902)
     assert b.commitment_hash == a.commitment_hash == ap.commitment_hash == terms_hash_hex(terms)
     # SLH-DSA key forms parse too.
@@ -916,7 +993,7 @@ def selftest() -> None:
             pass
     # The verifier's fail-closed parser rejects a hand-crafted timestamp-domain
     # bond even though it is numerically >= a (height) expiry.
-    evil_terms = {"version": 1, "amount_sats": 1, "expiry_height": 100, "nonce": "00" * 16}
+    evil_terms = {"version": 1, "amount_sats": MIN_BOND_SATS, "expiry_height": 100, "nonce": "00" * 16}
     evil_desc = bind_bond_descriptor(f"mr({k1},{{refund({ts_lock},{k2})}})", evil_terms)
     try:
         parse_bond_descriptor(evil_desc)
@@ -929,7 +1006,7 @@ def selftest() -> None:
     assert parse_bond_descriptor(ok_desc).refund_locktime == ts - 1
     # terms.expiry_height in the timestamp domain is rejected.
     try:
-        validate_terms({"version": 1, "amount_sats": 1, "expiry_height": ts, "nonce": "x"})
+        validate_terms({"version": 1, "amount_sats": MIN_BOND_SATS, "expiry_height": ts, "nonce": "x"})
         raise AssertionError("timestamp-domain expiry_height must be rejected")
     except ValueError:
         pass
@@ -984,7 +1061,7 @@ def _make_cli_rpc(cli_cmd: str) -> Rpc:
         if not text:
             return None
         try:
-            return json.loads(text)
+            return json.loads(text, object_pairs_hook=_no_dup_pairs)
         except json.JSONDecodeError:
             return text  # bare-string results (e.g. signmessage)
     return rpc
@@ -992,7 +1069,7 @@ def _make_cli_rpc(cli_cmd: str) -> Rpc:
 
 def _load_json(path: str) -> dict:
     with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        return json.load(f, object_pairs_hook=_no_dup_pairs)
 
 
 def main(argv=None) -> int:
@@ -1013,7 +1090,7 @@ def main(argv=None) -> int:
 
     sp = sub.add_parser("verify", help="verify an offer bundle against the node")
     sp.add_argument("bundle_json")
-    sp.add_argument("--min-conf", type=int, default=20)
+    sp.add_argument("--min-conf", type=int, default=RECOMMENDED_MIN_CONF)
     sp.add_argument("--require-attestation", action="store_true")
     sp.add_argument("--expected-challenge", default=None,
                     help="fresh buyer/venue challenge that the attestation must match")
@@ -1084,7 +1161,8 @@ def main(argv=None) -> int:
 
 
 __all__ = [
-    "OTC_TAG", "COINBASE_MATURITY", "SWAP_REORG_MARGIN_BLOCKS", "REQUIRED_TERMS_FIELDS",
+    "OTC_TAG", "COINBASE_MATURITY", "RECOMMENDED_MIN_CONF", "MIN_BOND_SATS",
+    "SWAP_REORG_MARGIN_BLOCKS", "REQUIRED_TERMS_FIELDS",
     "validate_terms", "canonical_terms_bytes",
     "terms_hash", "terms_hash_hex", "commitment_leaf_expr",
     "attestation_message", "soft_bond_descriptor", "venue_bond_descriptor",

--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -478,7 +478,8 @@ class OfferVerification:
 
 def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
                  require_attestation: bool = False,
-                 expected_challenge: Optional[str] = None) -> OfferVerification:
+                 expected_challenge: Optional[str] = None,
+                 expected_venue_pubkey: Optional[str] = None) -> OfferVerification:
     """
     Run the full §4.3 verification against a local node. Returns a report whose
     `ok` is True only if every executed check passed. Trust-minimized: nothing is
@@ -502,6 +503,10 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
     if (expected_challenge is not None and
             (not isinstance(expected_challenge, str) or not expected_challenge)):
         check("parameters", False, "expected_challenge must be a non-empty string")
+        return OfferVerification(False, tier, address, 0, 0, checks)
+    if (expected_venue_pubkey is not None and
+            (not isinstance(expected_venue_pubkey, str) or not expected_venue_pubkey)):
+        check("parameters", False, "expected_venue_pubkey must be a non-empty string")
         return OfferVerification(False, tier, address, 0, 0, checks)
 
     # C1 — terms are well-formed and canonicalizable.
@@ -549,6 +554,26 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
                  f" ctv_template_hash={bond.ctv_hash} terms_match={ctv_terms_ok}")
               + ("" if bond.refund_locktime >= expiry else
                  " (refund unlocks BEFORE offer expiry)"))
+        # Tier A's "the venue can grief but never take" guarantee holds ONLY if
+        # the 2-of-2 venue key is an independent party the buyer trusts. Nothing
+        # on-chain proves that: a seller can set venue_pubkey to a second key it
+        # controls, making the settlement path unilaterally seller-signable so
+        # the seller pulls the bond mid-quote (phantom supply). The buyer must
+        # PIN the venue key. Fail closed for tier A unless it is pinned and matches.
+        if bond.tier == "A":
+            if expected_venue_pubkey is None:
+                check("venue-key", False,
+                      f"tier A bond requires expected_venue_pubkey to prove the venue "
+                      f"is an independent party (descriptor venue_pubkey={bond.venue_pubkey}); "
+                      f"without it the 2-of-2 could be seller+seller and pullable mid-quote")
+            else:
+                venue_ok = (bond.venue_pubkey or "").lower() == expected_venue_pubkey.lower()
+                check("venue-key", venue_ok,
+                      f"descriptor venue_pubkey={bond.venue_pubkey}; "
+                      f"expected={expected_venue_pubkey}")
+        elif expected_venue_pubkey is not None:
+            check("venue-key", True,
+                  f"expected_venue_pubkey ignored for tier {bond.tier} (no venue leg)")
     except Exception as e:  # noqa: BLE001
         check("descriptor-shape", False, str(e))
         return OfferVerification(False, tier, address, 0, expiry, checks)
@@ -850,6 +875,11 @@ def selftest() -> None:
     except ValueError:
         pass
 
+    # Tier-A venue-key pinning: an empty expected_venue_pubkey is rejected in the
+    # offline parameter-validation stage (no node touched before it).
+    vrep = verify_offer(None, {"version": 1, "terms": {}}, expected_venue_pubkey="")
+    assert any(c.name == "parameters" and not c.ok for c in vrep.checks)
+
     # Amount formatting.
     assert sats_to_btx_str(5_000_000_000_000) == "50000.00000000"
     assert to_sat("50000.00000000") == 5_000_000_000_000
@@ -910,6 +940,9 @@ def main(argv=None) -> int:
     sp.add_argument("--require-attestation", action="store_true")
     sp.add_argument("--expected-challenge", default=None,
                     help="fresh buyer/venue challenge that the attestation must match")
+    sp.add_argument("--expected-venue-pubkey", default=None,
+                    help="for tier A: the independent venue's pubkey the 2-of-2 must "
+                         "use; required to trust a tier-A bond (else it fails closed)")
 
     sp = sub.add_parser("watch", help="watch a bundle's bond outpoints until spent/expired")
     sp.add_argument("bundle_json")
@@ -943,7 +976,8 @@ def main(argv=None) -> int:
     if args.cmd == "verify":
         report = verify_offer(rpc, _load_json(args.bundle_json), min_conf=args.min_conf,
                               require_attestation=args.require_attestation,
-                              expected_challenge=args.expected_challenge)
+                              expected_challenge=args.expected_challenge,
+                              expected_venue_pubkey=args.expected_venue_pubkey)
         print(json.dumps(report.as_dict(), indent=2))
         return 0 if report.ok else 1
 

--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -766,7 +766,13 @@ def swap_hash160_hex(preimage: bytes) -> str:
 def build_swap_claim(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
                      vout: int, preimage: bytes, dest_address: str,
                      fee_sat: int = 20000) -> str:
-    """Buyer claims the settlement vault with the preimage (reveals it on-chain)."""
+    """Build+sign the preimage-revealing claim tx (via buildhtlcclaim) and return hex; does not broadcast.
+
+    WARNING: broadcasting reveals the preimage on-chain. Confirm the HTLC funding
+    output is deeply confirmed and not RBF-replaceable before broadcasting; revealing
+    against unconfirmed or replaceable funding lets the counterparty replace that
+    funding and reuse the now-public preimage to take the other (cross-chain) leg.
+    """
     try:
         res = rpc_wallet("buildhtlcclaim", descriptor_with_checksum,
                          {"txid": txid, "vout": vout}, preimage.hex(),

--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -71,8 +71,10 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib.util
 import json
 import os
+from pathlib import Path
 import re
 import shlex
 import subprocess
@@ -84,9 +86,27 @@ from typing import Callable, Optional
 
 Rpc = Callable[..., object]
 
+try:
+    hashlib.new("ripemd160", b"")
+
+    def _ripemd160(data: bytes) -> bytes:
+        return hashlib.new("ripemd160", data).digest()
+except ValueError:
+    try:
+        from contrib.wbtx._ripemd160 import ripemd160 as _ripemd160
+    except ImportError:
+        _fallback = Path(__file__).resolve().parents[1] / "wbtx" / "_ripemd160.py"
+        spec = importlib.util.spec_from_file_location("btx_wbtx_ripemd160", _fallback)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"unable to load RIPEMD160 fallback from {_fallback}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _ripemd160 = module.ripemd160
+
 COIN = 100_000_000
 COINBASE_MATURITY = 100
 RECOMMENDED_MIN_CONF = 20
+MAX_VERIFY_OUTPOINTS = 1000
 # Funding below this floor is practically unspendable with the default helper
 # fee (20_000 sats) once dust and script overhead are accounted for.
 MIN_BOND_SATS = 20_000 + 1_000
@@ -303,6 +323,14 @@ def _validated_bond(bond: BondInfo) -> BondInfo:
     can be an immediately-spendable early-exit path — exactly the class of
     hidden early exit parse_bond_descriptor promises to reject."""
     require_block_height_locktime(bond.refund_locktime, "refund_locktime")
+    if bond.tier == "A":
+        settle_key = (bond.settle_pubkey or "").lower()
+        venue_key = (bond.venue_pubkey or "").lower()
+        if settle_key == venue_key:
+            raise ValueError(
+                "tier A descriptor has duplicate multi_pq keys "
+                "(settle_pubkey == venue_pubkey): this collapses 2-of-2 to one key"
+            )
     return bond
 
 
@@ -649,6 +677,13 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = RECOMMENDED_MIN_CONF,
     if not isinstance(outpoints, list):
         check("outpoints", False, "bond.outpoints must be a JSON array")
         return OfferVerification(False, tier, address, 0, expiry, checks)
+    if len(outpoints) > MAX_VERIFY_OUTPOINTS:
+        check(
+            "outpoints",
+            False,
+            f"bond.outpoints has {len(outpoints)} entries; max allowed is {MAX_VERIFY_OUTPOINTS}",
+        )
+        return OfferVerification(False, tier, address, 0, expiry, checks)
     seen = set()
     all_utxos_ok = len(outpoints) > 0
     if not outpoints:
@@ -900,7 +935,7 @@ def new_preimage() -> bytes:
 
 def swap_hash160_hex(preimage: bytes) -> str:
     """RIPEMD160(SHA256(preimage)) — same hashlock domain as the EVM HTLC contract."""
-    return hashlib.new("ripemd160", hashlib.sha256(preimage).digest()).hexdigest()
+    return _ripemd160(hashlib.sha256(preimage).digest()).hex()
 
 
 def build_swap_claim(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
@@ -986,6 +1021,12 @@ def selftest() -> None:
     a_desc = bind_bond_descriptor(venue_bond_descriptor(k1, k3, 901, k2), terms)
     a = parse_bond_descriptor(a_desc)
     assert (a.tier, a.venue_pubkey, a.refund_locktime) == ("A", k3, 901)
+    # Tier A duplicate multi_pq keys are rejected (must remain independent 2-of-2).
+    try:
+        parse_bond_descriptor(bind_bond_descriptor(venue_bond_descriptor(k1, k1, 901, k2), terms))
+        raise AssertionError("tier A duplicate settle/venue keys must be rejected")
+    except ValueError:
+        pass
     ap_desc = bind_bond_descriptor(ctv_bond_descriptor("11" * 32, k1, 902, k2), terms)
     ap = parse_bond_descriptor(ap_desc)
     assert f"ctv_pk({'11' * 32},{k1})" in ap_desc
@@ -1074,6 +1115,19 @@ def selftest() -> None:
     vrep = verify_offer(_tier_selftest_rpc, tier_bundle, expected_ctv_template_hash="22" * 32)
     assert any(c.name == "ctv-template" and not c.ok and
                "pins tier A+ but bond is tier B" in c.detail for c in vrep.checks)
+    # Outpoint bundles above the hard cap are rejected before per-outpoint RPC churn.
+    oversized_bundle = {
+        "version": 1,
+        "terms": tier_terms,
+        "bond": {
+            "descriptor": tier_b_desc,
+            "tier": "B",
+            "outpoints": [{"txid": "11" * 32, "vout": i} for i in range(MAX_VERIFY_OUTPOINTS + 1)],
+        },
+    }
+    vrep = verify_offer(_tier_selftest_rpc, oversized_bundle)
+    assert any(c.name == "outpoints" and not c.ok and
+               "max allowed" in c.detail for c in vrep.checks)
 
     # Cross-leg timeout asymmetry helper: other+margin must be STRICTLY below BTX.
     check_swap_timeout_asymmetry(btx_refund_height=1000, other_leg_deadline_height=900)
@@ -1088,6 +1142,8 @@ def selftest() -> None:
         raise AssertionError("too-tight timeout asymmetry must fail closed")
     except ValueError:
         pass
+    # swap_hash160 fallback path uses same test vector as wBTX helper.
+    assert swap_hash160_hex(bytes([0x42]) * 32) == "8739f40ec4dbf569dcb38134c6e7310908566981"
 
     # Amount formatting.
     assert sats_to_btx_str(5_000_000_000_000) == "50000.00000000"

--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -75,6 +75,36 @@ COINBASE_MATURITY = 100
 # binding is a hidden P2MR `commit(sha256(terms))` leaf, not an OP_RETURN output.
 OTC_TAG = b"BTXOTC1"
 
+# Consensus locktime domain split (BIP65 / CheckLockTime): a CLTV value (and a
+# tx nLockTime) BELOW this is a block HEIGHT; AT OR ABOVE it is a Unix TIMESTAMP.
+# The whole OTC escrow is height-denominated (terms.expiry_height, the C5
+# height<expiry check), and a refund leaf must out-live the offer's expiry
+# HEIGHT. A refund_locktime >= this threshold is therefore NOT a "far-future
+# height" — it is a timestamp, and any value just above the threshold is a
+# timestamp already ~10 years in the past, i.e. a CLTV that is spendable NOW.
+# Comparing such a value numerically against a block height (refund_locktime >=
+# expiry_height) is a domain confusion that lets a seller advertise an
+# "unpullable until expiry" bond whose refund is in fact immediately spendable.
+# All escrow/vault locktimes MUST be in the height domain so the numeric
+# comparison against expiry_height is meaningful.
+LOCKTIME_THRESHOLD = 500_000_000
+
+
+def require_block_height_locktime(value: int, field: str) -> int:
+    """Fail closed unless `value` is a CLTV/nLockTime in the BLOCK-HEIGHT domain
+    (0 < value < LOCKTIME_THRESHOLD). Rejects the timestamp domain, which would
+    make a height-vs-locktime comparison meaningless and can encode an
+    immediately-spendable refund. Returns the value for convenient chaining."""
+    if type(value) is not int or isinstance(value, bool):
+        raise ValueError(f"{field} must be an integer block height")
+    if value <= 0 or value >= LOCKTIME_THRESHOLD:
+        raise ValueError(
+            f"{field}={value} is not a block-height locktime: it must satisfy "
+            f"0 < {field} < {LOCKTIME_THRESHOLD} (LOCKTIME_THRESHOLD). A value "
+            f">= the threshold is a Unix-timestamp locktime — comparing it to a "
+            f"block height is a domain confusion and can be spendable immediately.")
+    return value
+
 
 # ============================= terms canonicalization =============================
 
@@ -110,6 +140,9 @@ def validate_terms(terms: dict) -> None:
         raise ValueError("terms.amount_sats must be a positive integer (satoshis)")
     if type(terms["expiry_height"]) is not int or terms["expiry_height"] <= 0:
         raise ValueError("terms.expiry_height must be a positive integer (block height)")
+    # expiry_height is a block height; a value in the timestamp domain would
+    # make the refund_locktime >= expiry_height covering check meaningless.
+    require_block_height_locktime(terms["expiry_height"], "terms.expiry_height")
     if not isinstance(terms["nonce"], str) or not terms["nonce"]:
         raise ValueError("terms.nonce must be a non-empty string")
 
@@ -162,12 +195,14 @@ _TIER_APLUS_UNBOUND_RE = re.compile(
 
 def soft_bond_descriptor(settle_pubkey: str, refund_locktime: int, refund_pubkey: str) -> str:
     """Tier B: seller settles unilaterally pre-expiry; refund leaf after expiry."""
+    require_block_height_locktime(refund_locktime, "refund_locktime")
     return f"mr({settle_pubkey},{{refund({refund_locktime},{refund_pubkey})}})"
 
 
 def venue_bond_descriptor(settle_pubkey: str, venue_pubkey: str,
                           refund_locktime: int, refund_pubkey: str) -> str:
     """Tier A: 2-of-2 seller+venue settlement handoff; seller-only refund after expiry."""
+    require_block_height_locktime(refund_locktime, "refund_locktime")
     return (f"mr(multi_pq(2,{settle_pubkey},{venue_pubkey}),"
             f"{{refund({refund_locktime},{refund_pubkey})}})")
 
@@ -175,6 +210,7 @@ def venue_bond_descriptor(settle_pubkey: str, venue_pubkey: str,
 def ctv_bond_descriptor(ctv_template_hash_hex: str, settle_pubkey: str,
                         refund_locktime: int, refund_pubkey: str) -> str:
     """Tier A+: settlement constrained by covenant to one pre-committed transaction."""
+    require_block_height_locktime(refund_locktime, "refund_locktime")
     if (not isinstance(ctv_template_hash_hex, str) or
             not re.fullmatch(_HASH256, ctv_template_hash_hex)):
         raise ValueError("ctv_template_hash_hex must be 32 bytes of hex")
@@ -206,21 +242,31 @@ def parse_bond_descriptor(descriptor: str) -> BondInfo:
     desc = strip_checksum(descriptor).replace(" ", "")
     m = _TIER_APLUS_RE.match(desc)
     if m:
-        return BondInfo(tier="A+", ctv_hash=m.group(1).lower(), settle_pubkey=m.group(2),
+        return _validated_bond(BondInfo(tier="A+", ctv_hash=m.group(1).lower(), settle_pubkey=m.group(2),
                         refund_locktime=int(m.group(3)), refund_pubkey=m.group(4),
-                        commitment_hash=m.group(5).lower())
+                        commitment_hash=m.group(5).lower()))
     m = _TIER_A_RE.match(desc)
     if m:
-        return BondInfo(tier="A", settle_pubkey=m.group(1), venue_pubkey=m.group(2),
+        return _validated_bond(BondInfo(tier="A", settle_pubkey=m.group(1), venue_pubkey=m.group(2),
                         refund_locktime=int(m.group(3)), refund_pubkey=m.group(4),
-                        commitment_hash=m.group(5).lower())
+                        commitment_hash=m.group(5).lower()))
     m = _TIER_B_RE.match(desc)
     if m:
-        return BondInfo(tier="B", settle_pubkey=m.group(1),
+        return _validated_bond(BondInfo(tier="B", settle_pubkey=m.group(1),
                         refund_locktime=int(m.group(2)), refund_pubkey=m.group(3),
-                        commitment_hash=m.group(4).lower())
+                        commitment_hash=m.group(4).lower()))
     raise ValueError("unrecognized bond descriptor shape (fail-closed); "
                      "expected a terms-bound tier A+/A/B form")
+
+
+def _validated_bond(bond: BondInfo) -> BondInfo:
+    """Fail closed on a parsed bond whose refund locktime is not a block height.
+    A timestamp-domain refund_locktime (>= LOCKTIME_THRESHOLD) would make the
+    downstream `refund_locktime >= expiry_height` covering check meaningless and
+    can be an immediately-spendable early-exit path — exactly the class of
+    hidden early exit parse_bond_descriptor promises to reject."""
+    require_block_height_locktime(bond.refund_locktime, "refund_locktime")
+    return bond
 
 
 def bind_bond_descriptor(descriptor: str, terms: dict) -> str:
@@ -675,6 +721,10 @@ def build_bond_refund(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
 def swap_vault_descriptor(preimage_hash160_hex: str, claimer_pubkey: str, refund_locktime: int,
                           sender_pubkey: str) -> str:
     """Stage-2, two-leaf HTLC settlement vault (identical to the wBTX Model-B leg)."""
+    # Same domain rule as the bond refund: the HTLC refund leaf's locktime must
+    # be a block height so its relation to the offer/expiry is meaningful and it
+    # is not immediately spendable as a past timestamp.
+    require_block_height_locktime(refund_locktime, "refund_locktime")
     return (f"mr(htlc_tx({preimage_hash160_hex},{claimer_pubkey}),"
             f"refund({refund_locktime},{sender_pubkey}))")
 
@@ -763,6 +813,43 @@ def selftest() -> None:
             raise AssertionError(f"must fail closed: {bad[:40]}...")
         except ValueError:
             pass
+    # Locktime domain guard: a refund_locktime in the TIMESTAMP domain
+    # (>= LOCKTIME_THRESHOLD) is a hidden immediately-spendable early exit and
+    # MUST fail closed everywhere — parse, build, and terms validation.
+    ts = LOCKTIME_THRESHOLD              # first timestamp-domain value
+    ts_lock = LOCKTIME_THRESHOLD + 1     # a timestamp ~10 years in the past
+    # Builders reject it.
+    for build in (
+        lambda: soft_bond_descriptor(k1, ts_lock, k2),
+        lambda: venue_bond_descriptor(k1, k3, ts_lock, k2),
+        lambda: ctv_bond_descriptor("11" * 32, k1, ts_lock, k2),
+        lambda: swap_vault_descriptor("ab" * 20, k1, ts_lock, k2),
+    ):
+        try:
+            build()
+            raise AssertionError("timestamp-domain refund_locktime must be rejected at build")
+        except ValueError:
+            pass
+    # The verifier's fail-closed parser rejects a hand-crafted timestamp-domain
+    # bond even though it is numerically >= a (height) expiry.
+    evil_terms = {"version": 1, "amount_sats": 1, "expiry_height": 100, "nonce": "00" * 16}
+    evil_desc = bind_bond_descriptor(f"mr({k1},{{refund({ts_lock},{k2})}})", evil_terms)
+    try:
+        parse_bond_descriptor(evil_desc)
+        raise AssertionError("parse_bond_descriptor must reject a timestamp-domain refund locktime")
+    except ValueError:
+        pass
+    assert ts_lock >= evil_terms["expiry_height"]  # the confusion the numeric check missed
+    # A height-domain bond at exactly the threshold-minus-one still parses.
+    ok_desc = bind_bond_descriptor(f"mr({k1},{{refund({ts - 1},{k2})}})", evil_terms)
+    assert parse_bond_descriptor(ok_desc).refund_locktime == ts - 1
+    # terms.expiry_height in the timestamp domain is rejected.
+    try:
+        validate_terms({"version": 1, "amount_sats": 1, "expiry_height": ts, "nonce": "x"})
+        raise AssertionError("timestamp-domain expiry_height must be rejected")
+    except ValueError:
+        pass
+
     # Amount formatting.
     assert sats_to_btx_str(5_000_000_000_000) == "50000.00000000"
     assert to_sat("50000.00000000") == 5_000_000_000_000

--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -50,6 +50,22 @@ Verification NEVER trusts the seller: descriptor shape is checked against a stri
 allow-list (unknown shapes fail closed), outpoints are checked in the UTXO set,
 the descriptor's terms-hash commitment is checked against the vault output, and the
 optional attestation is checked with verifymessage.
+
+Spend-signing & key-reuse safety (audit guidance):
+  * SIGHASH_ALL: every escrow/HTLC spend this SDK helps build must be signed with
+    SIGHASH_ALL. A non-ALL sighash (NONE/SINGLE/ANYONECANPAY) leaves the spend's
+    outputs malleable by a third party — never sign an escrow spend with anything
+    but ALL. (The P2MR script layer permits non-ALL by design; the safety lives
+    in HOW you sign.)
+  * CSFS key/message uniqueness: OP_CHECKSIGFROMSTACK verifies a signature over a
+    witness-supplied message, so a revealed (signature, message/preimage) pair
+    REPLAYS on any output that reuses the same key + message. Prefer the
+    transaction-bound htlc_tx() leaf (which this SDK uses) over a bare csfs()
+    leaf; never reuse a CSFS/oracle key across offers, and bind each CSFS message
+    to a unique per-offer context (the terms hash / nonce already provide this).
+  * Confirmation depth: treat a bond as real supply only at a reorg-safe depth
+    (>= COINBASE_MATURITY here); shallow/RBF-replaceable funding is rejected by
+    verify_offer, but off-chain settlement decisions must respect depth too.
 """
 from __future__ import annotations
 

--- a/contrib/otc/btx_otc.py
+++ b/contrib/otc/btx_otc.py
@@ -88,6 +88,9 @@ OTC_TAG = b"BTXOTC1"
 # All escrow/vault locktimes MUST be in the height domain so the numeric
 # comparison against expiry_height is meaningful.
 LOCKTIME_THRESHOLD = 500_000_000
+# Cross-leg HTLC safety margin in BTX blocks. This is materially above the
+# observed ~6-block mainnet reorg depth (~30 minutes at ~90-second blocks).
+SWAP_REORG_MARGIN_BLOCKS = 20
 
 
 def require_block_height_locktime(value: int, field: str) -> int:
@@ -479,7 +482,8 @@ class OfferVerification:
 def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
                  require_attestation: bool = False,
                  expected_challenge: Optional[str] = None,
-                 expected_venue_pubkey: Optional[str] = None) -> OfferVerification:
+                 expected_venue_pubkey: Optional[str] = None,
+                 expected_ctv_template_hash: Optional[str] = None) -> OfferVerification:
     """
     Run the full §4.3 verification against a local node. Returns a report whose
     `ok` is True only if every executed check passed. Trust-minimized: nothing is
@@ -507,6 +511,12 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
     if (expected_venue_pubkey is not None and
             (not isinstance(expected_venue_pubkey, str) or not expected_venue_pubkey)):
         check("parameters", False, "expected_venue_pubkey must be a non-empty string")
+        return OfferVerification(False, tier, address, 0, 0, checks)
+    if (expected_ctv_template_hash is not None and
+            (not isinstance(expected_ctv_template_hash, str) or
+             not re.fullmatch(_HASH256, expected_ctv_template_hash))):
+        check("parameters", False,
+              "expected_ctv_template_hash must be a non-empty 32-byte hex string")
         return OfferVerification(False, tier, address, 0, 0, checks)
 
     # C1 — terms are well-formed and canonicalizable.
@@ -574,6 +584,22 @@ def verify_offer(rpc: Rpc, bundle: dict, min_conf: int = 20,
         elif expected_venue_pubkey is not None:
             check("venue-key", True,
                   f"expected_venue_pubkey ignored for tier {bond.tier} (no venue leg)")
+        if bond.tier == "A+":
+            if expected_ctv_template_hash is None:
+                check("ctv-template", False,
+                      "tier A+ requires expected_ctv_template_hash (independently "
+                      "derived by the buyer from the agreed settlement outputs) to "
+                      "prove the covenant pays the buyer; the descriptor+terms hash "
+                      "is seller-supplied")
+            else:
+                ctv_ok = bond.ctv_hash.lower() == expected_ctv_template_hash.lower()
+                check("ctv-template", ctv_ok,
+                      f"descriptor ctv_template_hash={bond.ctv_hash}; "
+                      f"expected={expected_ctv_template_hash}")
+        elif expected_ctv_template_hash is not None:
+            check("ctv-template", True,
+                  f"expected_ctv_template_hash ignored for tier {bond.tier} "
+                  f"(no CTV covenant leg)")
     except Exception as e:  # noqa: BLE001
         check("descriptor-shape", False, str(e))
         return OfferVerification(False, tier, address, 0, expiry, checks)
@@ -743,6 +769,30 @@ def build_bond_refund(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
     return res["hex"]
 
 
+def check_swap_timeout_asymmetry(btx_refund_height: int, other_leg_deadline_height: int,
+                                 reorg_margin_blocks: int = SWAP_REORG_MARGIN_BLOCKS) -> None:
+    """Fail closed unless the BTX refund is safely LATER than the other leg deadline:
+    other_leg_deadline_height + reorg_margin_blocks < btx_refund_height. Both
+    values are BTX block heights (convert an EVM unix timeout first, e.g.
+    current_height + (evm_timeout_unix - now_unix)//block_seconds). This prevents
+    claim-one-leg/refund-the-other theft and leaves reorg/censorship margin after
+    a preimage-revealing claim."""
+    require_block_height_locktime(btx_refund_height, "btx_refund_height")
+    require_block_height_locktime(other_leg_deadline_height, "other_leg_deadline_height")
+    if (type(reorg_margin_blocks) is not int or isinstance(reorg_margin_blocks, bool) or
+            reorg_margin_blocks < 1):
+        raise ValueError("reorg_margin_blocks must be an integer >= 1")
+    if other_leg_deadline_height + reorg_margin_blocks >= btx_refund_height:
+        required_min = other_leg_deadline_height + reorg_margin_blocks + 1
+        raise ValueError(
+            "unsafe cross-leg timeout asymmetry: requires "
+            "other_leg_deadline_height + reorg_margin_blocks < btx_refund_height; "
+            f"got btx_refund_height={btx_refund_height}, "
+            f"other_leg_deadline_height={other_leg_deadline_height}, "
+            f"reorg_margin_blocks={reorg_margin_blocks}. "
+            f"Need btx_refund_height >= {required_min}.")
+
+
 def swap_vault_descriptor(preimage_hash160_hex: str, claimer_pubkey: str, refund_locktime: int,
                           sender_pubkey: str) -> str:
     """Stage-2, two-leaf HTLC settlement vault (identical to the wBTX Model-B leg)."""
@@ -772,6 +822,9 @@ def build_swap_claim(rpc_wallet: Rpc, descriptor_with_checksum: str, txid: str,
     output is deeply confirmed and not RBF-replaceable before broadcasting; revealing
     against unconfirmed or replaceable funding lets the counterparty replace that
     funding and reuse the now-public preimage to take the other (cross-chain) leg.
+    The integrator MUST also validate cross-leg timeout asymmetry with
+    check_swap_timeout_asymmetry(...) before funding, per doc §5 and
+    WBTXAtomicSwapHTLC.sol.
     """
     try:
         res = rpc_wallet("buildhtlcclaim", descriptor_with_checksum,
@@ -885,6 +938,24 @@ def selftest() -> None:
     # offline parameter-validation stage (no node touched before it).
     vrep = verify_offer(None, {"version": 1, "terms": {}}, expected_venue_pubkey="")
     assert any(c.name == "parameters" and not c.ok for c in vrep.checks)
+    # Tier-A+ CTV pinning: an empty expected_ctv_template_hash is rejected in the
+    # same offline parameter-validation stage (no node touched before it).
+    vrep = verify_offer(None, {"version": 1, "terms": {}}, expected_ctv_template_hash="")
+    assert any(c.name == "parameters" and not c.ok for c in vrep.checks)
+
+    # Cross-leg timeout asymmetry helper: other+margin must be STRICTLY below BTX.
+    check_swap_timeout_asymmetry(btx_refund_height=1000, other_leg_deadline_height=900)
+    check_swap_timeout_asymmetry(btx_refund_height=921, other_leg_deadline_height=900)
+    try:
+        check_swap_timeout_asymmetry(btx_refund_height=920, other_leg_deadline_height=900)
+        raise AssertionError("boundary case must fail: other+margin must be strictly lower")
+    except ValueError:
+        pass
+    try:
+        check_swap_timeout_asymmetry(btx_refund_height=910, other_leg_deadline_height=900)
+        raise AssertionError("too-tight timeout asymmetry must fail closed")
+    except ValueError:
+        pass
 
     # Amount formatting.
     assert sats_to_btx_str(5_000_000_000_000) == "50000.00000000"
@@ -949,6 +1020,9 @@ def main(argv=None) -> int:
     sp.add_argument("--expected-venue-pubkey", default=None,
                     help="for tier A: the independent venue's pubkey the 2-of-2 must "
                          "use; required to trust a tier-A bond (else it fails closed)")
+    sp.add_argument("--expected-ctv-template-hash", default=None,
+                    help="for tier A+: buyer-derived settlement CTV template hash that "
+                         "must match the descriptor covenant (else it fails closed)")
 
     sp = sub.add_parser("watch", help="watch a bundle's bond outpoints until spent/expired")
     sp.add_argument("bundle_json")
@@ -983,7 +1057,8 @@ def main(argv=None) -> int:
         report = verify_offer(rpc, _load_json(args.bundle_json), min_conf=args.min_conf,
                               require_attestation=args.require_attestation,
                               expected_challenge=args.expected_challenge,
-                              expected_venue_pubkey=args.expected_venue_pubkey)
+                              expected_venue_pubkey=args.expected_venue_pubkey,
+                              expected_ctv_template_hash=args.expected_ctv_template_hash)
         print(json.dumps(report.as_dict(), indent=2))
         return 0 if report.ok else 1
 
@@ -1009,14 +1084,16 @@ def main(argv=None) -> int:
 
 
 __all__ = [
-    "OTC_TAG", "COINBASE_MATURITY", "REQUIRED_TERMS_FIELDS", "validate_terms", "canonical_terms_bytes",
+    "OTC_TAG", "COINBASE_MATURITY", "SWAP_REORG_MARGIN_BLOCKS", "REQUIRED_TERMS_FIELDS",
+    "validate_terms", "canonical_terms_bytes",
     "terms_hash", "terms_hash_hex", "commitment_leaf_expr",
     "attestation_message", "soft_bond_descriptor", "venue_bond_descriptor",
     "ctv_bond_descriptor", "BondInfo", "parse_bond_descriptor", "bind_bond_descriptor", "strip_checksum",
     "add_checksum", "bond_address", "refund_key_address", "ensure_refund_attestation_descriptor",
     "sats_to_btx_str", "to_sat", "create_offer",
     "Check", "OfferVerification", "verify_offer", "watch_offer", "build_bond_refund",
-    "swap_vault_descriptor", "new_preimage", "swap_hash160_hex", "build_swap_claim",
+    "check_swap_timeout_asymmetry", "swap_vault_descriptor", "new_preimage", "swap_hash160_hex",
+    "build_swap_claim",
     "build_swap_refund", "selftest",
 ]
 

--- a/contrib/wbtx/.gitignore
+++ b/contrib/wbtx/.gitignore
@@ -3,3 +3,6 @@ lib/
 out/
 cache/
 broadcast/
+lib/
+out/
+cache/

--- a/contrib/wbtx/LAUNCH-CHECKLIST.md
+++ b/contrib/wbtx/LAUNCH-CHECKLIST.md
@@ -1,0 +1,82 @@
+# wBTX bridge + OTC escrow — pre-launch checklist (0.34.6)
+
+Status of the money-movement tooling as of the 0.34.6 hardening pass. This tracks what is **done in-repo**
+and what remains **before any real value flows**. It is the operational companion to `SECURITY.md`.
+
+> The wBTX EVM contracts are UNAUDITED reference implementations. This checklist gets the code to
+> "effectively launch-ready barring an external audit"; it does **not** substitute for that audit.
+
+## 0. What this hardening pass closed (done ✅)
+
+All defects from the community pre-ship review (2026-08-22) and four internal adversarial rounds, each
+cursor-authored → `forge test`/selftest-gated → deepseek-audited → committed (PR #137):
+
+- **Mint attestation binds BTX finality** (block hash/height/attested-frontier/deadline + bridgeId) and
+  enforces depth ≥ `MIN_CONFIRMATIONS=100` + expiry. *(F1)*
+- **Durable guardian veto**, **fail-closed breakers** (`limitsConfigured`, all-non-zero), **continuous
+  token-bucket window** (no 2× boundary burst), budget consumed at execution. *(F2/F9/F11)*
+- **In-contract timelocks** on verifier swap (7d) / signer rotation (7d) / veto-clear (48h) + guardian
+  cancel; `guardianDelay` floor (6h). *(F4)*
+- **Issuance bound to an immutable bridge**, allowance-gated burns (no confiscation), **compliance hook**
+  excludes issuance + gas-capped try/catch + immediate clear; pause-independent `mintRefund`. *(F8/F13)*
+- **Attested + reversible redeem fulfillment** (M-of-N + depth, `unfulfillRedeem`), **non-release-attested
+  refund** routed through the supply cap, pause-independent. *(F3/F10/F12)*
+- **HTLC claim-expiry** (disjoint claim/refund), **exact-amount custody**, corrected **Model-B flow** +
+  `check_timeout_ordering`, `MIN_TIMEOUT` 30m→6h. *(F5/F6/F7)*
+- **SDK** robust `to_sat` (Decimal), `find_deposits` minconf floor (100), ripemd160 portability. *(F14/F15)*
+- **OTC escrow rounds 1–4:** locktime-domain, tier-A venue-key pinning (+ round-4 tier-downgrade fix),
+  BIP68 masking, tier-A+ CTV verification + made buildable (`ctv_pk`), timeout-asymmetry helper + flow
+  docs, 0-conf/RBF/dup-key/sub-floor guards.
+- **P2MR script findings** (r1/r2/r7) verified: r1 already guarded (trailing-SIGHASH-byte rejection present
+  at both checksig sites); r2/r7 by-design, addressed with SDK usage docs. **No consensus change.**
+- **Solvency invariant fuzz suite** added (`test/WBTXInvariant.t.sol`).
+
+Tests: `forge test` green; Python SDK selftests green.
+
+## 1. MUST complete before real value (blocking)
+
+- [ ] **External professional audit** of `WBTXBridge.sol` / `WBTX.sol` / `WBTXAtomicSwapHTLC.sol`. This is the
+      top gate; the internal loop (cursor-write → deepseek-audit → review) is strong but not a substitute.
+- [ ] **Address audit findings** and re-run the full suite + invariants.
+- [ ] **Invariant-fuzz campaign at scale** — the new suite is the seed; run high `runs`/`depth` (and/or
+      Echidna/Medusa) in CI and keep the solvency invariant (`circulating wBTX ≤ net attested backing`) green.
+- [ ] **Signer-set independence** (the review's deepest point — worry about someone *becoming* the verifier):
+      M-of-N with genuinely independent operators + custody (HSM/threshold), documented rotation. Security
+      reduces to `min(signer honesty, dominant-producer honesty, governance-key security)`.
+- [ ] **Governance = Timelock owned by a multisig** for the bridge admin, WBTX admin, and the verifier admin
+      (three distinct signer sets where possible). The contracts *recommend* but cannot *enforce* this.
+- [ ] **Deploy/wiring dry-run on testnet:** the immutable-bridge ↔ token construction order, role provisioning
+      (GOVERNANCE/GUARDIAN/FEDERATION/PAUSER all granted — the constructor grants none), the attestation
+      relayer, and `setLimits` with conservative non-zero breakers **before** the first mint.
+- [ ] **Testnet burn-in** with the real signer topology across a reorg + a signer-stall event.
+
+## 2. SHOULD complete (strongly recommended)
+
+- [ ] **Re-derive `MIN_CONFIRMATIONS` and the timeout floors** against the chain's *actual* block-production
+      concentration and observed reorg depth (SECURITY.md Addenda I/II) — `100` is grounded in
+      `COINBASE_MATURITY`, but the honest bound depends on producer concentration; re-measure by payout
+      address, not coinbase tag.
+- [ ] **Off-chain liveness interlock:** relayer/attestor refuses to sign during a block/checkpoint stall;
+      post-stall stabilization buffer before resuming mints.
+- [ ] **Monitoring → automated pause:** watch role grants, verifier/signer proposals, large outflows,
+      backing-invariant divergence; wire to an automated `mintPaused`, tested under weekend/holiday conditions.
+- [ ] **Value-scaled caps** set from an attack-cost model (mintable-per-window < cost to rewrite that window).
+
+## 3. Roadmap (not blocking 0.34.6, tracked for later)
+
+- [ ] **SPV / light-client trustless-depth relay** (SECURITY.md Addendum II) to remove the federation from the
+      depth claim — the path to L2BEAT Stage-1/2 trust-minimization.
+- [ ] **Independently-coded verify/veto layer** (CCIP-RMN style) distinct from the bridge signer set.
+
+## 4. Integrator / operator invariants (usage, documented in the SDKs)
+
+- Sign every escrow/HTLC spend with **SIGHASH_ALL** (never NONE/SINGLE/ANYONECANPAY).
+- Never reuse a **CSFS/oracle key** across contexts; prefer `htlc_tx()` over bare `csfs()`; bind CSFS
+  messages to a unique per-contract context (terms hash / nonce / operation_id).
+- Treat a deposit/bond as real only at **≥ 100 confirmations** and non-RBF; `check_timeout_ordering()` is
+  necessary-but-not-sufficient — the preimage-holder must fund the long (BTX) leg and claim the short leg first.
+- Tier-A/A+ escrow verification is fail-closed only if the buyer **pins** the expected venue / CTV template
+  and runs verification against **their own** node.
+
+---
+*Companion to SECURITY.md and the 0.34.6 hardening PR #137.*

--- a/contrib/wbtx/README.md
+++ b/contrib/wbtx/README.md
@@ -19,8 +19,9 @@ evm/WBTXBridge.sol           Model A: federation lock-and-mint, HARDENED — EIP
                              timelock governance; pluggable IAttestationVerifier (+ ECDSAMultisigVerifier
                              v1, upgradeable to a zk verifier).
 evm/WBTXAtomicSwapHTLC.sol   Model B: trustless HTLC, hashlock = RIPEMD160(SHA256(preimage)) (BTX-compatible),
-                             SafeERC20 + balance-delta, squat-proof swap id, reentrancy-guarded.
-test/WBTX.t.sol              Foundry suite (21 tests: replay, EIP-712, threshold, circuit-breaker,
+                             SafeERC20 + exact-amount custody check, squat-proof swap id (requested amount bound),
+                             disjoint claim/refund windows, watchtower-callable refunds, reentrancy-guarded.
+test/WBTX.t.sol              Foundry suite (replay, EIP-712, threshold, circuit-breaker,
                              guardian veto, redeem/refund, granular pause, permit, EIP-3009, compliance
                              hook, backing-relation fuzz, HTLC) — all passing on OZ v5.6.1 / solc 0.8.24.
 btx_wbtx.py                  Python SDK over the BTX node RPCs (descriptors + PSBT)
@@ -67,11 +68,13 @@ identical 20-byte value for the BTX descriptor.
    ```
    - `<H160>` = `RIPEMD160(SHA256(preimage))` (hex, 20 bytes).
    - `<claimer_pk>` = the claimer's ML-DSA/SLH-DSA transaction-signing pubkey.
-   - `<locktime>` = absolute block height/time after which `<sender_pk>` may refund.
+   - `<locktime>` = absolute BTX block height after which `<sender_pk>` may refund.
    Add the checksum with `getdescriptorinfo`, derive with `deriveaddresses`, import with
    `importdescriptors`.
 2. **Fund** the derived address (`sendtoaddress`).
-3. **Claim (recipient)** — use the wallet RPC:
+3. **Safe role ordering (critical):** the BTX funder generates the preimage/hashlock, funds the long BTX
+   leg, then claims the short EVM leg first; this reveals the preimage so the recipient can claim BTX.
+4. **Claim (recipient, on BTX after EVM reveal)** — use the wallet RPC:
    ```
    buildhtlcclaim "<descriptor#cksum>" {"txid":"<txid>","vout":<n>} "<preimage_hex>" "<dest_address>" <fee_sat>
        -> {"hex":"<signed raw tx>", "complete":true}
@@ -80,7 +83,7 @@ identical 20-byte value for the BTX descriptor.
    (the wallet produces a normal P2MR transaction-bound PQ signature and injects the
    32-byte `hash160` preimage), signs, and returns the raw tx. Broadcast
    it with `sendrawtransaction` — the preimage is now on-chain, so the counterparty can claim the EVM leg.
-4. **Refund (sender)** — after `<locktime>`, use the wallet RPC:
+5. **Refund (sender)** — after `<locktime>`, use the wallet RPC:
    ```
    buildhtlcrefund "<descriptor#cksum>" {"txid":"<txid>","vout":<n>} "<dest_address>" <locktime> <fee_sat>
        -> {"hex":"<signed raw tx>", "complete":true}
@@ -93,11 +96,11 @@ graceful `NotImplementedError` on older nodes that lack them); it also automates
 preimage extraction. See the module docstring for an end-to-end example.
 
 ## SECURITY notes (read before using)
-- **Timeout ordering (Model B).** The party who can be left holding nothing must have the *longer*
-  refund timeout. Standard rule: the BTX leg's refund `<locktime>` (the value passed to the descriptor's
-  `refund(...)` leaf and to `buildhtlcrefund`) must be **strictly and safely longer** than the EVM leg's
-  `open(..., timeout)`, so the secret-revealer never loses the race. Pick conservative deltas (account
-  for BTX ~90s blocks and EVM finality); the node/SDK does not police the cross-chain gap — you must.
+- **Timeout ordering (Model B).** The preimage-holder must claim the earlier-expiring leg and fund the
+  later-expiring leg. Keep BTX refund `<locktime>` strictly/safely longer than EVM `open(..., timeout)`,
+  and enforce it with `check_timeout_ordering(...)` before deriving/funding the descriptor.
+- **Swap id + amount integrity (Model B).** `computeId` binds the requested `amount`, and `open()` now
+  enforces `received == amount`; fee-on-transfer / underfunded tokens are rejected with `AmountMismatch`.
 - **Hash-domain agreement.** Both chains MUST use `RIPEMD160(SHA256(preimage))`. A mismatch silently
   breaks atomicity. The contract and SDK enforce this; do not substitute keccak256/sha256-only.
 - **Replay/finality binding (Model A).** The mint statement binds `{evmChainId, bridgeId, btxTxid, vout,

--- a/contrib/wbtx/README.md
+++ b/contrib/wbtx/README.md
@@ -100,8 +100,9 @@ preimage extraction. See the module docstring for an end-to-end example.
   for BTX ~90s blocks and EVM finality); the node/SDK does not police the cross-chain gap — you must.
 - **Hash-domain agreement.** Both chains MUST use `RIPEMD160(SHA256(preimage))`. A mismatch silently
   breaks atomicity. The contract and SDK enforce this; do not substitute keccak256/sha256-only.
-- **Replay binding (Model A).** The mint statement binds `{evmChainId, bridgeId, btxTxid, vout, to,
-  amountSat}`; an attestation cannot be replayed across chains/bridges/deposits/recipients/amounts.
+- **Replay/finality binding (Model A).** The mint statement binds `{evmChainId, bridgeId, btxTxid, vout,
+  btxBlockHash, btxBlockHeight, attestedHeight, to, amountSat, deadline}`; signatures are chain/bridge/
+  deposit/recipient/amount specific, finality-depth enforceable, and time-bounded.
 - **EVM-leg trust (Model A v1).** `ECDSAMultisigVerifier` is *classical* M-of-N. The authoritative
   security is the PQ attestation on BTX; the BTX lock+refund bounds exposure. Upgrade the verifier to
   the zk-attestation path (architecture §8) to make the EVM leg post-quantum too.

--- a/contrib/wbtx/SECURITY.md
+++ b/contrib/wbtx/SECURITY.md
@@ -33,9 +33,11 @@ upgrade/init bug, (5) access-control/message-auth, (6) infinite-approval/fronten
 ## 2. Defense checklist → where implemented
 
 ### Bridge (`WBTXBridge` + `ECDSAMultisigVerifier`)
-- **EIP-712 typed attestation** with domain `{name,version,block.chainid,address(this)}` → cross-chain,
-  cross-bridge, **post-fork** replay all prevented. (Fixes the latent bug in the v0 draft, which
-  captured `chainid` at construction and would stay replayable on a forked chain.) *Class 2/3.*
+- **EIP-712 typed attestation** with domain `{name,version,block.chainid,address(this)}` and struct
+  `{bridgeId,btxTxid,vout,btxBlockHash,btxBlockHeight,attestedHeight,to,amountSat,deadline}` →
+  cross-chain/cross-bridge replay is prevented, mint statements are time-bounded, and depth is
+  enforceable on-chain via `MIN_CONFIRMATIONS = 100` (code-level floor). (Fixes the latent bug in the v0
+  draft, which captured `chainid` at construction and would stay replayable on a forked chain.) *Class 2/3.*
 - **Outpoint replay guard** `minted[depositKey(txid,vout)]`, set before mint (CEI); `depositKey` uses
   `abi.encode` (collision-safe). One mint per BTX deposit. *Class 3.*
 - **OZ `ECDSA.recover`** in the verifier → rejects high-s malleability, bad `v`, and `ecrecover==0`;

--- a/contrib/wbtx/SECURITY.md
+++ b/contrib/wbtx/SECURITY.md
@@ -82,10 +82,15 @@ upgrade/init bug, (5) access-control/message-auth, (6) infinite-approval/fronten
 - **`rescueERC20`** (SafeERC20) recovers *foreign* tokens mis-sent here; **cannot** touch wBTX. *Class 6.*
 
 ### HTLC (`WBTXAtomicSwapHTLC`)
-- **SafeERC20 + balance-delta accounting** → non-standard (USDT), fee-on-transfer, rebasing tokens
-  cannot break custody/insolvency. *Class 5 (Qubit/Meter).*
+- **SafeERC20 + exact-amount custody enforcement** (`received == requested amount`) rejects
+  fee-on-transfer/underfunded opens, so the swap id's requested amount and custodied amount cannot diverge.
+  *Class 5 (Qubit/Meter).*
 - **In-contract, sender-bound swap id** (`computeId`) → no `id`-squatting front-run. *(HTLC griefing.)*
-- **ReentrancyGuard** + CEI; **timeout sanity bounds** (`MIN/MAX_TIMEOUT`).
+- **Disjoint claim/refund windows:** `claim` is valid only before `timeout`, `refund` at/after `timeout`,
+  eliminating post-timeout dual-spend races.
+- **Watchtower-defensible refunds:** anyone may trigger a timed-out refund, but funds always return to the
+  original sender.
+- **ReentrancyGuard** + CEI; **timeout sanity bounds** (`MIN/MAX_TIMEOUT`, min 6h).
 - **Hash domain** `RIPEMD160(SHA256(preimage))` matches BTX `OP_HASH160` exactly (verified against a
   BTX node: preimage `0x42…42` → `8739f40ec4dbf569dcb38134c6e7310908566981`).
 
@@ -129,8 +134,9 @@ upgrade/init bug, (5) access-control/message-auth, (6) infinite-approval/fronten
   the zk/SPV verifier (architecture §C/§8).
 - **Federation key custody** is the dominant real-world risk (Ronin/Harmony/Multichain were all key
   compromises, not contract bugs). Require independent operators, HSM/threshold custody, and monitoring.
-- **HTLC cross-chain timeout asymmetry** cannot be enforced on-chain — the SDK/integrator MUST set the
-  slower/first leg's timeout strictly longer than the faster/second leg (e.g. BTX 24–48h vs EVM 6–12h).
+- **HTLC cross-chain timeout asymmetry** still cannot be inferred from on-chain state alone, but the SDK
+  now rejects unsafe pairings preflight via `check_timeout_ordering(...)`. Integrators must supply
+  conservative BTX block-time and reorg/stall margins when building descriptors.
 - **Frontend/supply-chain** (BadgerDAO) is out of contract scope — harden CDN/DNS and prefer finite
   approvals/permit.
 

--- a/contrib/wbtx/SECURITY.md
+++ b/contrib/wbtx/SECURITY.md
@@ -69,8 +69,11 @@ upgrade/init bug, (5) access-control/message-auth, (6) infinite-approval/fronten
   `receiveWithAuthorization`, `cancelAuthorization`) — gasless approvals AND gasless transfers /
   meta-transactions with random-nonce replay protection (Circle FiatToken pattern). `receiveWith-
   Authorization` is payee-gated (front-run safe).
-- **Role separation** (`MINTER_ROLE`/`BURNER_ROLE` held by the bridge, `PAUSER`/`UNPAUSER` separate,
-  `RESCUER`) via `AccessControlDefaultAdminRules` (2-step + delay). *Class 5.*
+- **Issuance bound to an immutable bridge**: `mint`/`burn`/`mintRefund` revert unless `msg.sender` is the
+  `bridge` set at construction (non-zero enforced) — no `MINTER_ROLE`/`BURNER_ROLE`, so a compromised admin
+  cannot grant issuance to an EOA. `burn`/`burnFrom` spend an ERC-20 allowance, so they cannot confiscate a
+  holder's balance. `PAUSER`/`UNPAUSER` and `RESCUER` remain separate via `AccessControlDefaultAdminRules`
+  (2-step + delay). *Class 5.*
 - **Issuance pause** (mint/burn) — the backing-safety lever — **without** freezing holder transfers
   (deliberate: no censorship lever; see Decisions).
 - **Optional compliance hook** (`IComplianceHook`) — default **OFF** (`address(0)` = neutral); only the

--- a/contrib/wbtx/SECURITY.md
+++ b/contrib/wbtx/SECURITY.md
@@ -52,8 +52,13 @@ upgrade/init bug, (5) access-control/message-auth, (6) infinite-approval/fronten
   threshold even with "valid" attestation. *Class 1/2 (tBTC pattern).*
 - **Granular pause** (`PAUSER_ROLE`): independent `mintPaused` (the critical backing-safety lever) and
   `redeemPaused`, so halting minting doesn't trap redemptions and vice versa. **Role separation** via
-  `AccessControlDefaultAdminRules` (2-step admin + enforced delay); `setVerifier`/`setLimits`/
-  `refundRedeem` are `GOVERNANCE_ROLE` (**must be a Timelock owned by a multisig**). *Class 5 (Poly).*
+  `AccessControlDefaultAdminRules` (2-step admin + enforced delay). Trust-anchor changes are
+  timelocked **in-contract**, not by convention: the verifier swap is `proposeVerifier`→`applyVerifier`
+  after `VERIFIER_DELAY` (7 days) with a `GUARDIAN_ROLE` `cancelPendingVerifier`; signer rotation is
+  `proposeRotation`→`applyRotation` after `ROTATION_DELAY` (7 days); a guardian veto is cleared only via
+  `proposeClearVeto`→`applyClearVeto` after `CLEAR_VETO_DELAY` (48h). `setLimits`/`refundRedeem` are
+  `GOVERNANCE_ROLE` and `setLimits` rejects a `guardianDelay` below `MIN_GUARDIAN_DELAY` (6h) or any
+  zero breaker (owner **should** still be a Timelock+multisig). *Class 5 (Poly).*
 - **Redeem safety:** `uint64` truncation guard; auditable `Redeem` records; `fulfillRedeem` (federation
   writes the BTX txid on-chain); `refundRedeem` (governance re-mints to the burner after
   `redeemRefundTimeout` if a redemption can't be honored) → no silently-lost funds. *renBTC/FBTC lesson.*

--- a/contrib/wbtx/SECURITY.md
+++ b/contrib/wbtx/SECURITY.md
@@ -50,8 +50,10 @@ upgrade/init bug, (5) access-control/message-auth, (6) infinite-approval/fronten
 - **Guardian veto / optimistic minting:** mints above `optimisticThresholdSat` are time-queued
   (`guardianDelay`); a `GUARDIAN_ROLE` can `cancelQueuedMint` within the window. Bounds a compromised
   threshold even with "valid" attestation. *Class 1/2 (tBTC pattern).*
-- **Granular pause** (`PAUSER_ROLE`): independent `mintPaused` (the critical backing-safety lever) and
-  `redeemPaused`, so halting minting doesn't trap redemptions and vice versa. **Role separation** via
+- **Granular pause** (asymmetric trust): independent `mintPaused` (the critical backing-safety lever) and
+  `redeemPaused`, so halting minting doesn't trap redemptions and vice versa. **Pausing is `PAUSER_ROLE`
+  (fast, low trust); unpausing requires `GOVERNANCE_ROLE`** — a low-trust key can trip a breaker but cannot
+  lift it. **Role separation** via
   `AccessControlDefaultAdminRules` (2-step admin + enforced delay). Trust-anchor changes are
   timelocked **in-contract**, not by convention: the verifier swap is `proposeVerifier`→`applyVerifier`
   after `VERIFIER_DELAY` (7 days) with a `GUARDIAN_ROLE` `cancelPendingVerifier`; signer rotation is

--- a/contrib/wbtx/_ripemd160.py
+++ b/contrib/wbtx/_ripemd160.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2021 Pieter Wuille
+# Copyright (c) 2026 The BTX developers
+# Distributed under the MIT software license.
+"""Pure Python RIPEMD-160 implementation vendored for contrib/wbtx."""
+
+# Message schedule indexes for the left path.
+ML = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    7, 4, 13, 1, 10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8,
+    3, 10, 14, 4, 9, 15, 8, 1, 2, 7, 0, 6, 13, 11, 5, 12,
+    1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7, 15, 14, 5, 6, 2,
+    4, 0, 5, 9, 7, 12, 2, 10, 14, 1, 3, 8, 11, 6, 15, 13,
+]
+
+# Message schedule indexes for the right path.
+MR = [
+    5, 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12,
+    6, 11, 3, 7, 0, 13, 5, 10, 14, 15, 8, 12, 4, 9, 1, 2,
+    15, 5, 1, 3, 7, 14, 6, 9, 11, 8, 12, 2, 10, 0, 4, 13,
+    8, 6, 4, 1, 3, 11, 15, 0, 5, 12, 2, 13, 9, 7, 10, 14,
+    12, 15, 10, 4, 1, 5, 8, 7, 6, 2, 13, 14, 0, 3, 9, 11,
+]
+
+# Rotation counts for the left path.
+RL = [
+    11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8,
+    7, 6, 8, 13, 11, 9, 7, 15, 7, 12, 15, 9, 11, 7, 13, 12,
+    11, 13, 6, 7, 14, 9, 13, 15, 14, 8, 13, 6, 5, 12, 7, 5,
+    11, 12, 14, 15, 14, 15, 9, 8, 9, 14, 5, 6, 8, 6, 5, 12,
+    9, 15, 5, 11, 6, 8, 13, 12, 5, 12, 13, 14, 11, 8, 5, 6,
+]
+
+# Rotation counts for the right path.
+RR = [
+    8, 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6,
+    9, 13, 15, 7, 12, 8, 9, 11, 7, 7, 12, 7, 6, 15, 13, 11,
+    9, 7, 15, 11, 8, 6, 6, 14, 12, 13, 5, 14, 13, 13, 7, 5,
+    15, 5, 8, 11, 14, 14, 6, 14, 6, 9, 12, 9, 12, 5, 15, 8,
+    8, 5, 12, 9, 12, 5, 14, 6, 8, 13, 6, 5, 15, 13, 11, 11,
+]
+
+# K constants for the left and right paths.
+KL = [0, 0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xA953FD4E]
+KR = [0x50A28BE6, 0x5C4DD124, 0x6D703EF3, 0x7A6D76E9, 0]
+
+
+def fi(x: int, y: int, z: int, i: int) -> int:
+    """The f1..f5 functions from the RIPEMD-160 specification."""
+    if i == 0:
+        return x ^ y ^ z
+    if i == 1:
+        return (x & y) | (~x & z)
+    if i == 2:
+        return (x | ~y) ^ z
+    if i == 3:
+        return (x & z) | (y & ~z)
+    if i == 4:
+        return x ^ (y | ~z)
+    raise ValueError("invalid RIPEMD-160 round")
+
+
+def rol(x: int, i: int) -> int:
+    """Rotate the bottom 32 bits of x left by i bits."""
+    return ((x << i) | ((x & 0xFFFFFFFF) >> (32 - i))) & 0xFFFFFFFF
+
+
+def compress(h0: int, h1: int, h2: int, h3: int, h4: int, block: bytes) -> tuple[int, int, int, int, int]:
+    """Compress state (h0..h4) with a 64-byte block."""
+    al, bl, cl, dl, el = h0, h1, h2, h3, h4
+    ar, br, cr, dr, er = h0, h1, h2, h3, h4
+    x = [int.from_bytes(block[4 * i:4 * (i + 1)], "little") for i in range(16)]
+
+    for j in range(80):
+        rnd = j >> 4
+        al = rol(al + fi(bl, cl, dl, rnd) + x[ML[j]] + KL[rnd], RL[j]) + el
+        al, bl, cl, dl, el = el, al, bl, rol(cl, 10), dl
+
+        ar = rol(ar + fi(br, cr, dr, 4 - rnd) + x[MR[j]] + KR[rnd], RR[j]) + er
+        ar, br, cr, dr, er = er, ar, br, rol(cr, 10), dr
+
+    return (
+        h1 + cl + dr,
+        h2 + dl + er,
+        h3 + el + ar,
+        h4 + al + br,
+        h0 + bl + cr,
+    )
+
+
+def ripemd160(data: bytes) -> bytes:
+    """Compute the RIPEMD-160 hash of data."""
+    state = (0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0)
+
+    for b in range(len(data) >> 6):
+        state = compress(*state, data[64 * b:64 * (b + 1)])
+
+    pad = b"\x80" + b"\x00" * ((119 - len(data)) & 63)
+    fin = data[len(data) & ~63:] + pad + (8 * len(data)).to_bytes(8, "little")
+
+    for b in range(len(fin) >> 6):
+        state = compress(*state, fin[64 * b:64 * (b + 1)])
+
+    return b"".join((h & 0xFFFFFFFF).to_bytes(4, "little") for h in state)

--- a/contrib/wbtx/btx_wbtx.py
+++ b/contrib/wbtx/btx_wbtx.py
@@ -11,6 +11,21 @@ Hash domain (CRITICAL): BTX P2MR HTLC leaves lock under OP_HASH160 = RIPEMD160(S
 The EVM contract hashes identically (sha256 + ripemd160 precompiles). Always use the SAME 32-byte
 preimage on both chains.
 
+Spend-signing & key-reuse safety (audit guidance):
+  * SIGHASH_ALL: sign every BTX-leg claim/refund with SIGHASH_ALL (the node's
+    buildhtlc{claim,refund} RPCs do). A non-ALL sighash leaves the spend's outputs
+    third-party-malleable. Never parameterize an escrow/HTLC spend to a non-ALL type.
+  * CSFS key/message uniqueness: a revealed (signature, message) pair for a CSFS key
+    replays on any output reusing that key + message. This SDK uses the
+    transaction-bound htlc_tx() leaf (not a bare csfs() leaf) and the federation
+    binds each attestation to a unique operation_id — keep it that way; never reuse
+    a CSFS/oracle key across contexts.
+  * Timeout ordering + flow: check_timeout_ordering() is NECESSARY BUT NOT SUFFICIENT
+    — the preimage-holder must FUND the long (BTX) leg and CLAIM the short (EVM) leg
+    first (the safe Model-B assignment), else the ordering alone does not prevent a
+    claim-one-leg/refund-the-other theft. Validate depth (>= 100) before treating a
+    deposit as final.
+
 The pure helpers (hashing, descriptor construction, address derivation, deposit scan, preimage
 extraction) work against any stock btxd. The funds-critical *spend* builders call the node's
 buildhtlc{claim,refund} wallet RPCs, which encapsulate control-block + preimage +

--- a/contrib/wbtx/btx_wbtx.py
+++ b/contrib/wbtx/btx_wbtx.py
@@ -51,12 +51,20 @@ End-to-end swap flow (BTX leg of a trustless BTX<->EVM atomic swap)::
         evm_timeout_unix=evm_timeout_unix,
         now_unix=now_unix,
         current_btx_height=current_btx_height,
-        block_seconds=worst_case_block_seconds,
+        min_block_seconds=fastest_plausible_block_seconds,
         reorg_margin_blocks=reorg_margin_blocks,
-    )  # descriptor() enforces safe timeout ordering before funds move
+    )  # descriptor() performs a static ordering check
     desc = add_checksum(rpc, leg.descriptor())   # mr(htlc_tx(h160,claimer),refund(lt,sender))
     addr = swap_address(rpc, desc)               # the single P2MR lock address
     import_watch(rpc_wallet, desc)               # so the wallet indexes deposits to it
+    # REQUIRED right before funding broadcast: re-check against the live tip height/time.
+    assert_timeout_ordering_at_tip(
+        rpc,
+        btx_refund_height=btx_refund_height,
+        evm_timeout_unix=evm_timeout_unix,
+        min_block_seconds=fastest_plausible_block_seconds,
+        reorg_margin_blocks=reorg_margin_blocks,
+    )
     # ... funder pays `addr`; funder also opens/claims the short EVM leg with the same hashlock ...
 
     dep = find_deposits(rpc_wallet, addr)[0]
@@ -109,23 +117,32 @@ def btx_hash160_hex(preimage: bytes) -> str:
 
 
 # ----------------------------- descriptors -----------------------------
+# `min_block_seconds` is the FASTEST plausible BTX block interval, used to bound the
+# EARLIEST wall-clock time the BTX refund height becomes spendable. It must not exceed
+# the chain's block target (nPowTargetSpacing = 90s): a larger value over-estimates
+# time-to-refund and would false-accept an unsafe cross-leg config. Cap it at the
+# target so "fastest plausible" can never be claimed slower than target.
+BTX_TARGET_BLOCK_SECONDS = 90
+MAX_REASONABLE_MIN_BLOCK_SECONDS = BTX_TARGET_BLOCK_SECONDS
 
 def check_timeout_ordering(
     btx_refund_height: int,
     evm_timeout_unix: int,
     now_unix: int,
     current_btx_height: int,
-    block_seconds: int,
+    min_block_seconds: int,
     reorg_margin_blocks: int,
 ) -> int:
     """Validate that BTX refund expiry safely out-lives EVM expiry.
 
-    BTX refund locktimes are height-based. Convert the height gap into wall-clock seconds with a
-    pessimistic block interval (`block_seconds`) and require:
+    BTX refund locktimes are height-based. Convert the height gap into wall-clock seconds with the
+    FASTEST plausible BTX block interval (`min_block_seconds`) and require:
 
-      btx_refund_unix > evm_timeout_unix + reorg_margin_blocks * block_seconds
+      btx_refund_unix > evm_timeout_unix + reorg_margin_blocks * min_block_seconds
 
-    so the BTX leg keeps a safety margin for reorg/stall risk after the EVM leg expires.
+    Using the fastest plausible interval is required for safety: if difficulty drops and blocks
+    arrive faster, the BTX refund is reachable sooner in wall-clock time.
+    A too-large interval can falsely accept unsafe cross-leg configs.
     Returns the estimated BTX refund unix timestamp when valid; otherwise raises ValueError.
     """
     if btx_refund_height <= 0:
@@ -136,20 +153,63 @@ def check_timeout_ordering(
         raise ValueError("btx_refund_height must be greater than current_btx_height")
     if evm_timeout_unix <= 0 or now_unix <= 0:
         raise ValueError("evm_timeout_unix and now_unix must be unix timestamps")
-    if block_seconds <= 0:
-        raise ValueError("block_seconds must be > 0")
+    if type(min_block_seconds) is not int or isinstance(min_block_seconds, bool):
+        raise ValueError("min_block_seconds must be an integer number of seconds")
+    if min_block_seconds <= 0:
+        raise ValueError("min_block_seconds must be > 0")
+    if min_block_seconds > MAX_REASONABLE_MIN_BLOCK_SECONDS:
+        raise ValueError(
+            f"min_block_seconds={min_block_seconds} is implausibly large; use the FASTEST plausible "
+            "BTX block interval so timeout ordering is checked against earliest refund arrival "
+            f"(must be <= {MAX_REASONABLE_MIN_BLOCK_SECONDS})"
+        )
     if reorg_margin_blocks < 0:
         raise ValueError("reorg_margin_blocks must be >= 0")
 
     blocks_until_refund = btx_refund_height - current_btx_height
-    btx_refund_unix = now_unix + blocks_until_refund * block_seconds
-    required_min_refund_unix = evm_timeout_unix + reorg_margin_blocks * block_seconds
+    btx_refund_unix = now_unix + blocks_until_refund * min_block_seconds
+    required_min_refund_unix = evm_timeout_unix + reorg_margin_blocks * min_block_seconds
     if btx_refund_unix <= required_min_refund_unix:
         raise ValueError(
             "Unsafe timeout ordering: BTX refund does not out-live EVM timeout by the required margin "
             f"(btx_refund_unix={btx_refund_unix}, required>{required_min_refund_unix})"
         )
     return btx_refund_unix
+
+
+def assert_timeout_ordering_at_tip(
+    rpc: Rpc,
+    btx_refund_height: int,
+    evm_timeout_unix: int,
+    min_block_seconds: int,
+    reorg_margin_blocks: int,
+) -> int:
+    """Re-run timeout ordering against the live tip immediately before funding.
+
+    This check is REQUIRED right before broadcasting funding for the BTX leg; descriptor-time
+    checks alone can go stale while heights/timestamps advance. Uses live tip height and tip block
+    time from the connected node and raises ValueError on unsafe ordering.
+    """
+    tip_height = rpc("getblockcount")
+    if type(tip_height) is not int or tip_height < 0:
+        raise ValueError(f"getblockcount returned invalid height: {tip_height!r}")
+    tip_hash = rpc("getblockhash", tip_height)
+    if not isinstance(tip_hash, str) or not tip_hash:
+        raise ValueError(f"getblockhash returned invalid hash for height {tip_height}: {tip_hash!r}")
+    tip_header = rpc("getblockheader", tip_hash)
+    if not isinstance(tip_header, dict):
+        raise ValueError(f"getblockheader returned invalid payload for {tip_hash}: {tip_header!r}")
+    tip_time = tip_header.get("time")
+    if type(tip_time) is not int or tip_time <= 0:
+        raise ValueError(f"getblockheader({tip_hash}) missing valid 'time': {tip_time!r}")
+    return check_timeout_ordering(
+        btx_refund_height=btx_refund_height,
+        evm_timeout_unix=evm_timeout_unix,
+        now_unix=tip_time,
+        current_btx_height=tip_height,
+        min_block_seconds=min_block_seconds,
+        reorg_margin_blocks=reorg_margin_blocks,
+    )
 
 
 @dataclass
@@ -162,17 +222,21 @@ class HtlcLeg:
     evm_timeout_unix: int
     now_unix: int
     current_btx_height: int
-    block_seconds: int
+    min_block_seconds: int
     reorg_margin_blocks: int
 
     def descriptor(self) -> str:
-        """The (checksum-less) mr() descriptor; add checksum via add_checksum(rpc, ...)."""
+        """The (checksum-less) mr() descriptor; add checksum via add_checksum(rpc, ...).
+
+        This runs the static timeout check. Before moving funds, callers MUST re-run
+        assert_timeout_ordering_at_tip(...) against the live tip.
+        """
         check_timeout_ordering(
             btx_refund_height=self.refund_locktime,
             evm_timeout_unix=self.evm_timeout_unix,
             now_unix=self.now_unix,
             current_btx_height=self.current_btx_height,
-            block_seconds=self.block_seconds,
+            min_block_seconds=self.min_block_seconds,
             reorg_margin_blocks=self.reorg_margin_blocks,
         )
         return (f"mr(htlc_tx({self.preimage_hash160_hex},{self.claimer_pubkey}),"
@@ -260,6 +324,9 @@ def build_claim(rpc_wallet: Rpc, descriptor_with_checksum: str, deposit: Deposit
     """
     Build+sign the HTLC CLAIM (recipient) spending `deposit` to `dest_address`, revealing `preimage`.
 
+    Pre-funding requirement: the integration must have called
+    assert_timeout_ordering_at_tip(...) immediately before broadcasting HTLC funding.
+
     Calls the node wallet RPC
         buildhtlcclaim "<desc#cksum>" {"txid","vout"} "<preimage_hex>" "<dest_address>" <fee_sat>
     which performs the audited control-block + preimage witness assembly and transaction signing.
@@ -290,6 +357,9 @@ def build_refund(rpc_wallet: Rpc, descriptor_with_checksum: str, deposit: Deposi
                  dest_address: str, locktime: int, fee_sat: int = 1000) -> str:
     """
     Build+sign the HTLC REFUND (sender) reclaiming `deposit` to `dest_address` after `locktime`.
+
+    Pre-funding requirement: the integration must have called
+    assert_timeout_ordering_at_tip(...) immediately before broadcasting HTLC funding.
 
     Calls the node wallet RPC
         buildhtlcrefund "<desc#cksum>" {"txid","vout"} "<dest_address>" <locktime> <fee_sat>
@@ -337,8 +407,8 @@ def extract_preimage(rpc: Rpc, claim_txid: str, expected_hash160_hex: str) -> Op
 
 __all__ = [
     "new_preimage", "btx_hash160", "btx_hash160_hex", "HtlcLeg", "add_checksum", "swap_address",
-    "import_watch", "Deposit", "find_deposits", "to_sat", "sat_to_wbtx", "check_timeout_ordering", "build_claim",
-    "build_refund", "extract_preimage",
+    "import_watch", "Deposit", "find_deposits", "to_sat", "sat_to_wbtx", "check_timeout_ordering",
+    "assert_timeout_ordering_at_tip", "build_claim", "build_refund", "extract_preimage",
 ]
 
 
@@ -352,7 +422,7 @@ if __name__ == "__main__":
             evm_timeout_unix=now + 1_700,
             now_unix=now,
             current_btx_height=1_000_000,
-            block_seconds=90,
+            min_block_seconds=90,
             reorg_margin_blocks=2,
         )
     except ValueError:
@@ -366,7 +436,7 @@ if __name__ == "__main__":
         evm_timeout_unix=now + 1_700,
         now_unix=now,
         current_btx_height=1_000_000,
-        block_seconds=90,
+        min_block_seconds=90,
         reorg_margin_blocks=2,
     )
     print("timeout ordering self-check OK")

--- a/contrib/wbtx/btx_wbtx.py
+++ b/contrib/wbtx/btx_wbtx.py
@@ -19,24 +19,36 @@ marked NotImplementedError is raised on older nodes that lack the RPCs (graceful
 
 End-to-end swap flow (BTX leg of a trustless BTX<->EVM atomic swap)::
 
-    from btx_wbtx import (new_preimage, btx_hash160_hex, HtlcLeg, add_checksum,
+    from btx_wbtx import (HtlcLeg, add_checksum,
                           swap_address, import_watch, find_deposits, build_claim, build_refund)
 
     # rpc / rpc_wallet are callables: rpc(method, *params) -> parsed JSON (raise on error).
-    secret = new_preimage()                      # 32-byte swap secret (keep private until claim)
-    h160   = btx_hash160_hex(secret)             # == RIPEMD160(SHA256(secret)); use on BOTH chains
+    # SAFE role assignment: the BTX funder generates the secret + hashlock, funds BTX (long leg),
+    # then claims EVM (short leg) first to reveal the preimage. The recipient uses that
+    # revealed preimage to claim BTX before BTX refund height.
+    h160 = hashlock_from_btx_funder              # RIPEMD160(SHA256(preimage)); same on BOTH chains
 
-    leg = HtlcLeg(claimer_pubkey=recipient_pk, sender_pubkey=funder_pk, preimage_hash160_hex=h160,
-                  refund_locktime=btx_refund_height)   # BTX timeout STRICTLY > EVM timeout
+    leg = HtlcLeg(
+        claimer_pubkey=recipient_pk,
+        sender_pubkey=funder_pk,
+        preimage_hash160_hex=h160,
+        refund_locktime=btx_refund_height,       # absolute BTX block height
+        evm_timeout_unix=evm_timeout_unix,
+        now_unix=now_unix,
+        current_btx_height=current_btx_height,
+        block_seconds=worst_case_block_seconds,
+        reorg_margin_blocks=reorg_margin_blocks,
+    )  # descriptor() enforces safe timeout ordering before funds move
     desc = add_checksum(rpc, leg.descriptor())   # mr(htlc_tx(h160,claimer),refund(lt,sender))
     addr = swap_address(rpc, desc)               # the single P2MR lock address
     import_watch(rpc_wallet, desc)               # so the wallet indexes deposits to it
-    # ... funder pays `addr`; counterparty opens the EVM leg under the SAME hashlock h160 ...
+    # ... funder pays `addr`; funder also opens/claims the short EVM leg with the same hashlock ...
 
     dep = find_deposits(rpc_wallet, addr)[0]
-    # Recipient claims, revealing the preimage with a transaction-bound wallet signature:
-    raw = build_claim(rpc_wallet, desc, dep, secret, recipient_dest_addr, fee_sat=1000)
-    rpc("sendrawtransaction", raw)               # preimage now public -> claim the EVM leg
+    # Recipient claims BTX using the preimage that was revealed when the funder claimed EVM:
+    revealed_preimage = secret_from_evm_claim
+    raw = build_claim(rpc_wallet, desc, dep, revealed_preimage, recipient_dest_addr, fee_sat=1000)
+    rpc("sendrawtransaction", raw)
 
     # OR, if the swap is abandoned, the funder refunds after refund_locktime:
     raw = build_refund(rpc_wallet, desc, dep, funder_dest_addr, btx_refund_height, fee_sat=1000)
@@ -45,6 +57,7 @@ End-to-end swap flow (BTX leg of a trustless BTX<->EVM atomic swap)::
 from __future__ import annotations
 import hashlib
 import os
+import time
 from dataclasses import dataclass
 from typing import Callable, Optional
 
@@ -70,16 +83,71 @@ def btx_hash160_hex(preimage: bytes) -> str:
 
 # ----------------------------- descriptors -----------------------------
 
+def check_timeout_ordering(
+    btx_refund_height: int,
+    evm_timeout_unix: int,
+    now_unix: int,
+    current_btx_height: int,
+    block_seconds: int,
+    reorg_margin_blocks: int,
+) -> int:
+    """Validate that BTX refund expiry safely out-lives EVM expiry.
+
+    BTX refund locktimes are height-based. Convert the height gap into wall-clock seconds with a
+    pessimistic block interval (`block_seconds`) and require:
+
+      btx_refund_unix > evm_timeout_unix + reorg_margin_blocks * block_seconds
+
+    so the BTX leg keeps a safety margin for reorg/stall risk after the EVM leg expires.
+    Returns the estimated BTX refund unix timestamp when valid; otherwise raises ValueError.
+    """
+    if btx_refund_height <= 0:
+        raise ValueError("btx_refund_height must be a positive absolute BTX block height")
+    if current_btx_height < 0:
+        raise ValueError("current_btx_height must be non-negative")
+    if btx_refund_height <= current_btx_height:
+        raise ValueError("btx_refund_height must be greater than current_btx_height")
+    if evm_timeout_unix <= 0 or now_unix <= 0:
+        raise ValueError("evm_timeout_unix and now_unix must be unix timestamps")
+    if block_seconds <= 0:
+        raise ValueError("block_seconds must be > 0")
+    if reorg_margin_blocks < 0:
+        raise ValueError("reorg_margin_blocks must be >= 0")
+
+    blocks_until_refund = btx_refund_height - current_btx_height
+    btx_refund_unix = now_unix + blocks_until_refund * block_seconds
+    required_min_refund_unix = evm_timeout_unix + reorg_margin_blocks * block_seconds
+    if btx_refund_unix <= required_min_refund_unix:
+        raise ValueError(
+            "Unsafe timeout ordering: BTX refund does not out-live EVM timeout by the required margin "
+            f"(btx_refund_unix={btx_refund_unix}, required>{required_min_refund_unix})"
+        )
+    return btx_refund_unix
+
+
 @dataclass
 class HtlcLeg:
     """Parameters of the BTX HTLC leg of a swap."""
     claimer_pubkey: str    # recipient's ML-DSA hex (or pk_slh(...)): claims with preimage + their sig
     sender_pubkey: str     # funder's ML-DSA hex (or pk_slh(...)): refunds after locktime
     preimage_hash160_hex: str
-    refund_locktime: int   # absolute block height (or unix time) for the refund leaf
+    refund_locktime: int   # absolute BTX block height for the refund leaf
+    evm_timeout_unix: int
+    now_unix: int
+    current_btx_height: int
+    block_seconds: int
+    reorg_margin_blocks: int
 
     def descriptor(self) -> str:
-        """The (checksum-less) mr() descriptor; add a checksum via add_checksum(rpc, ...)."""
+        """The (checksum-less) mr() descriptor; add checksum via add_checksum(rpc, ...)."""
+        check_timeout_ordering(
+            btx_refund_height=self.refund_locktime,
+            evm_timeout_unix=self.evm_timeout_unix,
+            now_unix=self.now_unix,
+            current_btx_height=self.current_btx_height,
+            block_seconds=self.block_seconds,
+            reorg_margin_blocks=self.reorg_margin_blocks,
+        )
         return (f"mr(htlc_tx({self.preimage_hash160_hex},{self.claimer_pubkey}),"
                 f"refund({self.refund_locktime},{self.sender_pubkey}))")
 
@@ -230,6 +298,36 @@ def extract_preimage(rpc: Rpc, claim_txid: str, expected_hash160_hex: str) -> Op
 
 __all__ = [
     "new_preimage", "btx_hash160", "btx_hash160_hex", "HtlcLeg", "add_checksum", "swap_address",
-    "import_watch", "Deposit", "find_deposits", "to_sat", "sat_to_wbtx", "build_claim",
+    "import_watch", "Deposit", "find_deposits", "to_sat", "sat_to_wbtx", "check_timeout_ordering", "build_claim",
     "build_refund", "extract_preimage",
 ]
+
+
+if __name__ == "__main__":
+    now = int(time.time())
+    # Unsafe: BTX timeout is too close to EVM timeout after margin.
+    rejected = False
+    try:
+        check_timeout_ordering(
+            btx_refund_height=1_000_020,
+            evm_timeout_unix=now + 1_700,
+            now_unix=now,
+            current_btx_height=1_000_000,
+            block_seconds=90,
+            reorg_margin_blocks=2,
+        )
+    except ValueError:
+        rejected = True
+    if not rejected:
+        raise SystemExit("self-check failed: unsafe timeout ordering was accepted")
+
+    # Safe: BTX timeout remains well beyond EVM timeout + margin.
+    check_timeout_ordering(
+        btx_refund_height=1_000_200,
+        evm_timeout_unix=now + 1_700,
+        now_unix=now,
+        current_btx_height=1_000_000,
+        block_seconds=90,
+        reorg_margin_blocks=2,
+    )
+    print("timeout ordering self-check OK")

--- a/contrib/wbtx/btx_wbtx.py
+++ b/contrib/wbtx/btx_wbtx.py
@@ -55,6 +55,7 @@ End-to-end swap flow (BTX leg of a trustless BTX<->EVM atomic swap)::
     rpc("sendrawtransaction", raw)
 """
 from __future__ import annotations
+from decimal import Decimal, InvalidOperation
 import hashlib
 import os
 import time
@@ -67,6 +68,17 @@ Rpc = Callable[..., object]
 
 # ----------------------------- hashing / preimage -----------------------------
 
+try:
+    hashlib.new("ripemd160", b"")
+
+    def _ripemd160(data: bytes) -> bytes:
+        return hashlib.new("ripemd160", data).digest()
+except ValueError:
+    try:
+        from ._ripemd160 import ripemd160 as _ripemd160
+    except ImportError:
+        from _ripemd160 import ripemd160 as _ripemd160
+
 def new_preimage() -> bytes:
     """A fresh 32-byte swap secret."""
     return os.urandom(32)
@@ -74,7 +86,7 @@ def new_preimage() -> bytes:
 
 def btx_hash160(preimage: bytes) -> bytes:
     """RIPEMD160(SHA256(preimage)) — the 20-byte hashlock used by BOTH chains."""
-    return hashlib.new("ripemd160", hashlib.sha256(preimage).digest()).digest()
+    return _ripemd160(hashlib.sha256(preimage).digest())
 
 
 def btx_hash160_hex(preimage: bytes) -> str:
@@ -180,19 +192,31 @@ class Deposit:
     confirmations: int
 
 
-def find_deposits(rpc_wallet: Rpc, address: str, minconf: int = 0) -> list[Deposit]:
-    """List UTXOs paid to the (imported) HTLC/lock address — for relayers/orchestrators."""
+def find_deposits(rpc_wallet: Rpc, address: str, minconf: int = 100, unsafe: bool = False) -> list[Deposit]:
+    """List UTXOs paid to the HTLC/lock address, enforcing a 100-conf safety floor by default."""
+    if minconf < 100 and not unsafe:
+        raise ValueError("minconf below safety floor (100); pass unsafe=True to override explicitly")
     out = []
     for u in rpc_wallet("listunspent", minconf, 9_999_999, [address]):
-        out.append(Deposit(u["txid"], u["vout"], str(u["amount"]), int(u.get("confirmations", 0))))
+        confirmations = int(u.get("confirmations", 0))
+        if confirmations < minconf:
+            continue
+        out.append(Deposit(u["txid"], u["vout"], str(u["amount"]), confirmations))
     return out
 
 
-def to_sat(amount_btx: str) -> int:
-    """Convert a node decimal-BTX string to int satoshis (8 dp) exactly."""
-    whole, _, frac = amount_btx.partition(".")
-    frac = (frac + "00000000")[:8]
-    return int(whole) * 100_000_000 + int(frac)
+def to_sat(amount_btx: object) -> int:
+    """Convert a BTX amount into satoshis with exact 8-decimal precision."""
+    try:
+        d = Decimal(str(amount_btx))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"not a BTX amount: {amount_btx!r}") from exc
+    if not d.is_finite():
+        raise ValueError(f"not a BTX amount: {amount_btx!r}")
+    scaled = d.scaleb(8)
+    if scaled != scaled.to_integral_value():
+        raise ValueError(f"sub-satoshi precision: {amount_btx!r}")
+    return int(scaled)
 
 
 def sat_to_wbtx(amount_sat: int) -> int:
@@ -331,3 +355,46 @@ if __name__ == "__main__":
         reorg_margin_blocks=2,
     )
     print("timeout ordering self-check OK")
+
+    if to_sat("1e-08") != 1:
+        raise SystemExit("self-check failed: to_sat('1e-08') != 1")
+    if to_sat("0.00000001") != 1:
+        raise SystemExit("self-check failed: to_sat('0.00000001') != 1")
+    if to_sat(Decimal("50000.00000000")) != 5_000_000_000_000:
+        raise SystemExit("self-check failed: to_sat(Decimal('50000.00000000')) mismatch")
+
+    for bad_amount in ("0.000000001", "not-an-amount"):
+        try:
+            to_sat(bad_amount)
+        except ValueError:
+            pass
+        else:
+            raise SystemExit(f"self-check failed: to_sat({bad_amount!r}) should have raised ValueError")
+    print("to_sat self-check OK")
+
+    def _rpc_must_not_be_called(*_args) -> list[dict[str, object]]:
+        raise AssertionError("rpc_wallet should not be called when minconf floor rejects request")
+
+    try:
+        find_deposits(_rpc_must_not_be_called, "btx_guard_test_address", minconf=99, unsafe=False)
+    except ValueError:
+        pass
+    else:
+        raise SystemExit("self-check failed: minconf<100 without unsafe=True did not raise")
+
+    def _rpc_mixed_confirmations(method: str, *_params) -> list[dict[str, object]]:
+        if method != "listunspent":
+            raise AssertionError("unexpected RPC method")
+        return [
+            {"txid": "aa" * 32, "vout": 0, "amount": "0.10000000", "confirmations": 99},
+            {"txid": "bb" * 32, "vout": 1, "amount": "0.20000000", "confirmations": 100},
+        ]
+
+    filtered = find_deposits(_rpc_mixed_confirmations, "btx_filter_test_address", minconf=100)
+    if len(filtered) != 1 or filtered[0].txid != "bb" * 32:
+        raise SystemExit("self-check failed: confirmation filtering in find_deposits is incorrect")
+    print("find_deposits self-check OK")
+
+    if btx_hash160(bytes([0x42]) * 32).hex() != "8739f40ec4dbf569dcb38134c6e7310908566981":
+        raise SystemExit("self-check failed: btx_hash160 test vector mismatch")
+    print("btx_hash160 self-check OK")

--- a/contrib/wbtx/evm/WBTX.sol
+++ b/contrib/wbtx/evm/WBTX.sol
@@ -9,7 +9,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
-/// @dev Optional, governance-installed transfer-compliance hook. Reverts to block a transfer/mint/burn.
+/// @dev Optional, governance-installed transfer-compliance hook for holder transfers.
 ///      Unset by default (the token is credibly neutral); only a Timelock can install one.
 interface IComplianceHook {
     function check(address from, address to, uint256 amount) external view;
@@ -42,11 +42,12 @@ contract WBTX is ERC20, ERC20Permit, AccessControlDefaultAdminRules {
     using SafeERC20 for IERC20;
     using ECDSA for bytes32;
 
-    bytes32 public constant MINTER_ROLE   = keccak256("MINTER_ROLE");
-    bytes32 public constant BURNER_ROLE   = keccak256("BURNER_ROLE");
     bytes32 public constant PAUSER_ROLE   = keccak256("PAUSER_ROLE");   // fast, low-trust trigger
     bytes32 public constant UNPAUSER_ROLE = keccak256("UNPAUSER_ROLE"); // separate / higher-trust
     bytes32 public constant RESCUER_ROLE  = keccak256("RESCUER_ROLE");
+    uint256 public constant HOOK_GAS_CAP  = 100_000;
+
+    address public immutable bridge;
 
     // EIP-3009 typehashes (Circle FiatToken).
     bytes32 public constant TRANSFER_WITH_AUTHORIZATION_TYPEHASH =
@@ -79,14 +80,23 @@ contract WBTX is ERC20, ERC20Permit, AccessControlDefaultAdminRules {
     error AuthExpired();
     error AuthUsedOrCanceled();
     error CallerMustBePayee();
+    error NotBridge();
+    error BadComplianceHook();
 
     /// @param admin      DEFAULT_ADMIN (use a Timelock owned by a multisig). 2-step + `adminDelay`.
     /// @param adminDelay enforced delay (seconds) on DEFAULT_ADMIN transfer (e.g. 2 days).
-    constructor(address admin, uint48 adminDelay)
+    /// @param bridge_    immutable bridge authority for issuance primitives.
+    constructor(address admin, uint48 adminDelay, address bridge_)
         ERC20("Wrapped BTX", "wBTX")
         ERC20Permit("Wrapped BTX")
         AccessControlDefaultAdminRules(adminDelay, admin)
-    {}
+    {
+        // The bridge is the sole issuance authority and is immutable, so a zero
+        // or wrong address here would permanently brick mint/burn/mintRefund with
+        // no recovery. Fail closed at deploy.
+        if (bridge_ == address(0)) revert NotBridge();
+        bridge = bridge_;
+    }
 
     function decimals() public pure override returns (uint8) { return 18; }
 
@@ -94,11 +104,27 @@ contract WBTX is ERC20, ERC20Permit, AccessControlDefaultAdminRules {
 
     modifier whenIssuanceNotPaused() { if (issuancePaused) revert IssuanceIsPaused(); _; }
 
-    function mint(address to, uint256 value) external onlyRole(MINTER_ROLE) whenIssuanceNotPaused {
+    function mint(address to, uint256 value) external whenIssuanceNotPaused {
+        if (msg.sender != bridge) revert NotBridge();
         _mint(to, value);
     }
-    function burn(address from, uint256 value) external onlyRole(BURNER_ROLE) whenIssuanceNotPaused {
+
+    function burn(address from, uint256 value) external whenIssuanceNotPaused {
+        if (msg.sender != bridge) revert NotBridge();
+        _spendAllowance(from, msg.sender, value);
         _burn(from, value);
+    }
+
+    function burnFrom(address from, uint256 value) external whenIssuanceNotPaused {
+        _spendAllowance(from, msg.sender, value);
+        _burn(from, value);
+    }
+
+    /// @notice Pause-independent redemption-refund issuance path. Used so emergency issuance pauses
+    ///         cannot strand already-burned redeems awaiting governance refund.
+    function mintRefund(address to, uint256 value) external {
+        if (msg.sender != bridge) revert NotBridge();
+        _mint(to, value);
     }
 
     // ---- pause (asymmetric trust: fast to pause, slow to unpause) ----
@@ -108,15 +134,25 @@ contract WBTX is ERC20, ERC20Permit, AccessControlDefaultAdminRules {
 
     // ---- optional compliance hook (default OFF) ----
 
-    function setComplianceHook(IComplianceHook hook) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        complianceHook = hook;
-        emit ComplianceHookUpdated(address(hook));
+    function setComplianceHook(IComplianceHook newHook) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        address hookAddress = address(newHook);
+        if (hookAddress != address(0) && hookAddress.code.length == 0) revert BadComplianceHook();
+        complianceHook = newHook;
+        emit ComplianceHookUpdated(hookAddress);
     }
 
-    /// @dev Single transfer/mint/burn chokepoint; consults the compliance hook iff one is installed.
+    function clearComplianceHook() external onlyRole(PAUSER_ROLE) {
+        complianceHook = IComplianceHook(address(0));
+        emit ComplianceHookUpdated(address(0));
+    }
+
+    /// @dev Single transfer/mint/burn chokepoint. Hook applies to holder transfers only and fail-opens
+    ///      on hook faults so neither issuance nor transfers can be bricked by a bad hook contract.
     function _update(address from, address to, uint256 value) internal override {
         IComplianceHook hook = complianceHook;
-        if (address(hook) != address(0)) hook.check(from, to, value);
+        if (from != address(0) && to != address(0) && address(hook) != address(0)) {
+            try hook.check{gas: HOOK_GAS_CAP}(from, to, value) { } catch { }
+        }
         super._update(from, to, value);
     }
 

--- a/contrib/wbtx/evm/WBTXAtomicSwapHTLC.sol
+++ b/contrib/wbtx/evm/WBTXAtomicSwapHTLC.sol
@@ -37,7 +37,7 @@ contract WBTXAtomicSwapHTLC is ReentrancyGuard {
     }
 
     /// @dev Sanity bounds (NOT the cross-chain asymmetry rule). Tune per deployment.
-    uint64 public constant MIN_TIMEOUT = 30 minutes;
+    uint64 public constant MIN_TIMEOUT = 6 hours;
     uint64 public constant MAX_TIMEOUT = 30 days;
 
     mapping(bytes32 => Swap) public swaps;
@@ -53,9 +53,10 @@ contract WBTXAtomicSwapHTLC is ReentrancyGuard {
     error BadTimeout();
     error NotOpen();
     error BadPreimage();
+    error Expired();
     error TooEarly();
-    error NotSender();
     error NoValueReceived();
+    error AmountMismatch(uint256 requested, uint256 received);
 
     /// @dev BTX-compatible hashlock: RIPEMD160(SHA256(preimage)) (precompiles 0x02 then 0x03).
     function btxHash160(bytes calldata preimage) public pure returns (bytes20) {
@@ -84,12 +85,13 @@ contract WBTXAtomicSwapHTLC is ReentrancyGuard {
         id = computeId(recipient, token, amount, hashlock, timeout, salt);
         if (swaps[id].state != State.INVALID) revert IdExists();
 
-        // Balance-delta accounting: custody EXACTLY what arrived (fee-on-transfer/rebasing safe).
+        // Balance-delta accounting: reject fee-on-transfer underfunding and custody only exact swaps.
         IERC20 t = IERC20(token);
         uint256 before = t.balanceOf(address(this));
         t.safeTransferFrom(msg.sender, address(this), amount);
         uint256 received = t.balanceOf(address(this)) - before;
         if (received == 0) revert NoValueReceived();
+        if (received != amount) revert AmountMismatch(amount, received);
 
         swaps[id] = Swap({
             token: token, sender: msg.sender, recipient: recipient, amount: received,
@@ -102,17 +104,17 @@ contract WBTXAtomicSwapHTLC is ReentrancyGuard {
     function claim(bytes32 id, bytes calldata preimage) external nonReentrant {
         Swap storage s = swaps[id];
         if (s.state != State.OPEN) revert NotOpen();
+        if (block.timestamp >= s.timeout) revert Expired();
         if (btxHash160(preimage) != s.hashlock) revert BadPreimage();
         s.state = State.CLAIMED;                              // effects before interaction
         IERC20(s.token).safeTransfer(s.recipient, s.amount);
         emit Claimed(id, preimage);
     }
 
-    /// @notice Refund to the sender at/after timeout if unclaimed.
+    /// @notice Refund to the sender at/after timeout if unclaimed (callable by anyone).
     function refund(bytes32 id) external nonReentrant {
         Swap storage s = swaps[id];
         if (s.state != State.OPEN) revert NotOpen();
-        if (msg.sender != s.sender) revert NotSender();
         if (block.timestamp < s.timeout) revert TooEarly();
         s.state = State.REFUNDED;
         IERC20(s.token).safeTransfer(s.sender, s.amount);

--- a/contrib/wbtx/evm/WBTXBridge.sol
+++ b/contrib/wbtx/evm/WBTXBridge.sol
@@ -35,6 +35,9 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     uint256 public immutable bridgeId;
     /// @dev 1 BTX satoshi == SAT_SCALE units of 18-decimal wBTX (the decided standard). Mirrors WBTX.
     uint256 public constant SAT_SCALE = 1e10;
+    /// @dev Code-level minimum finality floor: matches BTX COINBASE_MATURITY (100) and is ~3x the
+    ///      observed 34-block reorg; this is not governance-settable.
+    uint64 public constant MIN_CONFIRMATIONS = 100;
 
     bytes32 public constant GOVERNANCE_ROLE = keccak256("GOVERNANCE_ROLE"); // Timelock
     bytes32 public constant GUARDIAN_ROLE   = keccak256("GUARDIAN_ROLE");   // veto/cancel + pause
@@ -42,7 +45,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     bytes32 public constant FEDERATION_ROLE = keccak256("FEDERATION_ROLE"); // marks redeems fulfilled
 
     bytes32 private constant MINT_TYPEHASH =
-        keccak256("MintAttestation(bytes32 btxTxid,uint32 vout,address to,uint64 amountSat)");
+        keccak256("MintAttestation(uint256 bridgeId,bytes32 btxTxid,uint32 vout,bytes32 btxBlockHash,uint64 btxBlockHeight,uint64 attestedHeight,address to,uint64 amountSat,uint64 deadline)");
 
     IAttestationVerifier public verifier;
     // Granular pause: mint-pause is the critical backing-safety lever; redeem-pause is for BTX-side
@@ -91,6 +94,9 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     error SupplyCapExceeded();
     error NotQueued();
     error TooEarly();
+    error AttestationExpired();
+    error NotAttested();
+    error TooShallow();
     error BadDestination();
     error BelowOneSat();
     error UnknownRedeem();
@@ -141,9 +147,35 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
 
     /// @notice EIP-712 typed digest the federation signs. Domain binds {name, version, block.chainid,
     ///         address(this)} (live chainid => no post-fork replay; verifyingContract => no cross-bridge
-    ///         replay). The struct binds the exact deposit, recipient, and amount.
-    function mintDigest(bytes32 btxTxid, uint32 vout, address to, uint64 amountSat) public view returns (bytes32) {
-        return _hashTypedDataV4(keccak256(abi.encode(MINT_TYPEHASH, btxTxid, vout, to, amountSat)));
+    ///         replay). The struct binds bridge identity, exact deposit and BTX finality view, recipient,
+    ///         amount, and attestation expiry.
+    function mintDigest(
+        uint256 bridgeId_,
+        bytes32 btxTxid,
+        uint32 vout,
+        bytes32 btxBlockHash,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        address to,
+        uint64 amountSat,
+        uint64 deadline
+    ) public view returns (bytes32) {
+        return _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    MINT_TYPEHASH,
+                    bridgeId_,
+                    btxTxid,
+                    vout,
+                    btxBlockHash,
+                    btxBlockHeight,
+                    attestedHeight,
+                    to,
+                    amountSat,
+                    deadline
+                )
+            )
+        );
     }
 
     function depositKey(bytes32 btxTxid, uint32 vout) public pure returns (bytes32) {
@@ -154,15 +186,41 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
 
     /// @notice Mint wBTX for an attested BTX lock. Small mints execute immediately; mints above
     ///         `optimisticThresholdSat` are time-queued for guardian review. Idempotent per deposit.
-    function mint(bytes32 btxTxid, uint32 vout, address to, uint64 amountSat, bytes calldata proof)
-        external whenMintNotPaused nonReentrant
-    {
+    function mint(
+        bytes32 btxTxid,
+        uint32 vout,
+        bytes32 btxBlockHash,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        address to,
+        uint64 amountSat,
+        uint64 deadline,
+        bytes calldata proof
+    ) external whenMintNotPaused nonReentrant {
         if (to == address(0)) revert BadDestination();
         if (amountSat == 0) revert BelowOneSat();
+        if (block.timestamp > deadline) revert AttestationExpired();
+        if (attestedHeight < btxBlockHeight) revert NotAttested();
+        if (attestedHeight - btxBlockHeight < MIN_CONFIRMATIONS) revert TooShallow();
         bytes32 dk = depositKey(btxTxid, vout);
         if (minted[dk] || queued[dk].exists) revert AlreadyMinted();
 
-        if (!verifier.verifyMint(mintDigest(btxTxid, vout, to, amountSat), proof)) revert BadAttestation();
+        if (
+            !verifier.verifyMint(
+                mintDigest(
+                    bridgeId,
+                    btxTxid,
+                    vout,
+                    btxBlockHash,
+                    btxBlockHeight,
+                    attestedHeight,
+                    to,
+                    amountSat,
+                    deadline
+                ),
+                proof
+            )
+        ) revert BadAttestation();
 
         _checkAndConsumeLimits(amountSat);
 

--- a/contrib/wbtx/evm/WBTXBridge.sol
+++ b/contrib/wbtx/evm/WBTXBridge.sol
@@ -51,6 +51,8 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     uint64 public constant CLEAR_VETO_DELAY = 48 hours;
     /// @dev Governance cannot shrink guardian review to near-zero.
     uint64 public constant MIN_GUARDIAN_DELAY = 6 hours;
+    uint64 public constant MIN_ADMIN_DELAY = 1 days;
+    uint64 public constant MIN_REDEEM_REFUND_TIMEOUT = 1 days;
 
     bytes32 private constant MINT_TYPEHASH =
         keccak256("MintAttestation(uint256 bridgeId,bytes32 btxTxid,uint32 vout,bytes32 btxBlockHash,uint64 btxBlockHeight,uint64 attestedHeight,address to,uint64 amountSat,uint64 deadline)");
@@ -103,6 +105,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     }
     uint256 public redeemNonce;
     mapping(uint256 => Redeem) public redeems;
+    mapping(uint256 => bool) public fulfillmentRevoked;
     uint64 public redeemRefundTimeout;     // after this, an unfulfilled redeem may be governance-refunded
     uint64 public constant FULFILL_REVOKE_WINDOW = 2 days;
 
@@ -140,13 +143,19 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     error TooShallow();
     error BadDestination();
     error BelowOneSat();
+    error BadWBTX();
     error UnknownRedeem();
     error RedeemClosed();
+    error BridgeBindingMismatch();
+    error AdminDelayTooLow();
     error VerifierNotContract();
     error VerifierNotReady();
     error ClearVetoNotReady();
     error GuardianDelayTooLow();
+    error ThresholdAboveWindowCap();
+    error RedeemRefundTimeoutTooLow();
     error RevokeWindowElapsed();
+    error FulfillmentPermanentlyRevoked();
 
     modifier whenMintNotPaused() { if (mintPaused) revert MintPaused(); _; }
     modifier whenRedeemNotPaused() { if (redeemPaused) revert RedeemPaused(); _; }
@@ -158,6 +167,10 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         address admin,          // Timelock-owned multisig
         uint48  adminDelay
     ) EIP712("WBTXBridge", "1") AccessControlDefaultAdminRules(adminDelay, admin) {
+        if (address(wbtx_) == address(0) || address(wbtx_).code.length == 0) revert BadWBTX();
+        if (address(verifier_) == address(0) || address(verifier_).code.length == 0) revert VerifierNotContract();
+        if (wbtx_.bridge() != address(this)) revert BridgeBindingMismatch();
+        if (uint64(adminDelay) < MIN_ADMIN_DELAY) revert AdminDelayTooLow();
         wbtx = wbtx_;
         verifier = verifier_;
         bridgeId = bridgeId_;
@@ -203,21 +216,46 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
                 || guardianDelay_ == 0
         ) revert ZeroBreakerValue();
         if (guardianDelay_ < MIN_GUARDIAN_DELAY) revert GuardianDelayTooLow();
+        if (optimisticThresholdSat_ > windowMintCapSat_) revert ThresholdAboveWindowCap();
+        if (redeemRefundTimeout_ < MIN_REDEEM_REFUND_TIMEOUT) revert RedeemRefundTimeoutTooLow();
         if (uint256(windowMintCapSat_) / uint256(windowDuration_) == 0) revert WindowRateZero();
+
+        uint64 nowTs = uint64(block.timestamp);
+        if (!limitsConfigured) {
+            availableSat = windowMintCapSat_;
+        } else {
+            uint64 elapsed = nowTs - lastRefill;
+            uint256 replenished = uint256(elapsed) * uint256(windowMintCapSat) / uint256(windowDuration);
+            uint256 available = uint256(availableSat) + replenished;
+            if (available > windowMintCapSat) available = windowMintCapSat;
+            if (available > windowMintCapSat_) available = windowMintCapSat_;
+            availableSat = uint64(available);
+        }
+
         maxSupplyWbtx = maxSupplyWbtx_;
         windowMintCapSat = windowMintCapSat_;
         windowDuration = windowDuration_;
         optimisticThresholdSat = optimisticThresholdSat_;
         guardianDelay = guardianDelay_;
         redeemRefundTimeout = redeemRefundTimeout_;
-        availableSat = windowMintCapSat_;
-        lastRefill = uint64(block.timestamp);
+        lastRefill = nowTs;
         limitsConfigured = true;
         emit LimitsUpdated(maxSupplyWbtx_, windowMintCapSat_, windowDuration_, optimisticThresholdSat_, guardianDelay_, redeemRefundTimeout_);
     }
 
-    function setMintPaused(bool p) external onlyRole(PAUSER_ROLE) { mintPaused = p; emit MintPausedSet(p, msg.sender); }
-    function setRedeemPaused(bool p) external onlyRole(PAUSER_ROLE) { redeemPaused = p; emit RedeemPausedSet(p, msg.sender); }
+    function setMintPaused(bool p) external {
+        if (p) _checkRole(PAUSER_ROLE, msg.sender);
+        else _checkRole(GOVERNANCE_ROLE, msg.sender);
+        mintPaused = p;
+        emit MintPausedSet(p, msg.sender);
+    }
+
+    function setRedeemPaused(bool p) external {
+        if (p) _checkRole(PAUSER_ROLE, msg.sender);
+        else _checkRole(GOVERNANCE_ROLE, msg.sender);
+        redeemPaused = p;
+        emit RedeemPausedSet(p, msg.sender);
+    }
 
     // ----------------------------- attestation -----------------------------
 
@@ -461,6 +499,8 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         Redeem storage r = redeems[redeemId];
         if (r.from == address(0)) revert UnknownRedeem();
         if (r.fulfilled || r.refunded) revert RedeemClosed();
+        if (fulfillmentRevoked[redeemId]) revert FulfillmentPermanentlyRevoked();
+        if (btxTxid == bytes32(0)) revert BadAttestation();
         if (block.timestamp > deadline) revert AttestationExpired();
         if (attestedHeight < btxBlockHeight) revert NotAttested();
         if (attestedHeight - btxBlockHeight < MIN_CONFIRMATIONS) revert TooShallow();
@@ -494,6 +534,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         if (block.timestamp > r.fulfilledAt + FULFILL_REVOKE_WINDOW) revert RevokeWindowElapsed();
 
         bytes32 releasedTxid = r.btxTxid;
+        fulfillmentRevoked[redeemId] = true;
         r.fulfilled = false;
         r.fulfilledAt = 0;
         r.btxTxid = bytes32(0);
@@ -511,7 +552,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     ) external onlyRole(GOVERNANCE_ROLE) nonReentrant {
         Redeem storage r = redeems[redeemId];
         if (r.from == address(0)) revert UnknownRedeem();
-        if (r.fulfilled || r.refunded) revert RedeemClosed();
+        if (r.refunded) revert RedeemClosed();
         if (block.timestamp < r.requestedAt + redeemRefundTimeout) revert TooEarly();
         if (block.timestamp > deadline) revert AttestationExpired();
         if (
@@ -528,6 +569,11 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
             )
         ) revert BadAttestation();
 
+        if (r.fulfilled) {
+            r.fulfilled = false;
+            r.fulfilledAt = 0;
+            r.btxTxid = bytes32(0);
+        }
         _checkAndConsumeLimits(r.amountSat);
         if (maxSupplyWbtx != 0 && wbtx.totalSupply() + r.amountWbtx > maxSupplyWbtx) revert SupplyCapExceeded();
 

--- a/contrib/wbtx/evm/WBTXBridge.sol
+++ b/contrib/wbtx/evm/WBTXBridge.sol
@@ -12,6 +12,8 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 ///      bridge passes the EIP-712 typed digest so the verifier is signature-scheme-agnostic.
 interface IAttestationVerifier {
     function verifyMint(bytes32 digest, bytes calldata proof) external view returns (bool);
+    function verifyFulfill(bytes32 digest, bytes calldata proof) external view returns (bool);
+    function verifyNonRelease(bytes32 digest, bytes calldata proof) external view returns (bool);
 }
 
 /// @title WBTXBridge — federation lock-and-mint bridge (Model A), hardened.
@@ -52,6 +54,14 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
 
     bytes32 private constant MINT_TYPEHASH =
         keccak256("MintAttestation(uint256 bridgeId,bytes32 btxTxid,uint32 vout,bytes32 btxBlockHash,uint64 btxBlockHeight,uint64 attestedHeight,address to,uint64 amountSat,uint64 deadline)");
+    bytes32 private constant REDEEM_FULFILL_TYPEHASH =
+        keccak256(
+            "RedeemFulfillment(uint256 bridgeId,uint256 redeemId,bytes32 btxTxid,bytes32 destHash,uint64 amountSat,uint64 btxBlockHeight,uint64 attestedHeight,uint64 deadline)"
+        );
+    bytes32 private constant REDEEM_NONRELEASE_TYPEHASH =
+        keccak256(
+            "RedeemNonRelease(uint256 bridgeId,uint256 redeemId,bytes32 destHash,uint64 amountSat,uint64 asOfBtxHeight,uint64 deadline)"
+        );
 
     IAttestationVerifier public verifier;
     IAttestationVerifier public pendingVerifier;
@@ -80,10 +90,21 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     mapping(bytes32 => uint64) public clearVetoEta;
 
     // --- redeem lifecycle (auditable + refundable) ---
-    struct Redeem { address from; uint64 amountSat; uint256 amountWbtx; uint64 requestedAt; bool fulfilled; bool refunded; }
+    struct Redeem {
+        address from;
+        uint64 amountSat;
+        uint256 amountWbtx;
+        uint64 requestedAt;
+        uint64 fulfilledAt;
+        bytes32 destHash;
+        bytes32 btxTxid;
+        bool fulfilled;
+        bool refunded;
+    }
     uint256 public redeemNonce;
     mapping(uint256 => Redeem) public redeems;
     uint64 public redeemRefundTimeout;     // after this, an unfulfilled redeem may be governance-refunded
+    uint64 public constant FULFILL_REVOKE_WINDOW = 2 days;
 
     event MintExecuted(bytes32 indexed depositKey, bytes32 btxTxid, uint32 vout, address indexed to, uint64 amountSat, uint256 amountWbtx);
     event MintQueued(bytes32 indexed depositKey, address indexed to, uint64 amountSat, uint64 executeAfter);
@@ -91,6 +112,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     event VetoCleared(bytes32 indexed depositKey, address indexed by);
     event RedeemRequested(uint256 indexed redeemId, address indexed from, uint64 amountSat, bytes btxDestination, uint256 amountWbtxBurned);
     event RedeemFulfilled(uint256 indexed redeemId, bytes32 btxTxid);
+    event FulfillmentRevoked(uint256 indexed redeemId, bytes32 btxTxid, address indexed by);
     event RedeemRefunded(uint256 indexed redeemId, address indexed to, uint256 amountWbtx);
     event VerifierProposed(address indexed pendingVerifier, uint64 verifierEta);
     event VerifierApplied(address indexed previousVerifier, address indexed currentVerifier);
@@ -124,6 +146,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     error VerifierNotReady();
     error ClearVetoNotReady();
     error GuardianDelayTooLow();
+    error RevokeWindowElapsed();
 
     modifier whenMintNotPaused() { if (mintPaused) revert MintPaused(); _; }
     modifier whenRedeemNotPaused() { if (redeemPaused) revert RedeemPaused(); _; }
@@ -225,6 +248,56 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
                     attestedHeight,
                     to,
                     amountSat,
+                    deadline
+                )
+            )
+        );
+    }
+
+    function fulfillDigest(
+        uint256 bridgeId_,
+        uint256 redeemId,
+        bytes32 btxTxid,
+        bytes32 destHash,
+        uint64 amountSat,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        uint64 deadline
+    ) public view returns (bytes32) {
+        return _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    REDEEM_FULFILL_TYPEHASH,
+                    bridgeId_,
+                    redeemId,
+                    btxTxid,
+                    destHash,
+                    amountSat,
+                    btxBlockHeight,
+                    attestedHeight,
+                    deadline
+                )
+            )
+        );
+    }
+
+    function nonReleaseDigest(
+        uint256 bridgeId_,
+        uint256 redeemId,
+        bytes32 destHash,
+        uint64 amountSat,
+        uint64 asOfBtxHeight,
+        uint64 deadline
+    ) public view returns (bytes32) {
+        return _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    REDEEM_NONRELEASE_TYPEHASH,
+                    bridgeId_,
+                    redeemId,
+                    destHash,
+                    amountSat,
+                    asOfBtxHeight,
                     deadline
                 )
             )
@@ -361,31 +434,107 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         wbtx.burnFrom(msg.sender, amountWbtx);           // burn FULL amount (dust included)
         redeemId = ++redeemNonce;
         redeems[redeemId] = Redeem({
-            from: msg.sender, amountSat: amountSat, amountWbtx: amountWbtx,
-            requestedAt: uint64(block.timestamp), fulfilled: false, refunded: false
+            from: msg.sender,
+            amountSat: amountSat,
+            amountWbtx: amountWbtx,
+            requestedAt: uint64(block.timestamp),
+            fulfilledAt: 0,
+            destHash: keccak256(btxDestination),
+            btxTxid: bytes32(0),
+            fulfilled: false,
+            refunded: false
         });
         emit RedeemRequested(redeemId, msg.sender, amountSat, btxDestination, amountWbtx);
     }
 
     /// @notice The federation records on-chain that a redeem was released on BTX (auditability).
-    function fulfillRedeem(uint256 redeemId, bytes32 btxTxid) external onlyRole(FEDERATION_ROLE) {
+    function fulfillRedeem(
+        uint256 redeemId,
+        bytes32 btxTxid,
+        bytes32 destHash,
+        uint64 amountSat,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        uint64 deadline,
+        bytes calldata proof
+    ) external onlyRole(FEDERATION_ROLE) {
         Redeem storage r = redeems[redeemId];
         if (r.from == address(0)) revert UnknownRedeem();
         if (r.fulfilled || r.refunded) revert RedeemClosed();
+        if (block.timestamp > deadline) revert AttestationExpired();
+        if (attestedHeight < btxBlockHeight) revert NotAttested();
+        if (attestedHeight - btxBlockHeight < MIN_CONFIRMATIONS) revert TooShallow();
+        if (destHash != r.destHash || amountSat != r.amountSat) revert BadAttestation();
+        if (
+            !verifier.verifyFulfill(
+                fulfillDigest(
+                    bridgeId,
+                    redeemId,
+                    btxTxid,
+                    destHash,
+                    amountSat,
+                    btxBlockHeight,
+                    attestedHeight,
+                    deadline
+                ),
+                proof
+            )
+        ) revert BadAttestation();
+
         r.fulfilled = true;
+        r.fulfilledAt = uint64(block.timestamp);
+        r.btxTxid = btxTxid;
         emit RedeemFulfilled(redeemId, btxTxid);
+    }
+
+    function unfulfillRedeem(uint256 redeemId) external onlyRole(GUARDIAN_ROLE) {
+        Redeem storage r = redeems[redeemId];
+        if (r.from == address(0)) revert UnknownRedeem();
+        if (!r.fulfilled || r.refunded) revert RedeemClosed();
+        if (block.timestamp > r.fulfilledAt + FULFILL_REVOKE_WINDOW) revert RevokeWindowElapsed();
+
+        bytes32 releasedTxid = r.btxTxid;
+        r.fulfilled = false;
+        r.fulfilledAt = 0;
+        r.btxTxid = bytes32(0);
+        emit FulfillmentRevoked(redeemId, releasedTxid, msg.sender);
     }
 
     /// @notice If a redeem cannot be honored on BTX (malformed destination, federation failure) and
     ///         the refund timeout has elapsed, governance re-mints wBTX to the original burner so no
     ///         funds are silently lost. (FBTC "safety committee" pattern.)
-    function refundRedeem(uint256 redeemId) external onlyRole(GOVERNANCE_ROLE) nonReentrant {
+    function refundRedeem(
+        uint256 redeemId,
+        uint64 asOfBtxHeight,
+        uint64 deadline,
+        bytes calldata proof
+    ) external onlyRole(GOVERNANCE_ROLE) nonReentrant {
         Redeem storage r = redeems[redeemId];
         if (r.from == address(0)) revert UnknownRedeem();
         if (r.fulfilled || r.refunded) revert RedeemClosed();
         if (block.timestamp < r.requestedAt + redeemRefundTimeout) revert TooEarly();
+        if (block.timestamp > deadline) revert AttestationExpired();
+        if (
+            !verifier.verifyNonRelease(
+                nonReleaseDigest(
+                    bridgeId,
+                    redeemId,
+                    r.destHash,
+                    r.amountSat,
+                    asOfBtxHeight,
+                    deadline
+                ),
+                proof
+            )
+        ) revert BadAttestation();
+
+        _checkAndConsumeLimits(r.amountSat);
+        if (maxSupplyWbtx != 0 && wbtx.totalSupply() + r.amountWbtx > maxSupplyWbtx) revert SupplyCapExceeded();
+
         r.refunded = true;
-        wbtx.mint(r.from, r.amountWbtx);
+        wbtx.mintRefund(r.from, r.amountWbtx);
+        bytes32 refundKey = keccak256(abi.encodePacked("redeem-refund", redeemId));
+        emit MintExecuted(refundKey, bytes32(0), 0, r.from, r.amountSat, r.amountWbtx);
         emit RedeemRefunded(redeemId, r.from, r.amountWbtx);
     }
 }
@@ -509,6 +658,18 @@ contract ECDSAMultisigVerifier is IAttestationVerifier, AccessControlDefaultAdmi
     function signers() external view returns (address[] memory) { return _signers; }
 
     function verifyMint(bytes32 digest, bytes calldata proof) external view returns (bool) {
+        return _verifyDigest(digest, proof);
+    }
+
+    function verifyFulfill(bytes32 digest, bytes calldata proof) external view returns (bool) {
+        return _verifyDigest(digest, proof);
+    }
+
+    function verifyNonRelease(bytes32 digest, bytes calldata proof) external view returns (bool) {
+        return _verifyDigest(digest, proof);
+    }
+
+    function _verifyDigest(bytes32 digest, bytes calldata proof) private view returns (bool) {
         bytes[] memory sigs = abi.decode(proof, (bytes[]));
         if (sigs.length > _signers.length) revert TooManySigs(); // fail fast; bound the loop
         if (sigs.length < threshold) return false;

--- a/contrib/wbtx/evm/WBTXBridge.sol
+++ b/contrib/wbtx/evm/WBTXBridge.sol
@@ -52,13 +52,14 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     // issues. Keeping them separate avoids halting redemptions when only minting must stop, and vice versa.
     bool public mintPaused;
     bool public redeemPaused;
+    bool public limitsConfigured;
 
     // --- circuit breaker (Ronin/Harmony lesson: cap blast radius, don't rely on humans noticing) ---
     uint256 public maxSupplyWbtx;          // hard ceiling on circulating wBTX (0 = unlimited)
     uint64  public windowMintCapSat;       // max sat minted per rolling window (0 = unlimited)
     uint64  public windowDuration;         // window length (seconds)
-    uint64  public windowStart;
-    uint64  public windowMintedSat;
+    uint64  public availableSat;
+    uint64  public lastRefill;
 
     // --- guardian veto (tBTC optimistic minting) ---
     uint64  public optimisticThresholdSat; // mints above this are time-queued
@@ -67,6 +68,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     struct QueuedMint { address to; uint64 amountSat; uint64 executeAfter; bool exists; }
     mapping(bytes32 => bool) public minted;        // depositKey => minted (authoritative replay guard)
     mapping(bytes32 => QueuedMint) public queued;  // depositKey => pending mint
+    mapping(bytes32 => bool) public vetoed;        // depositKey => guardian-vetoed until governance clears
 
     // --- redeem lifecycle (auditable + refundable) ---
     struct Redeem { address from; uint64 amountSat; uint256 amountWbtx; uint64 requestedAt; bool fulfilled; bool refunded; }
@@ -77,6 +79,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     event MintExecuted(bytes32 indexed depositKey, bytes32 btxTxid, uint32 vout, address indexed to, uint64 amountSat, uint256 amountWbtx);
     event MintQueued(bytes32 indexed depositKey, address indexed to, uint64 amountSat, uint64 executeAfter);
     event MintCancelled(bytes32 indexed depositKey, address indexed by);
+    event VetoCleared(bytes32 indexed depositKey, address indexed by);
     event RedeemRequested(uint256 indexed redeemId, address indexed from, uint64 amountSat, bytes btxDestination, uint256 amountWbtxBurned);
     event RedeemFulfilled(uint256 indexed redeemId, bytes32 btxTxid);
     event RedeemRefunded(uint256 indexed redeemId, address indexed to, uint256 amountWbtx);
@@ -88,10 +91,14 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     error MintPaused();
     error RedeemPaused();
     error AlreadyMinted();
+    error Vetoed();
     error BadAttestation();
     error AmountOverflow();
     error WindowCapExceeded();
     error SupplyCapExceeded();
+    error NotConfigured();
+    error ZeroBreakerValue();
+    error WindowRateZero();
     error NotQueued();
     error TooEarly();
     error AttestationExpired();
@@ -131,12 +138,23 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         uint256 maxSupplyWbtx_, uint64 windowMintCapSat_, uint64 windowDuration_,
         uint64 optimisticThresholdSat_, uint64 guardianDelay_, uint64 redeemRefundTimeout_
     ) external onlyRole(GOVERNANCE_ROLE) {
+        if (
+            maxSupplyWbtx_ == 0
+                || windowMintCapSat_ == 0
+                || windowDuration_ == 0
+                || optimisticThresholdSat_ == 0
+                || guardianDelay_ == 0
+        ) revert ZeroBreakerValue();
+        if (uint256(windowMintCapSat_) / uint256(windowDuration_) == 0) revert WindowRateZero();
         maxSupplyWbtx = maxSupplyWbtx_;
         windowMintCapSat = windowMintCapSat_;
-        windowDuration = windowDuration_ == 0 ? 1 days : windowDuration_;
+        windowDuration = windowDuration_;
         optimisticThresholdSat = optimisticThresholdSat_;
         guardianDelay = guardianDelay_;
         redeemRefundTimeout = redeemRefundTimeout_;
+        availableSat = windowMintCapSat_;
+        lastRefill = uint64(block.timestamp);
+        limitsConfigured = true;
         emit LimitsUpdated(maxSupplyWbtx_, windowMintCapSat_, windowDuration_, optimisticThresholdSat_, guardianDelay_, redeemRefundTimeout_);
     }
 
@@ -197,6 +215,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         uint64 deadline,
         bytes calldata proof
     ) external whenMintNotPaused nonReentrant {
+        if (!limitsConfigured) revert NotConfigured();
         if (to == address(0)) revert BadDestination();
         if (amountSat == 0) revert BelowOneSat();
         if (block.timestamp > deadline) revert AttestationExpired();
@@ -204,6 +223,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         if (attestedHeight - btxBlockHeight < MIN_CONFIRMATIONS) revert TooShallow();
         bytes32 dk = depositKey(btxTxid, vout);
         if (minted[dk] || queued[dk].exists) revert AlreadyMinted();
+        if (vetoed[dk]) revert Vetoed();
 
         if (
             !verifier.verifyMint(
@@ -221,8 +241,6 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
                 proof
             )
         ) revert BadAttestation();
-
-        _checkAndConsumeLimits(amountSat);
 
         if (optimisticThresholdSat != 0 && amountSat > optimisticThresholdSat && guardianDelay != 0) {
             uint64 executeAfter = uint64(block.timestamp) + guardianDelay;
@@ -245,16 +263,25 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         _doMint(dk, btxTxid, vout, q.to, q.amountSat);
     }
 
-    /// @notice A GUARDIAN cancels a queued (suspicious) mint within the delay window. The deposit can
-    ///         then be re-attested/re-minted only after governance review (the outpoint is freed).
+    /// @notice A GUARDIAN cancels a queued (suspicious) mint within the delay window and durably vetoes
+    ///         the deposit key until governance clears it.
     function cancelQueuedMint(bytes32 btxTxid, uint32 vout) external onlyRole(GUARDIAN_ROLE) {
         bytes32 dk = depositKey(btxTxid, vout);
         if (!queued[dk].exists) revert NotQueued();
         delete queued[dk];
+        vetoed[dk] = true;
         emit MintCancelled(dk, msg.sender);
     }
 
+    /// @notice Governance-only veto clear.
+    /// @dev MUST be controlled by the governance timelock so veto clears are delayed and reviewable.
+    function clearVeto(bytes32 dk) external onlyRole(GOVERNANCE_ROLE) {
+        vetoed[dk] = false;
+        emit VetoCleared(dk, msg.sender);
+    }
+
     function _doMint(bytes32 dk, bytes32 btxTxid, uint32 vout, address to, uint64 amountSat) private {
+        _checkAndConsumeLimits(amountSat);
         uint256 amountWbtx = uint256(amountSat) * SAT_SCALE;
         if (maxSupplyWbtx != 0 && wbtx.totalSupply() + amountWbtx > maxSupplyWbtx) revert SupplyCapExceeded();
         wbtx.mint(to, amountWbtx);
@@ -263,11 +290,15 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
 
     function _checkAndConsumeLimits(uint64 amountSat) private {
         if (windowMintCapSat == 0) return;
+        if (uint256(windowMintCapSat) / uint256(windowDuration) == 0) revert WindowRateZero();
         uint64 nowTs = uint64(block.timestamp);
-        if (nowTs >= windowStart + windowDuration) { windowStart = nowTs; windowMintedSat = 0; }
-        // overflow-safe accumulation
-        if (uint256(windowMintedSat) + amountSat > windowMintCapSat) revert WindowCapExceeded();
-        windowMintedSat += amountSat;
+        uint64 elapsed = nowTs - lastRefill;
+        uint256 replenished = uint256(elapsed) * uint256(windowMintCapSat) / uint256(windowDuration);
+        uint256 available = uint256(availableSat) + replenished;
+        if (available > windowMintCapSat) available = windowMintCapSat;
+        if (available < amountSat) revert WindowCapExceeded();
+        availableSat = uint64(available - amountSat);
+        lastRefill = nowTs;
     }
 
     // ----------------------------- redeem -----------------------------
@@ -278,6 +309,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     function redeem(uint256 amountWbtx, bytes calldata btxDestination)
         external whenRedeemNotPaused nonReentrant returns (uint256 redeemId)
     {
+        if (!limitsConfigured) revert NotConfigured();
         if (btxDestination.length == 0 || btxDestination.length > 128) revert BadDestination();
         uint256 sat = amountWbtx / SAT_SCALE;            // round down
         if (sat == 0) revert BelowOneSat();

--- a/contrib/wbtx/evm/WBTXBridge.sol
+++ b/contrib/wbtx/evm/WBTXBridge.sol
@@ -358,7 +358,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         if (sat > type(uint64).max) revert AmountOverflow(); // defensive truncation guard
         uint64 amountSat = uint64(sat);
 
-        wbtx.burn(msg.sender, amountWbtx);               // burn FULL amount (dust included)
+        wbtx.burnFrom(msg.sender, amountWbtx);           // burn FULL amount (dust included)
         redeemId = ++redeemNonce;
         redeems[redeemId] = Redeem({
             from: msg.sender, amountSat: amountSat, amountWbtx: amountWbtx,

--- a/contrib/wbtx/evm/WBTXBridge.sol
+++ b/contrib/wbtx/evm/WBTXBridge.sol
@@ -43,11 +43,19 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     bytes32 public constant GUARDIAN_ROLE   = keccak256("GUARDIAN_ROLE");   // veto/cancel + pause
     bytes32 public constant PAUSER_ROLE     = keccak256("PAUSER_ROLE");
     bytes32 public constant FEDERATION_ROLE = keccak256("FEDERATION_ROLE"); // marks redeems fulfilled
+    /// @dev Trust-anchor change delay (L2BEAT Stage-1 style exit window).
+    uint64 public constant VERIFIER_DELAY = 7 days;
+    /// @dev Shorter delay for clearing a guardian veto on an otherwise honest user deposit.
+    uint64 public constant CLEAR_VETO_DELAY = 48 hours;
+    /// @dev Governance cannot shrink guardian review to near-zero.
+    uint64 public constant MIN_GUARDIAN_DELAY = 6 hours;
 
     bytes32 private constant MINT_TYPEHASH =
         keccak256("MintAttestation(uint256 bridgeId,bytes32 btxTxid,uint32 vout,bytes32 btxBlockHash,uint64 btxBlockHeight,uint64 attestedHeight,address to,uint64 amountSat,uint64 deadline)");
 
     IAttestationVerifier public verifier;
+    IAttestationVerifier public pendingVerifier;
+    uint64 public verifierEta;
     // Granular pause: mint-pause is the critical backing-safety lever; redeem-pause is for BTX-side
     // issues. Keeping them separate avoids halting redemptions when only minting must stop, and vice versa.
     bool public mintPaused;
@@ -69,6 +77,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     mapping(bytes32 => bool) public minted;        // depositKey => minted (authoritative replay guard)
     mapping(bytes32 => QueuedMint) public queued;  // depositKey => pending mint
     mapping(bytes32 => bool) public vetoed;        // depositKey => guardian-vetoed until governance clears
+    mapping(bytes32 => uint64) public clearVetoEta;
 
     // --- redeem lifecycle (auditable + refundable) ---
     struct Redeem { address from; uint64 amountSat; uint256 amountWbtx; uint64 requestedAt; bool fulfilled; bool refunded; }
@@ -83,7 +92,10 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     event RedeemRequested(uint256 indexed redeemId, address indexed from, uint64 amountSat, bytes btxDestination, uint256 amountWbtxBurned);
     event RedeemFulfilled(uint256 indexed redeemId, bytes32 btxTxid);
     event RedeemRefunded(uint256 indexed redeemId, address indexed to, uint256 amountWbtx);
-    event VerifierUpdated(address indexed previous, address indexed current);
+    event VerifierProposed(address indexed pendingVerifier, uint64 verifierEta);
+    event VerifierApplied(address indexed previousVerifier, address indexed currentVerifier);
+    event PendingVerifierCancelled(address indexed by);
+    event ClearVetoProposed(bytes32 indexed depositKey, uint64 executeAfter);
     event MintPausedSet(bool paused, address indexed by);
     event RedeemPausedSet(bool paused, address indexed by);
     event LimitsUpdated(uint256 maxSupplyWbtx, uint64 windowMintCapSat, uint64 windowDuration, uint64 optimisticThresholdSat, uint64 guardianDelay, uint64 redeemRefundTimeout);
@@ -108,6 +120,10 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
     error BelowOneSat();
     error UnknownRedeem();
     error RedeemClosed();
+    error VerifierNotContract();
+    error VerifierNotReady();
+    error ClearVetoNotReady();
+    error GuardianDelayTooLow();
 
     modifier whenMintNotPaused() { if (mintPaused) revert MintPaused(); _; }
     modifier whenRedeemNotPaused() { if (redeemPaused) revert RedeemPaused(); _; }
@@ -129,9 +145,27 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
 
     // ----------------------------- governance -----------------------------
 
-    function setVerifier(IAttestationVerifier v) external onlyRole(GOVERNANCE_ROLE) {
-        emit VerifierUpdated(address(verifier), address(v));
-        verifier = v;
+    function proposeVerifier(IAttestationVerifier v) external onlyRole(GOVERNANCE_ROLE) {
+        if (address(v) == address(0) || address(v).code.length == 0) revert VerifierNotContract();
+        pendingVerifier = v;
+        verifierEta = uint64(block.timestamp) + VERIFIER_DELAY;
+        emit VerifierProposed(address(v), verifierEta);
+    }
+
+    function applyVerifier() external {
+        if (verifierEta == 0 || block.timestamp < verifierEta) revert VerifierNotReady();
+        address previous = address(verifier);
+        IAttestationVerifier next = pendingVerifier;
+        verifier = next;
+        pendingVerifier = IAttestationVerifier(address(0));
+        verifierEta = 0;
+        emit VerifierApplied(previous, address(next));
+    }
+
+    function cancelPendingVerifier() external onlyRole(GUARDIAN_ROLE) {
+        pendingVerifier = IAttestationVerifier(address(0));
+        verifierEta = 0;
+        emit PendingVerifierCancelled(msg.sender);
     }
 
     function setLimits(
@@ -145,6 +179,7 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
                 || optimisticThresholdSat_ == 0
                 || guardianDelay_ == 0
         ) revert ZeroBreakerValue();
+        if (guardianDelay_ < MIN_GUARDIAN_DELAY) revert GuardianDelayTooLow();
         if (uint256(windowMintCapSat_) / uint256(windowDuration_) == 0) revert WindowRateZero();
         maxSupplyWbtx = maxSupplyWbtx_;
         windowMintCapSat = windowMintCapSat_;
@@ -273,9 +308,16 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
         emit MintCancelled(dk, msg.sender);
     }
 
-    /// @notice Governance-only veto clear.
-    /// @dev MUST be controlled by the governance timelock so veto clears are delayed and reviewable.
-    function clearVeto(bytes32 dk) external onlyRole(GOVERNANCE_ROLE) {
+    /// @notice Governance-only proposal to clear a guardian veto after a short review delay.
+    function proposeClearVeto(bytes32 dk) external onlyRole(GOVERNANCE_ROLE) {
+        clearVetoEta[dk] = uint64(block.timestamp) + CLEAR_VETO_DELAY;
+        emit ClearVetoProposed(dk, clearVetoEta[dk]);
+    }
+
+    function applyClearVeto(bytes32 dk) external {
+        uint64 eta = clearVetoEta[dk];
+        if (eta == 0 || block.timestamp < eta) revert ClearVetoNotReady();
+        delete clearVetoEta[dk];
         vetoed[dk] = false;
         emit VetoCleared(dk, msg.sender);
     }
@@ -362,36 +404,101 @@ contract WBTXBridge is EIP712, AccessControlDefaultAdminRules, ReentrancyGuard {
 contract ECDSAMultisigVerifier is IAttestationVerifier, AccessControlDefaultAdminRules {
     using ECDSA for bytes32;
 
+    bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
+    uint64 public constant ROTATION_DELAY = 7 days;
+
     address[] private _signers;
+    address[] private _pendingSigners;
     mapping(address => bool) public isSigner;
     uint256 public threshold;
+    uint256 public pendingThreshold;
+    uint64 public rotationEta;
 
     event SignersRotated(address[] signers, uint256 threshold);
+    event RotationProposed(address[] signers, uint256 threshold, uint64 rotationEta);
+    event PendingRotationCancelled(address indexed by);
 
     error BadThreshold();
     error DupOrZeroSigner();
     error TooManySigs();
     error NotOrdered();
+    error SignersNotAscending();
+    error RotationNotReady();
 
     constructor(address admin, uint48 adminDelay, address[] memory signers_, uint256 threshold_)
         AccessControlDefaultAdminRules(adminDelay, admin)
     {
         _rotate(signers_, threshold_);
+        _grantRole(GUARDIAN_ROLE, admin);
     }
 
-    /// @notice Replace the entire signer set + threshold (governance/Timelock only). Clears the prior
-    ///         set first (no stale-signer accumulation — the gap flagged in the v0 reference).
+    /// @notice Legacy name routed through timelocked rotation flow.
     function rotateSigners(address[] calldata signers_, uint256 threshold_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _proposeRotation(signers_, threshold_);
+    }
+
+    /// @notice Propose signer set + threshold replacement, applied after a fixed delay.
+    function proposeRotation(address[] calldata signers_, uint256 threshold_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _proposeRotation(signers_, threshold_);
+    }
+
+    function applyRotation() external {
+        if (rotationEta == 0 || block.timestamp < rotationEta) revert RotationNotReady();
+        uint256 len = _pendingSigners.length;
+        address[] memory signers_ = new address[](len);
+        for (uint256 i = 0; i < len; i++) {
+            signers_[i] = _pendingSigners[i];
+        }
+        uint256 threshold_ = pendingThreshold;
+        delete _pendingSigners;
+        pendingThreshold = 0;
+        rotationEta = 0;
         _rotate(signers_, threshold_);
+    }
+
+    function cancelPendingRotation() external onlyRole(GUARDIAN_ROLE) {
+        delete _pendingSigners;
+        pendingThreshold = 0;
+        rotationEta = 0;
+        emit PendingRotationCancelled(msg.sender);
+    }
+
+    function pendingSigners() external view returns (address[] memory) {
+        return _pendingSigners;
+    }
+
+    function _proposeRotation(address[] calldata signers_, uint256 threshold_) private {
+        _validateRotation(signers_, threshold_);
+        delete _pendingSigners;
+        for (uint256 i = 0; i < signers_.length; i++) {
+            _pendingSigners.push(signers_[i]);
+        }
+        pendingThreshold = threshold_;
+        rotationEta = uint64(block.timestamp) + ROTATION_DELAY;
+        emit RotationProposed(signers_, threshold_, rotationEta);
+    }
+
+    function _validateRotation(address[] calldata signers_, uint256 threshold_) private pure {
+        if (threshold_ == 0 || threshold_ > signers_.length) revert BadThreshold();
+        address prev = address(0);
+        for (uint256 i = 0; i < signers_.length; i++) {
+            address s = signers_[i];
+            if (s == address(0)) revert DupOrZeroSigner();
+            if (s <= prev) revert SignersNotAscending();
+            prev = s;
+        }
     }
 
     function _rotate(address[] memory signers_, uint256 threshold_) private {
         if (threshold_ == 0 || threshold_ > signers_.length) revert BadThreshold();
+        address prev = address(0);
         for (uint256 i = 0; i < _signers.length; i++) { isSigner[_signers[i]] = false; }
         delete _signers;
         for (uint256 i = 0; i < signers_.length; i++) {
             address s = signers_[i];
             if (s == address(0) || isSigner[s]) revert DupOrZeroSigner();
+            if (s <= prev) revert SignersNotAscending();
+            prev = s;
             isSigner[s] = true;
             _signers.push(s);
         }

--- a/contrib/wbtx/test/WBTX.t.sol
+++ b/contrib/wbtx/test/WBTX.t.sol
@@ -25,12 +25,27 @@ contract WBTXTest is Test {
     uint64 constant DEFAULT_WINDOW_CAP_SAT = 2_100_000_000_000_000;
     uint64 constant DEFAULT_WINDOW_DURATION = 1 days;
     uint64 constant DEFAULT_OPTIMISTIC_THRESHOLD_SAT = 2_100_000_000_000_000;
-    uint64 constant DEFAULT_GUARDIAN_DELAY = 1 hours;
+    uint64 constant DEFAULT_GUARDIAN_DELAY = 6 hours;
     uint64 constant DEFAULT_REDEEM_REFUND_TIMEOUT = 7 days;
 
+    function _initialSignersSorted() internal view returns (address[] memory signers) {
+        signers = new address[](3);
+        signers[0] = vm.addr(pk1);
+        signers[1] = vm.addr(pk2);
+        signers[2] = vm.addr(pk3);
+        for (uint256 i = 1; i < signers.length; i++) {
+            address key = signers[i];
+            uint256 j = i;
+            while (j > 0 && signers[j - 1] > key) {
+                signers[j] = signers[j - 1];
+                unchecked { --j; }
+            }
+            signers[j] = key;
+        }
+    }
+
     function setUp() public {
-        address[] memory signers = new address[](3);
-        signers[0] = vm.addr(pk1); signers[1] = vm.addr(pk2); signers[2] = vm.addr(pk3);
+        address[] memory signers = _initialSignersSorted();
         verifier = new ECDSAMultisigVerifier(admin, 0, signers, 2); // 2-of-3
         wbtx = new WBTX(admin, 0);
         bridge = new WBTXBridge(wbtx, IAttestationVerifier(address(verifier)), 1, admin, 0);
@@ -44,6 +59,7 @@ contract WBTXTest is Test {
         bridge.grantRole(bridge.GUARDIAN_ROLE(), guardian);
         bridge.grantRole(bridge.PAUSER_ROLE(), pauser);
         bridge.grantRole(bridge.FEDERATION_ROLE(), gov);
+        verifier.grantRole(verifier.GUARDIAN_ROLE(), guardian);
         vm.stopPrank();
 
         vm.prank(gov);
@@ -239,7 +255,7 @@ contract WBTXTest is Test {
 
     function test_WindowCapEnforced() public {
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, 50_000, 1 hours, 1_000_000, 1 hours, 7 days); // window cap 50k sat
+        bridge.setLimits(type(uint256).max, 50_000, 1 hours, 1_000_000, 6 hours, 7 days); // window cap 50k sat
         bytes32 txid = keccak256("dep5");
         uint64 deadline = _futureDeadline();
         bytes memory proof = _attest(
@@ -253,7 +269,7 @@ contract WBTXTest is Test {
 
     function test_GuardianVetoFlow() public {
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 1 hours, 7 days); // queue mints > 100k sat
+        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 6 hours, 7 days); // queue mints > 100k sat
         bytes32 txid = keccak256("dep6");
         uint64 deadline = _futureDeadline();
         bytes memory proof = _attest(
@@ -277,7 +293,7 @@ contract WBTXTest is Test {
 
     function test_GuardianQueueExecutesAfterDelay() public {
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 1 hours, 7 days);
+        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 6 hours, 7 days);
         bytes32 txid = keccak256("dep7");
         uint64 deadline = _futureDeadline();
         bytes memory proof = _attest(
@@ -286,14 +302,14 @@ contract WBTXTest is Test {
         bridge.mint(
             txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 500_000, deadline, proof
         );
-        vm.warp(block.timestamp + 2 hours);
+        vm.warp(block.timestamp + 7 hours);
         bridge.executeQueuedMint(txid, 0);
         assertEq(wbtx.balanceOf(address(0xBEEF)), 500_000 * 1e10);
     }
 
-    function test_Veto_DurableBlocksResubmit() public {
+    function test_ClearVeto_Timelocked() public {
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 1 hours, 7 days);
+        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 6 hours, 7 days);
 
         bytes32 txid = keccak256("veto-race");
         uint32 vout = 9;
@@ -317,18 +333,18 @@ contract WBTXTest is Test {
         );
 
         vm.prank(gov);
-        bridge.clearVeto(dk);
+        bridge.proposeClearVeto(dk);
+        assertTrue(bridge.vetoed(dk));
+        vm.expectRevert(WBTXBridge.ClearVetoNotReady.selector);
+        bridge.applyClearVeto(dk);
+        vm.warp(block.timestamp + bridge.CLEAR_VETO_DELAY());
+        bridge.applyClearVeto(dk);
         assertFalse(bridge.vetoed(dk));
-        bridge.mint(
-            txid, vout, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), amountSat, deadline, proof
-        );
-        (, , , bool exists) = bridge.queued(dk);
-        assertTrue(exists);
     }
 
     function test_Window_NoBoundaryBurst() public {
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, 1_000, 100, 10_000, 1 hours, 7 days);
+        bridge.setLimits(type(uint256).max, 1_000, 100, 10_000, 6 hours, 7 days);
 
         vm.warp(block.timestamp + 99);
         uint64 deadline = _futureDeadline();
@@ -362,7 +378,7 @@ contract WBTXTest is Test {
 
     function test_Window_QueueReservesNothing() public {
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, 1_000, 100, 500, 1 hours, 7 days);
+        bridge.setLimits(type(uint256).max, 1_000, 100, 500, 6 hours, 7 days);
 
         uint64 deadline = _futureDeadline();
         bytes32 queuedTxid = keccak256("queue-reserve-1");
@@ -385,15 +401,14 @@ contract WBTXTest is Test {
         bridge.mint(
             fullCapTxid, 4, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline, fullCapProof
         );
-        vm.warp(block.timestamp + 2 hours);
+        vm.warp(block.timestamp + 7 hours);
         bridge.executeQueuedMint(fullCapTxid, 4);
         assertEq(wbtx.balanceOf(address(0xBEEF)), 1_000 * 1e10);
         assertEq(bridge.availableSat(), 0);
     }
 
     function test_Mint_RevertsWhenNotConfigured() public {
-        address[] memory signers = new address[](3);
-        signers[0] = vm.addr(pk1); signers[1] = vm.addr(pk2); signers[2] = vm.addr(pk3);
+        address[] memory signers = _initialSignersSorted();
         ECDSAMultisigVerifier verifier2 = new ECDSAMultisigVerifier(admin, 0, signers, 2);
         WBTX wbtx2 = new WBTX(admin, 0);
         WBTXBridge bridge2 = new WBTXBridge(wbtx2, IAttestationVerifier(address(verifier2)), 1, admin, 0);
@@ -477,7 +492,80 @@ contract WBTXTest is Test {
 
     function test_VerifierGovernanceGated() public {
         vm.expectRevert();
-        bridge.setVerifier(IAttestationVerifier(address(0xdead)));  // not GOVERNANCE_ROLE
+        bridge.proposeVerifier(IAttestationVerifier(address(verifier)));  // not GOVERNANCE_ROLE
+    }
+
+    function test_SetVerifier_Timelocked() public {
+        MockVerifier next = new MockVerifier(true);
+        vm.prank(gov);
+        bridge.proposeVerifier(IAttestationVerifier(address(next)));
+
+        assertEq(address(bridge.verifier()), address(verifier));
+        vm.expectRevert(WBTXBridge.VerifierNotReady.selector);
+        bridge.applyVerifier();
+
+        vm.warp(block.timestamp + bridge.VERIFIER_DELAY());
+        bridge.applyVerifier();
+        assertEq(address(bridge.verifier()), address(next));
+
+        vm.prank(gov);
+        vm.expectRevert(WBTXBridge.VerifierNotContract.selector);
+        bridge.proposeVerifier(IAttestationVerifier(address(0)));
+
+        vm.prank(gov);
+        vm.expectRevert(WBTXBridge.VerifierNotContract.selector);
+        bridge.proposeVerifier(IAttestationVerifier(address(0xBEEF)));
+    }
+
+    function test_CancelPendingVerifier() public {
+        MockVerifier next = new MockVerifier(true);
+        vm.prank(gov);
+        bridge.proposeVerifier(IAttestationVerifier(address(next)));
+        vm.prank(guardian);
+        bridge.cancelPendingVerifier();
+
+        vm.warp(block.timestamp + bridge.VERIFIER_DELAY());
+        vm.expectRevert(WBTXBridge.VerifierNotReady.selector);
+        bridge.applyVerifier();
+        assertEq(address(bridge.verifier()), address(verifier));
+    }
+
+    function test_RotateSigners_Timelocked() public {
+        address[] memory nextSigners = new address[](2);
+        nextSigners[0] = address(0x1111);
+        nextSigners[1] = address(0x2222);
+
+        vm.prank(admin);
+        verifier.proposeRotation(nextSigners, 1);
+        assertEq(verifier.threshold(), 2);
+        vm.expectRevert(ECDSAMultisigVerifier.RotationNotReady.selector);
+        verifier.applyRotation();
+
+        vm.warp(block.timestamp + verifier.ROTATION_DELAY());
+        verifier.applyRotation();
+        assertEq(verifier.threshold(), 1);
+        assertTrue(verifier.isSigner(nextSigners[0]));
+        assertTrue(verifier.isSigner(nextSigners[1]));
+        assertFalse(verifier.isSigner(vm.addr(pk1)));
+
+        address[] memory cancelledSigners = new address[](2);
+        cancelledSigners[0] = address(0x3333);
+        cancelledSigners[1] = address(0x4444);
+        vm.prank(admin);
+        verifier.proposeRotation(cancelledSigners, 1);
+        vm.prank(guardian);
+        verifier.cancelPendingRotation();
+        vm.warp(block.timestamp + verifier.ROTATION_DELAY());
+        vm.expectRevert(ECDSAMultisigVerifier.RotationNotReady.selector);
+        verifier.applyRotation();
+    }
+
+    function test_SetLimits_RejectsLowGuardianDelay() public {
+        vm.startPrank(gov);
+        uint64 tooLowGuardianDelay = bridge.MIN_GUARDIAN_DELAY() - 1;
+        vm.expectRevert(WBTXBridge.GuardianDelayTooLow.selector);
+        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, tooLowGuardianDelay, 7 days);
+        vm.stopPrank();
     }
 
     function test_GranularPause() public {
@@ -513,6 +601,18 @@ contract WBTXTest is Test {
         );
         assertEq(wbtx.totalSupply(), uint256(amountSat) * 1e10);
         assertEq(wbtx.balanceOf(address(0xBEEF)), wbtx.totalSupply());
+    }
+}
+
+contract MockVerifier is IAttestationVerifier {
+    bool public immutable allow;
+
+    constructor(bool allow_) {
+        allow = allow_;
+    }
+
+    function verifyMint(bytes32, bytes calldata) external view returns (bool) {
+        return allow;
     }
 }
 

--- a/contrib/wbtx/test/WBTX.t.sol
+++ b/contrib/wbtx/test/WBTX.t.sol
@@ -21,6 +21,12 @@ contract WBTXTest is Test {
     bytes32 constant DEFAULT_BTX_BLOCK_HASH = keccak256("btx-block");
     uint64 constant DEFAULT_BTX_BLOCK_HEIGHT = 1_000_000;
     uint64 constant DEFAULT_ATTESTED_HEIGHT = DEFAULT_BTX_BLOCK_HEIGHT + 150;
+    uint256 constant DEFAULT_MAX_SUPPLY_WBTX = type(uint256).max;
+    uint64 constant DEFAULT_WINDOW_CAP_SAT = 2_100_000_000_000_000;
+    uint64 constant DEFAULT_WINDOW_DURATION = 1 days;
+    uint64 constant DEFAULT_OPTIMISTIC_THRESHOLD_SAT = 2_100_000_000_000_000;
+    uint64 constant DEFAULT_GUARDIAN_DELAY = 1 hours;
+    uint64 constant DEFAULT_REDEEM_REFUND_TIMEOUT = 7 days;
 
     function setUp() public {
         address[] memory signers = new address[](3);
@@ -39,6 +45,16 @@ contract WBTXTest is Test {
         bridge.grantRole(bridge.PAUSER_ROLE(), pauser);
         bridge.grantRole(bridge.FEDERATION_ROLE(), gov);
         vm.stopPrank();
+
+        vm.prank(gov);
+        bridge.setLimits(
+            DEFAULT_MAX_SUPPLY_WBTX,
+            DEFAULT_WINDOW_CAP_SAT,
+            DEFAULT_WINDOW_DURATION,
+            DEFAULT_OPTIMISTIC_THRESHOLD_SAT,
+            DEFAULT_GUARDIAN_DELAY,
+            DEFAULT_REDEEM_REFUND_TIMEOUT
+        );
     }
 
     // --- helpers ---
@@ -47,7 +63,8 @@ contract WBTXTest is Test {
         return uint64(block.timestamp + 1 days);
     }
 
-    function _attest(
+    function _attestFor(
+        WBTXBridge targetBridge,
         bytes32 txid,
         uint32 vout,
         bytes32 btxBlockHash,
@@ -57,8 +74,8 @@ contract WBTXTest is Test {
         uint64 amtSat,
         uint64 deadline
     ) internal view returns (bytes memory) {
-        bytes32 digest = bridge.mintDigest(
-            bridge.bridgeId(),
+        bytes32 digest = targetBridge.mintDigest(
+            targetBridge.bridgeId(),
             txid,
             vout,
             btxBlockHash,
@@ -77,6 +94,19 @@ contract WBTXTest is Test {
         if (vm.addr(pk1) < vm.addr(pk2)) { sigs[0] = sigA; sigs[1] = sigB; }
         else { sigs[0] = sigB; sigs[1] = sigA; }
         return abi.encode(sigs);
+    }
+
+    function _attest(
+        bytes32 txid,
+        uint32 vout,
+        bytes32 btxBlockHash,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        address to,
+        uint64 amtSat,
+        uint64 deadline
+    ) internal view returns (bytes memory) {
+        return _attestFor(bridge, txid, vout, btxBlockHash, btxBlockHeight, attestedHeight, to, amtSat, deadline);
     }
 
     // --- mint ---
@@ -209,7 +239,7 @@ contract WBTXTest is Test {
 
     function test_WindowCapEnforced() public {
         vm.prank(gov);
-        bridge.setLimits(0, 50_000, 1 days, 0, 0, 7 days); // window cap 50k sat
+        bridge.setLimits(type(uint256).max, 50_000, 1 hours, 1_000_000, 1 hours, 7 days); // window cap 50k sat
         bytes32 txid = keccak256("dep5");
         uint64 deadline = _futureDeadline();
         bytes memory proof = _attest(
@@ -223,7 +253,7 @@ contract WBTXTest is Test {
 
     function test_GuardianVetoFlow() public {
         vm.prank(gov);
-        bridge.setLimits(0, 0, 1 days, 100_000, 1 hours, 7 days); // queue mints > 100k sat
+        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 1 hours, 7 days); // queue mints > 100k sat
         bytes32 txid = keccak256("dep6");
         uint64 deadline = _futureDeadline();
         bytes memory proof = _attest(
@@ -247,7 +277,7 @@ contract WBTXTest is Test {
 
     function test_GuardianQueueExecutesAfterDelay() public {
         vm.prank(gov);
-        bridge.setLimits(0, 0, 1 days, 100_000, 1 hours, 7 days);
+        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 1 hours, 7 days);
         bytes32 txid = keccak256("dep7");
         uint64 deadline = _futureDeadline();
         bytes memory proof = _attest(
@@ -259,6 +289,135 @@ contract WBTXTest is Test {
         vm.warp(block.timestamp + 2 hours);
         bridge.executeQueuedMint(txid, 0);
         assertEq(wbtx.balanceOf(address(0xBEEF)), 500_000 * 1e10);
+    }
+
+    function test_Veto_DurableBlocksResubmit() public {
+        vm.prank(gov);
+        bridge.setLimits(type(uint256).max, 1_000_000, 1 hours, 100_000, 1 hours, 7 days);
+
+        bytes32 txid = keccak256("veto-race");
+        uint32 vout = 9;
+        uint64 amountSat = 500_000;
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, vout, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), amountSat, deadline
+        );
+
+        bridge.mint(
+            txid, vout, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), amountSat, deadline, proof
+        );
+        vm.prank(guardian);
+        bridge.cancelQueuedMint(txid, vout);
+
+        bytes32 dk = bridge.depositKey(txid, vout);
+        assertTrue(bridge.vetoed(dk));
+        vm.expectRevert(WBTXBridge.Vetoed.selector);
+        bridge.mint(
+            txid, vout, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), amountSat, deadline, proof
+        );
+
+        vm.prank(gov);
+        bridge.clearVeto(dk);
+        assertFalse(bridge.vetoed(dk));
+        bridge.mint(
+            txid, vout, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), amountSat, deadline, proof
+        );
+        (, , , bool exists) = bridge.queued(dk);
+        assertTrue(exists);
+    }
+
+    function test_Window_NoBoundaryBurst() public {
+        vm.prank(gov);
+        bridge.setLimits(type(uint256).max, 1_000, 100, 10_000, 1 hours, 7 days);
+
+        vm.warp(block.timestamp + 99);
+        uint64 deadline = _futureDeadline();
+
+        bytes32 txid1 = keccak256("boundary-1");
+        bytes memory proof1 = _attest(
+            txid1, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 990, deadline
+        );
+        bridge.mint(
+            txid1, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 990, deadline, proof1
+        );
+
+        vm.warp(block.timestamp + 1);
+        bytes32 txid2 = keccak256("boundary-2");
+        bytes memory proof2 = _attest(
+            txid2, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 20, deadline
+        );
+        bridge.mint(
+            txid2, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 20, deadline, proof2
+        );
+
+        bytes32 txid3 = keccak256("boundary-3");
+        bytes memory proof3 = _attest(
+            txid3, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1, deadline
+        );
+        vm.expectRevert(WBTXBridge.WindowCapExceeded.selector);
+        bridge.mint(
+            txid3, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1, deadline, proof3
+        );
+    }
+
+    function test_Window_QueueReservesNothing() public {
+        vm.prank(gov);
+        bridge.setLimits(type(uint256).max, 1_000, 100, 500, 1 hours, 7 days);
+
+        uint64 deadline = _futureDeadline();
+        bytes32 queuedTxid = keccak256("queue-reserve-1");
+        bytes memory queuedProof = _attest(
+            queuedTxid, 3, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 900, deadline
+        );
+        bridge.mint(
+            queuedTxid, 3, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 900, deadline, queuedProof
+        );
+        assertEq(bridge.availableSat(), 1_000);
+
+        vm.prank(guardian);
+        bridge.cancelQueuedMint(queuedTxid, 3);
+        assertEq(bridge.availableSat(), 1_000);
+
+        bytes32 fullCapTxid = keccak256("queue-reserve-2");
+        bytes memory fullCapProof = _attest(
+            fullCapTxid, 4, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline
+        );
+        bridge.mint(
+            fullCapTxid, 4, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline, fullCapProof
+        );
+        vm.warp(block.timestamp + 2 hours);
+        bridge.executeQueuedMint(fullCapTxid, 4);
+        assertEq(wbtx.balanceOf(address(0xBEEF)), 1_000 * 1e10);
+        assertEq(bridge.availableSat(), 0);
+    }
+
+    function test_Mint_RevertsWhenNotConfigured() public {
+        address[] memory signers = new address[](3);
+        signers[0] = vm.addr(pk1); signers[1] = vm.addr(pk2); signers[2] = vm.addr(pk3);
+        ECDSAMultisigVerifier verifier2 = new ECDSAMultisigVerifier(admin, 0, signers, 2);
+        WBTX wbtx2 = new WBTX(admin, 0);
+        WBTXBridge bridge2 = new WBTXBridge(wbtx2, IAttestationVerifier(address(verifier2)), 1, admin, 0);
+
+        vm.startPrank(admin);
+        wbtx2.grantRole(wbtx2.MINTER_ROLE(), address(bridge2));
+        wbtx2.grantRole(wbtx2.BURNER_ROLE(), address(bridge2));
+        bridge2.grantRole(bridge2.GOVERNANCE_ROLE(), gov);
+        vm.stopPrank();
+
+        bytes32 txid = keccak256("dep-not-configured");
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attestFor(
+            bridge2, txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline
+        );
+
+        vm.expectRevert(WBTXBridge.NotConfigured.selector);
+        bridge2.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline, proof
+        );
+
+        vm.prank(gov);
+        vm.expectRevert(WBTXBridge.ZeroBreakerValue.selector);
+        bridge2.setLimits(0, 1, 1, 1, 1, 7 days);
     }
 
     // --- redeem ---

--- a/contrib/wbtx/test/WBTX.t.sol
+++ b/contrib/wbtx/test/WBTX.t.sol
@@ -15,6 +15,7 @@ contract WBTXTest is Test {
     address admin = address(0xA11CE);
     address gov   = address(0x60F);     // governance (timelock stand-in)
     address guardian = address(0x6A7D);
+    address federation = address(0xFED);
     address pauser = address(0x9A05E);
     // three federation signers (sorted ascending by address for the proof)
     uint256 pk1 = 0xA11; uint256 pk2 = 0xB22; uint256 pk3 = 0xC33;
@@ -58,7 +59,7 @@ contract WBTXTest is Test {
         bridge.grantRole(bridge.GOVERNANCE_ROLE(), gov);
         bridge.grantRole(bridge.GUARDIAN_ROLE(), guardian);
         bridge.grantRole(bridge.PAUSER_ROLE(), pauser);
-        bridge.grantRole(bridge.FEDERATION_ROLE(), gov);
+        bridge.grantRole(bridge.FEDERATION_ROLE(), federation);
         verifier.grantRole(verifier.GUARDIAN_ROLE(), guardian);
         vm.stopPrank();
 
@@ -77,6 +78,23 @@ contract WBTXTest is Test {
 
     function _futureDeadline() internal view returns (uint64) {
         return uint64(block.timestamp + 1 days);
+    }
+
+    function _proofForDigest(bytes32 digest) internal view returns (bytes memory) {
+        // sign with pk1 and pk2, then order by recovered address ascending
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(pk1, digest);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(pk2, digest);
+        bytes memory sigA = abi.encodePacked(r1, s1, v1);
+        bytes memory sigB = abi.encodePacked(r2, s2, v2);
+        bytes[] memory sigs = new bytes[](2);
+        if (vm.addr(pk1) < vm.addr(pk2)) {
+            sigs[0] = sigA;
+            sigs[1] = sigB;
+        } else {
+            sigs[0] = sigB;
+            sigs[1] = sigA;
+        }
+        return abi.encode(sigs);
     }
 
     function _attestFor(
@@ -101,15 +119,7 @@ contract WBTXTest is Test {
             amtSat,
             deadline
         );
-        // sign with pk1 and pk2, then order by recovered address ascending
-        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(pk1, digest);
-        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(pk2, digest);
-        bytes memory sigA = abi.encodePacked(r1, s1, v1);
-        bytes memory sigB = abi.encodePacked(r2, s2, v2);
-        bytes[] memory sigs = new bytes[](2);
-        if (vm.addr(pk1) < vm.addr(pk2)) { sigs[0] = sigA; sigs[1] = sigB; }
-        else { sigs[0] = sigB; sigs[1] = sigA; }
-        return abi.encode(sigs);
+        return _proofForDigest(digest);
     }
 
     function _attest(
@@ -123,6 +133,46 @@ contract WBTXTest is Test {
         uint64 deadline
     ) internal view returns (bytes memory) {
         return _attestFor(bridge, txid, vout, btxBlockHash, btxBlockHeight, attestedHeight, to, amtSat, deadline);
+    }
+
+    function _attestFulfill(
+        uint256 redeemId,
+        bytes32 btxTxid,
+        bytes32 destHash,
+        uint64 amountSat,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        uint64 deadline
+    ) internal view returns (bytes memory) {
+        bytes32 digest = bridge.fulfillDigest(
+            bridge.bridgeId(),
+            redeemId,
+            btxTxid,
+            destHash,
+            amountSat,
+            btxBlockHeight,
+            attestedHeight,
+            deadline
+        );
+        return _proofForDigest(digest);
+    }
+
+    function _attestNonRelease(
+        uint256 redeemId,
+        bytes32 destHash,
+        uint64 amountSat,
+        uint64 asOfBtxHeight,
+        uint64 deadline
+    ) internal view returns (bytes memory) {
+        bytes32 digest = bridge.nonReleaseDigest(
+            bridge.bridgeId(),
+            redeemId,
+            destHash,
+            amountSat,
+            asOfBtxHeight,
+            deadline
+        );
+        return _proofForDigest(digest);
     }
 
     // --- mint ---
@@ -448,17 +498,263 @@ contract WBTXTest is Test {
         );
         // redeem 1 BTX + 0.5 sat dust -> releases 100000000 sat (rounded down), burns the full amount
         uint256 amt = 100_000_000 * 1e10 + 5e9;
+        bytes memory destination = hex"00aabb";
         wbtx.approve(address(bridge), amt);
-        uint256 id = bridge.redeem(amt, hex"00aabb");
+        uint256 id = bridge.redeem(amt, destination);
         assertEq(wbtx.totalSupply(), 2e18 - amt);                  // full burn incl dust
-        ( , uint64 sat, , , bool fulfilled, ) = bridge.redeems(id);
+        (, uint64 sat, , , , bytes32 destHash, , bool fulfilled, ) = bridge.redeems(id);
         assertEq(sat, 100_000_000);                                // rounded down
+        assertEq(destHash, keccak256(destination));
         assertEq(fulfilled, false);
-        // refund after timeout re-mints the burned amount to the burner
+        // refund after timeout needs an attested non-release statement.
         vm.warp(block.timestamp + 8 days);
+        uint64 asOfBtxHeight = DEFAULT_ATTESTED_HEIGHT + 10;
+        uint64 refundDeadline = _futureDeadline();
+        bytes memory nonReleaseProof = _attestNonRelease(id, destHash, sat, asOfBtxHeight, refundDeadline);
         vm.prank(gov);
-        bridge.refundRedeem(id);
+        bridge.refundRedeem(id, asOfBtxHeight, refundDeadline, nonReleaseProof);
         assertEq(wbtx.balanceOf(address(this)), 2e18);             // made whole
+    }
+
+    function test_FulfillRedeem_RequiresAttestationAndDepth() public {
+        bytes32 txid = keccak256("redeem-fulfill-setup");
+        uint64 mintDeadline = _futureDeadline();
+        bytes memory mintProof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 200_000_000, mintDeadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 200_000_000, mintDeadline, mintProof
+        );
+
+        uint256 redeemAmount = 100_000_000 * 1e10;
+        bytes memory destination = hex"1122aabb";
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, destination);
+        (, uint64 amountSat, , , , bytes32 destHash, , , ) = bridge.redeems(redeemId);
+
+        bytes32 btxTxid = keccak256("release-txid-1");
+        uint64 fulfillDeadline = _futureDeadline();
+        uint64 shallowAttestedHeight = DEFAULT_BTX_BLOCK_HEIGHT + 99;
+        bytes memory shallowProof = _attestFulfill(
+            redeemId,
+            btxTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            shallowAttestedHeight,
+            fulfillDeadline
+        );
+        vm.prank(federation);
+        vm.expectRevert(WBTXBridge.TooShallow.selector);
+        bridge.fulfillRedeem(
+            redeemId,
+            btxTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            shallowAttestedHeight,
+            fulfillDeadline,
+            shallowProof
+        );
+
+        bytes memory forgedProof = _attestFulfill(
+            redeemId,
+            keccak256("different-release"),
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline
+        );
+        vm.prank(federation);
+        vm.expectRevert(WBTXBridge.BadAttestation.selector);
+        bridge.fulfillRedeem(
+            redeemId,
+            btxTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline,
+            forgedProof
+        );
+
+        bytes memory validProof = _attestFulfill(
+            redeemId,
+            btxTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline
+        );
+        vm.prank(federation);
+        bridge.fulfillRedeem(
+            redeemId,
+            btxTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline,
+            validProof
+        );
+        (, , , , uint64 fulfilledAt, , bytes32 storedTxid, bool fulfilled, ) = bridge.redeems(redeemId);
+        assertTrue(fulfilled);
+        assertGt(fulfilledAt, 0);
+        assertEq(storedTxid, btxTxid);
+    }
+
+    function test_UnfulfillRedeem_ReopensRefund() public {
+        bytes32 txid = keccak256("redeem-unfulfill-setup");
+        uint64 mintDeadline = _futureDeadline();
+        bytes memory mintProof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline, mintProof
+        );
+
+        uint256 redeemAmount = 100_000_000 * 1e10;
+        bytes memory destination = hex"99aabb";
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, destination);
+        (, uint64 amountSat, , , , bytes32 destHash, , , ) = bridge.redeems(redeemId);
+
+        bytes32 releaseTxid = keccak256("release-txid-2");
+        uint64 fulfillDeadline = _futureDeadline();
+        bytes memory fulfillProof = _attestFulfill(
+            redeemId,
+            releaseTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline
+        );
+        vm.prank(federation);
+        bridge.fulfillRedeem(
+            redeemId,
+            releaseTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline,
+            fulfillProof
+        );
+
+        vm.prank(guardian);
+        bridge.unfulfillRedeem(redeemId);
+        (, , , , uint64 fulfilledAt, , bytes32 storedTxid, bool fulfilled, ) = bridge.redeems(redeemId);
+        assertFalse(fulfilled);
+        assertEq(fulfilledAt, 0);
+        assertEq(storedTxid, bytes32(0));
+
+        vm.warp(block.timestamp + 8 days);
+        uint64 asOfBtxHeight = DEFAULT_ATTESTED_HEIGHT + 20;
+        uint64 refundDeadline = _futureDeadline();
+        bytes memory nonReleaseProof = _attestNonRelease(redeemId, destHash, amountSat, asOfBtxHeight, refundDeadline);
+        vm.prank(gov);
+        bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, nonReleaseProof);
+        assertEq(wbtx.balanceOf(address(this)), redeemAmount);
+    }
+
+    function test_RefundRedeem_RequiresNonReleaseAttestation() public {
+        bytes32 txid = keccak256("redeem-non-release-required");
+        uint64 mintDeadline = _futureDeadline();
+        bytes memory mintProof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline, mintProof
+        );
+
+        uint256 redeemAmount = 10_000 * 1e10;
+        bytes memory destination = hex"44aabb";
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, destination);
+        (, uint64 amountSat, , , , bytes32 destHash, , , ) = bridge.redeems(redeemId);
+
+        vm.warp(block.timestamp + 8 days);
+        uint64 asOfBtxHeight = DEFAULT_ATTESTED_HEIGHT + 5;
+        uint64 refundDeadline = _futureDeadline();
+        bytes memory forgedProof = _attestNonRelease(redeemId, destHash, amountSat, asOfBtxHeight + 1, refundDeadline);
+
+        vm.prank(gov);
+        vm.expectRevert(WBTXBridge.BadAttestation.selector);
+        bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, forgedProof);
+    }
+
+    function test_RefundRedeem_RoutesThroughSupplyCap() public {
+        bytes32 txid = keccak256("redeem-refund-cap-setup");
+        uint64 mintDeadline = _futureDeadline();
+        bytes memory mintProof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000, mintDeadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000, mintDeadline, mintProof
+        );
+
+        uint256 redeemAmount = 100_000 * 1e10;
+        bytes memory destination = hex"55aabb";
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, destination);
+        (, uint64 amountSat, , , , bytes32 destHash, , , ) = bridge.redeems(redeemId);
+        vm.warp(block.timestamp + 8 days);
+
+        uint64 asOfBtxHeight = DEFAULT_ATTESTED_HEIGHT + 7;
+        uint64 refundDeadline = _futureDeadline();
+        bytes memory nonReleaseProof = _attestNonRelease(redeemId, destHash, amountSat, asOfBtxHeight, refundDeadline);
+
+        vm.prank(gov);
+        bridge.setLimits(type(uint256).max, amountSat - 1, 1 days, 1_000_000, DEFAULT_GUARDIAN_DELAY, 7 days);
+        vm.prank(gov);
+        vm.expectRevert(WBTXBridge.WindowCapExceeded.selector);
+        bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, nonReleaseProof);
+
+        vm.prank(gov);
+        bridge.setLimits(redeemAmount - 1, amountSat, 1 days, 1_000_000, DEFAULT_GUARDIAN_DELAY, 7 days);
+        vm.prank(gov);
+        vm.expectRevert(WBTXBridge.SupplyCapExceeded.selector);
+        bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, nonReleaseProof);
+
+        vm.prank(gov);
+        bridge.setLimits(redeemAmount, amountSat, 1 days, 1_000_000, DEFAULT_GUARDIAN_DELAY, 7 days);
+        bytes32 refundKey = keccak256(abi.encodePacked("redeem-refund", redeemId));
+        vm.expectEmit(true, true, false, true, address(bridge));
+        emit WBTXBridge.MintExecuted(refundKey, bytes32(0), 0, address(this), amountSat, redeemAmount);
+        vm.prank(gov);
+        bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, nonReleaseProof);
+        assertEq(wbtx.balanceOf(address(this)), redeemAmount);
+    }
+
+    function test_RefundRedeem_WorksWhileIssuancePaused() public {
+        bytes32 txid = keccak256("redeem-refund-paused");
+        uint64 mintDeadline = _futureDeadline();
+        bytes memory mintProof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline, mintProof
+        );
+
+        uint256 redeemAmount = 25_000_000 * 1e10;
+        bytes memory destination = hex"66aabb";
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, destination);
+        (, uint64 amountSat, , , , bytes32 destHash, , , ) = bridge.redeems(redeemId);
+        vm.warp(block.timestamp + 8 days);
+
+        vm.prank(pauser);
+        wbtx.pauseIssuance();
+
+        uint64 asOfBtxHeight = DEFAULT_ATTESTED_HEIGHT + 11;
+        uint64 refundDeadline = _futureDeadline();
+        bytes memory nonReleaseProof = _attestNonRelease(redeemId, destHash, amountSat, asOfBtxHeight, refundDeadline);
+        vm.prank(gov);
+        bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, nonReleaseProof);
+        assertEq(wbtx.balanceOf(address(this)), 100_000_000 * 1e10);
     }
 
     // --- token roles / rescue / pause ---
@@ -724,6 +1020,14 @@ contract MockVerifier is IAttestationVerifier {
     }
 
     function verifyMint(bytes32, bytes calldata) external view returns (bool) {
+        return allow;
+    }
+
+    function verifyFulfill(bytes32, bytes calldata) external view returns (bool) {
+        return allow;
+    }
+
+    function verifyNonRelease(bytes32, bytes calldata) external view returns (bool) {
         return allow;
     }
 }

--- a/contrib/wbtx/test/WBTX.t.sol
+++ b/contrib/wbtx/test/WBTX.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {WBTX, IComplianceHook} from "../evm/WBTX.sol";
 import {WBTXBridge, ECDSAMultisigVerifier, IAttestationVerifier} from "../evm/WBTXBridge.sol";
 import {WBTXAtomicSwapHTLC} from "../evm/WBTXAtomicSwapHTLC.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract WBTXTest is Test {
@@ -1145,7 +1146,7 @@ contract HTLCTest is Test {
         bytes20 h = htlc.btxHash160(pre);
         vm.startPrank(alice);
         token.approve(address(htlc), 100e18);
-        bytes32 id = htlc.open(bob, address(token), 100e18, h, uint64(block.timestamp + 1 hours), bytes32("s"));
+        bytes32 id = htlc.open(bob, address(token), 100e18, h, uint64(block.timestamp + 7 hours), bytes32("s"));
         vm.stopPrank();
         vm.prank(bob);
         htlc.claim(id, pre);
@@ -1156,11 +1157,87 @@ contract HTLCTest is Test {
         bytes20 h = bytes20(hex"8739f40ec4dbf569dcb38134c6e7310908566981");
         vm.startPrank(alice);
         token.approve(address(htlc), 100e18);
-        bytes32 id = htlc.open(bob, address(token), 100e18, h, uint64(block.timestamp + 1 hours), bytes32("s"));
+        bytes32 id = htlc.open(bob, address(token), 100e18, h, uint64(block.timestamp + 7 hours), bytes32("s"));
         vm.stopPrank();
-        vm.warp(block.timestamp + 2 hours);
-        vm.prank(alice);
+        vm.warp(block.timestamp + 8 hours);
+        vm.prank(address(0xCA11AB1E));
         htlc.refund(id);
         assertEq(token.balanceOf(alice), 1000e18);
+    }
+
+    function test_ClaimRevertsWhenExpired() public {
+        bytes memory pre = new bytes(32);
+        for (uint i; i < 32; i++) pre[i] = 0x42;
+        bytes20 h = htlc.btxHash160(pre);
+
+        vm.startPrank(alice);
+        token.approve(address(htlc), 100e18);
+        bytes32 id = htlc.open(bob, address(token), 100e18, h, uint64(block.timestamp + 7 hours), bytes32("s-expired"));
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 8 hours);
+        vm.prank(bob);
+        vm.expectRevert(WBTXAtomicSwapHTLC.Expired.selector);
+        htlc.claim(id, pre);
+    }
+
+    function test_RefundAfterTimeoutAllowsThirdParty() public {
+        bytes20 h = bytes20(hex"8739f40ec4dbf569dcb38134c6e7310908566981");
+        vm.startPrank(alice);
+        token.approve(address(htlc), 100e18);
+        bytes32 id = htlc.open(bob, address(token), 100e18, h, uint64(block.timestamp + 7 hours), bytes32("s-watchtower"));
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 8 hours);
+        address watchtower = address(0xC0FFEE);
+        vm.prank(watchtower);
+        htlc.refund(id);
+        assertEq(token.balanceOf(alice), 1000e18);
+        assertEq(token.balanceOf(bob), 0);
+    }
+
+    function test_OpenRevertsOnFeeOnTransferUnderfunding() public {
+        MockFeeOnTransferToken feeToken = new MockFeeOnTransferToken(100); // 1%
+        feeToken.mint(alice, 1000e18);
+
+        bytes memory pre = new bytes(32);
+        for (uint i; i < 32; i++) pre[i] = 0x42;
+        bytes20 h = htlc.btxHash160(pre);
+
+        vm.startPrank(alice);
+        feeToken.approve(address(htlc), 100e18);
+        vm.expectRevert(abi.encodeWithSelector(WBTXAtomicSwapHTLC.AmountMismatch.selector, 100e18, 99e18));
+        htlc.open(bob, address(feeToken), 100e18, h, uint64(block.timestamp + 7 hours), bytes32("s-fee"));
+        vm.stopPrank();
+    }
+}
+
+contract MockFeeOnTransferToken is ERC20 {
+    uint256 public immutable feeBps;
+
+    constructor(uint256 feeBps_) ERC20("Fee Token", "FEE") {
+        feeBps = feeBps_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function transfer(address to, uint256 amount) public override returns (bool) {
+        address owner = _msgSender();
+        uint256 fee = (amount * feeBps) / 10_000;
+        uint256 net = amount - fee;
+        _transfer(owner, to, net);
+        if (fee > 0) _transfer(owner, address(0xDEAD), fee);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        _spendAllowance(from, _msgSender(), amount);
+        uint256 fee = (amount * feeBps) / 10_000;
+        uint256 net = amount - fee;
+        _transfer(from, to, net);
+        if (fee > 0) _transfer(from, address(0xDEAD), fee);
+        return true;
     }
 }

--- a/contrib/wbtx/test/WBTX.t.sol
+++ b/contrib/wbtx/test/WBTX.t.sol
@@ -29,6 +29,7 @@ contract WBTXTest is Test {
     uint64 constant DEFAULT_OPTIMISTIC_THRESHOLD_SAT = 2_100_000_000_000_000;
     uint64 constant DEFAULT_GUARDIAN_DELAY = 6 hours;
     uint64 constant DEFAULT_REDEEM_REFUND_TIMEOUT = 7 days;
+    uint48 constant BRIDGE_ADMIN_DELAY = 1 days;
 
     function _initialSignersSorted() internal view returns (address[] memory signers) {
         signers = new address[](3);
@@ -52,7 +53,7 @@ contract WBTXTest is Test {
         uint256 deployerNonce = vm.getNonce(address(this));
         address predictedBridge = vm.computeCreateAddress(address(this), deployerNonce + 1);
         wbtx = new WBTX(admin, 0, predictedBridge);
-        bridge = new WBTXBridge(wbtx, IAttestationVerifier(address(verifier)), 1, admin, 0);
+        bridge = new WBTXBridge(wbtx, IAttestationVerifier(address(verifier)), 1, admin, BRIDGE_ADMIN_DELAY);
 
         vm.startPrank(admin);
         wbtx.grantRole(wbtx.PAUSER_ROLE(), pauser);
@@ -306,16 +307,18 @@ contract WBTXTest is Test {
 
     function test_WindowCapEnforced() public {
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, 50_000, 1 hours, 1_000_000, 6 hours, 7 days); // window cap 50k sat
+        bridge.setLimits(type(uint256).max, 50_000, 1 hours, 50_000, 6 hours, 7 days); // queue mints > 50k sat
         bytes32 txid = keccak256("dep5");
         uint64 deadline = _futureDeadline();
         bytes memory proof = _attest(
             txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 60_000, deadline
         );
-        vm.expectRevert(WBTXBridge.WindowCapExceeded.selector);
         bridge.mint(
             txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 60_000, deadline, proof
         );
+        vm.warp(block.timestamp + 7 hours);
+        vm.expectRevert(WBTXBridge.WindowCapExceeded.selector);
+        bridge.executeQueuedMint(txid, 0);
     }
 
     function test_GuardianVetoFlow() public {
@@ -395,7 +398,7 @@ contract WBTXTest is Test {
 
     function test_Window_NoBoundaryBurst() public {
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, 1_000, 100, 10_000, 6 hours, 7 days);
+        bridge.setLimits(type(uint256).max, 1_000, 100, 1_000, 6 hours, 7 days);
 
         vm.warp(block.timestamp + 99);
         uint64 deadline = _futureDeadline();
@@ -464,7 +467,7 @@ contract WBTXTest is Test {
         uint256 deployerNonce = vm.getNonce(address(this));
         address predictedBridge2 = vm.computeCreateAddress(address(this), deployerNonce + 1);
         WBTX wbtx2 = new WBTX(admin, 0, predictedBridge2);
-        WBTXBridge bridge2 = new WBTXBridge(wbtx2, IAttestationVerifier(address(verifier2)), 1, admin, 0);
+        WBTXBridge bridge2 = new WBTXBridge(wbtx2, IAttestationVerifier(address(verifier2)), 1, admin, BRIDGE_ADMIN_DELAY);
 
         vm.startPrank(admin);
         bridge2.grantRole(bridge2.GOVERNANCE_ROLE(), gov);
@@ -606,6 +609,168 @@ contract WBTXTest is Test {
         assertEq(storedTxid, btxTxid);
     }
 
+    function test_Fulfill_RejectsZeroTxid() public {
+        bytes32 txid = keccak256("redeem-fulfill-zero-txid");
+        uint64 mintDeadline = _futureDeadline();
+        bytes memory mintProof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline, mintProof
+        );
+
+        uint256 redeemAmount = 10_000 * 1e10;
+        bytes memory destination = hex"77aabb";
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, destination);
+        (, uint64 amountSat, , , , bytes32 destHash, , , ) = bridge.redeems(redeemId);
+
+        uint64 fulfillDeadline = _futureDeadline();
+        bytes memory proof = _attestFulfill(
+            redeemId,
+            bytes32(0),
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline
+        );
+
+        vm.prank(federation);
+        vm.expectRevert(WBTXBridge.BadAttestation.selector);
+        bridge.fulfillRedeem(
+            redeemId,
+            bytes32(0),
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline,
+            proof
+        );
+    }
+
+    function test_Fulfill_RejectsRevoked() public {
+        bytes32 txid = keccak256("redeem-fulfill-revoked");
+        uint64 mintDeadline = _futureDeadline();
+        bytes memory mintProof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline, mintProof
+        );
+
+        uint256 redeemAmount = 20_000 * 1e10;
+        bytes memory destination = hex"88aabb";
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, destination);
+        (, uint64 amountSat, , , , bytes32 destHash, , , ) = bridge.redeems(redeemId);
+
+        bytes32 releaseTxid = keccak256("release-revoked");
+        uint64 fulfillDeadline = _futureDeadline();
+        bytes memory fulfillProof = _attestFulfill(
+            redeemId,
+            releaseTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline
+        );
+        vm.prank(federation);
+        bridge.fulfillRedeem(
+            redeemId,
+            releaseTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline,
+            fulfillProof
+        );
+
+        vm.prank(guardian);
+        bridge.unfulfillRedeem(redeemId);
+        assertTrue(bridge.fulfillmentRevoked(redeemId));
+
+        bytes memory refillProof = _attestFulfill(
+            redeemId,
+            keccak256("release-retry"),
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline
+        );
+        vm.prank(federation);
+        vm.expectRevert(WBTXBridge.FulfillmentPermanentlyRevoked.selector);
+        bridge.fulfillRedeem(
+            redeemId,
+            keccak256("release-retry"),
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline,
+            refillProof
+        );
+    }
+
+    function test_Refund_FulfilledRedeem_WithNonRelease() public {
+        bytes32 txid = keccak256("refund-fulfilled-nonrelease");
+        uint64 mintDeadline = _futureDeadline();
+        bytes memory mintProof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 100_000_000, mintDeadline, mintProof
+        );
+
+        uint256 redeemAmount = 50_000_000 * 1e10;
+        bytes memory destination = hex"abcd";
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, destination);
+        (, uint64 amountSat, , , , bytes32 destHash, , , ) = bridge.redeems(redeemId);
+
+        bytes32 releaseTxid = keccak256("fulfilled-before-refund");
+        uint64 fulfillDeadline = _futureDeadline();
+        bytes memory fulfillProof = _attestFulfill(
+            redeemId,
+            releaseTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline
+        );
+        vm.prank(federation);
+        bridge.fulfillRedeem(
+            redeemId,
+            releaseTxid,
+            destHash,
+            amountSat,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            fulfillDeadline,
+            fulfillProof
+        );
+
+        vm.warp(block.timestamp + 8 days);
+        uint64 asOfBtxHeight = DEFAULT_ATTESTED_HEIGHT + 15;
+        uint64 refundDeadline = _futureDeadline();
+        bytes memory nonReleaseProof = _attestNonRelease(redeemId, destHash, amountSat, asOfBtxHeight, refundDeadline);
+        vm.prank(gov);
+        bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, nonReleaseProof);
+
+        (, , , , uint64 fulfilledAt, , bytes32 storedTxid, bool fulfilled, bool refunded) = bridge.redeems(redeemId);
+        assertFalse(fulfilled);
+        assertTrue(refunded);
+        assertEq(fulfilledAt, 0);
+        assertEq(storedTxid, bytes32(0));
+        assertFalse(fulfilled && refunded);
+        assertEq(wbtx.balanceOf(address(this)), 100_000_000 * 1e10);
+    }
+
     function test_UnfulfillRedeem_ReopensRefund() public {
         bytes32 txid = keccak256("redeem-unfulfill-setup");
         uint64 mintDeadline = _futureDeadline();
@@ -709,19 +874,20 @@ contract WBTXTest is Test {
         bytes memory nonReleaseProof = _attestNonRelease(redeemId, destHash, amountSat, asOfBtxHeight, refundDeadline);
 
         vm.prank(gov);
-        bridge.setLimits(type(uint256).max, amountSat - 1, 1 days, 1_000_000, DEFAULT_GUARDIAN_DELAY, 7 days);
+        bridge.setLimits(type(uint256).max, amountSat - 1, 1 days, amountSat - 1, DEFAULT_GUARDIAN_DELAY, 7 days);
         vm.prank(gov);
         vm.expectRevert(WBTXBridge.WindowCapExceeded.selector);
         bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, nonReleaseProof);
 
         vm.prank(gov);
-        bridge.setLimits(redeemAmount - 1, amountSat, 1 days, 1_000_000, DEFAULT_GUARDIAN_DELAY, 7 days);
+        bridge.setLimits(redeemAmount - 1, amountSat, 1 days, amountSat, DEFAULT_GUARDIAN_DELAY, 7 days);
+        vm.warp(block.timestamp + 1);
         vm.prank(gov);
         vm.expectRevert(WBTXBridge.SupplyCapExceeded.selector);
         bridge.refundRedeem(redeemId, asOfBtxHeight, refundDeadline, nonReleaseProof);
 
         vm.prank(gov);
-        bridge.setLimits(redeemAmount, amountSat, 1 days, 1_000_000, DEFAULT_GUARDIAN_DELAY, 7 days);
+        bridge.setLimits(redeemAmount, amountSat, 1 days, amountSat, DEFAULT_GUARDIAN_DELAY, 7 days);
         bytes32 refundKey = keccak256(abi.encodePacked("redeem-refund", redeemId));
         vm.expectEmit(true, true, false, true, address(bridge));
         emit WBTXBridge.MintExecuted(refundKey, bytes32(0), 0, address(this), amountSat, redeemAmount);
@@ -977,6 +1143,13 @@ contract WBTXTest is Test {
         vm.stopPrank();
     }
 
+    function test_SetLimits_RejectsThresholdAboveWindow() public {
+        vm.startPrank(gov);
+        vm.expectRevert(WBTXBridge.ThresholdAboveWindowCap.selector);
+        bridge.setLimits(type(uint256).max, 100_000, 1 hours, 100_001, 6 hours, 7 days);
+        vm.stopPrank();
+    }
+
     function test_GranularPause() public {
         bytes32 txid = keccak256("gp");
         uint64 deadline = _futureDeadline();
@@ -988,7 +1161,7 @@ contract WBTXTest is Test {
         bridge.mint(
             txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 1_000, deadline, proof
         ); // mint blocked
-        vm.prank(pauser); bridge.setMintPaused(false);
+        vm.prank(gov); bridge.setMintPaused(false);
         bridge.mint(
             txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 1_000, deadline, proof
         ); // mint works again

--- a/contrib/wbtx/test/WBTX.t.sol
+++ b/contrib/wbtx/test/WBTX.t.sol
@@ -47,12 +47,12 @@ contract WBTXTest is Test {
     function setUp() public {
         address[] memory signers = _initialSignersSorted();
         verifier = new ECDSAMultisigVerifier(admin, 0, signers, 2); // 2-of-3
-        wbtx = new WBTX(admin, 0);
+        uint256 deployerNonce = vm.getNonce(address(this));
+        address predictedBridge = vm.computeCreateAddress(address(this), deployerNonce + 1);
+        wbtx = new WBTX(admin, 0, predictedBridge);
         bridge = new WBTXBridge(wbtx, IAttestationVerifier(address(verifier)), 1, admin, 0);
 
         vm.startPrank(admin);
-        wbtx.grantRole(wbtx.MINTER_ROLE(), address(bridge));
-        wbtx.grantRole(wbtx.BURNER_ROLE(), address(bridge));
         wbtx.grantRole(wbtx.PAUSER_ROLE(), pauser);
         wbtx.grantRole(wbtx.UNPAUSER_ROLE(), admin);
         bridge.grantRole(bridge.GOVERNANCE_ROLE(), gov);
@@ -410,12 +410,12 @@ contract WBTXTest is Test {
     function test_Mint_RevertsWhenNotConfigured() public {
         address[] memory signers = _initialSignersSorted();
         ECDSAMultisigVerifier verifier2 = new ECDSAMultisigVerifier(admin, 0, signers, 2);
-        WBTX wbtx2 = new WBTX(admin, 0);
+        uint256 deployerNonce = vm.getNonce(address(this));
+        address predictedBridge2 = vm.computeCreateAddress(address(this), deployerNonce + 1);
+        WBTX wbtx2 = new WBTX(admin, 0, predictedBridge2);
         WBTXBridge bridge2 = new WBTXBridge(wbtx2, IAttestationVerifier(address(verifier2)), 1, admin, 0);
 
         vm.startPrank(admin);
-        wbtx2.grantRole(wbtx2.MINTER_ROLE(), address(bridge2));
-        wbtx2.grantRole(wbtx2.BURNER_ROLE(), address(bridge2));
         bridge2.grantRole(bridge2.GOVERNANCE_ROLE(), gov);
         vm.stopPrank();
 
@@ -448,6 +448,7 @@ contract WBTXTest is Test {
         );
         // redeem 1 BTX + 0.5 sat dust -> releases 100000000 sat (rounded down), burns the full amount
         uint256 amt = 100_000_000 * 1e10 + 5e9;
+        wbtx.approve(address(bridge), amt);
         uint256 id = bridge.redeem(amt, hex"00aabb");
         assertEq(wbtx.totalSupply(), 2e18 - amt);                  // full burn incl dust
         ( , uint64 sat, , , bool fulfilled, ) = bridge.redeems(id);
@@ -463,8 +464,119 @@ contract WBTXTest is Test {
     // --- token roles / rescue / pause ---
 
     function test_OnlyBridgeMints() public {
+        vm.expectRevert(WBTX.NotBridge.selector);
+        wbtx.mint(address(this), 1);
+
+        vm.prank(address(bridge));
+        wbtx.mint(address(this), 1);
+        assertEq(wbtx.balanceOf(address(this)), 1);
+    }
+
+    function test_BurnRequiresAllowance() public {
+        address aliceUser = address(0xA71CE);
+        address bobUser = address(0xB0B1);
+        address spender = address(0xD00D);
+
+        vm.prank(address(bridge));
+        wbtx.mint(aliceUser, 10e18);
+        vm.prank(address(bridge));
+        wbtx.mint(bobUser, 5e18);
+
+        vm.prank(address(bridge));
         vm.expectRevert();
-        wbtx.mint(address(this), 1);                                // not MINTER_ROLE
+        wbtx.burn(aliceUser, 1e18);
+
+        vm.prank(spender);
+        vm.expectRevert();
+        wbtx.burnFrom(aliceUser, 1e18);
+
+        vm.prank(aliceUser);
+        wbtx.approve(address(bridge), 2e18);
+        vm.prank(address(bridge));
+        wbtx.burn(aliceUser, 2e18);
+        assertEq(wbtx.balanceOf(aliceUser), 8e18);
+
+        vm.prank(aliceUser);
+        wbtx.approve(spender, 1e18);
+        vm.prank(spender);
+        wbtx.burnFrom(aliceUser, 1e18);
+        assertEq(wbtx.balanceOf(aliceUser), 7e18);
+
+        vm.prank(address(bridge));
+        vm.expectRevert();
+        wbtx.burn(bobUser, 1e18);
+        assertEq(wbtx.balanceOf(bobUser), 5e18);
+    }
+
+    function test_ComplianceHook_ExcludesIssuance() public {
+        bytes32 txid1 = keccak256("hook-issuance-1");
+        uint64 deadline1 = _futureDeadline();
+        bytes memory proof1 = _attest(
+            txid1, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 2_000, deadline1
+        );
+        bridge.mint(
+            txid1, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 2_000, deadline1, proof1
+        );
+
+        MockRevertingHook badHook = new MockRevertingHook();
+        vm.prank(admin);
+        wbtx.setComplianceHook(badHook);
+
+        wbtx.transfer(address(0xBEEF), 1_000 * 1e10);
+
+        bytes32 txid2 = keccak256("hook-issuance-2");
+        uint64 deadline2 = _futureDeadline();
+        bytes memory proof2 = _attest(
+            txid2, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 1_000, deadline2
+        );
+        bridge.mint(
+            txid2, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 1_000, deadline2, proof2
+        );
+
+        uint256 redeemAmount = 500 * 1e10;
+        wbtx.approve(address(bridge), redeemAmount);
+        uint256 redeemId = bridge.redeem(redeemAmount, hex"00aabb");
+        assertGt(redeemId, 0);
+    }
+
+    function test_ComplianceHook_CannotBrick() public {
+        vm.prank(address(bridge));
+        wbtx.mint(address(this), 5e18);
+
+        MockRevertingHook revertingHook = new MockRevertingHook();
+        vm.prank(admin);
+        wbtx.setComplianceHook(revertingHook);
+        wbtx.transfer(address(0xBEEF), 1e18);
+        assertEq(wbtx.balanceOf(address(0xBEEF)), 1e18);
+
+        MockGasBurningHook gasBurningHook = new MockGasBurningHook();
+        vm.prank(admin);
+        wbtx.setComplianceHook(gasBurningHook);
+        wbtx.transfer(address(0xCAFE), 1e18);
+        assertEq(wbtx.balanceOf(address(0xCAFE)), 1e18);
+    }
+
+    function test_ClearComplianceHook() public {
+        MockRevertingHook badHook = new MockRevertingHook();
+        vm.prank(admin);
+        wbtx.setComplianceHook(badHook);
+        assertTrue(address(wbtx.complianceHook()) != address(0));
+
+        vm.prank(pauser);
+        wbtx.clearComplianceHook();
+        assertEq(address(wbtx.complianceHook()), address(0));
+    }
+
+    function test_MintRefund_WorksWhilePaused() public {
+        vm.prank(pauser);
+        wbtx.pauseIssuance();
+
+        vm.prank(address(bridge));
+        wbtx.mintRefund(address(this), 123);
+        assertEq(wbtx.balanceOf(address(this)), 123);
+
+        vm.expectRevert(WBTX.NotBridge.selector);
+        wbtx.mintRefund(address(this), 1);
     }
 
     function test_IssuancePauseBlocksMint() public {
@@ -616,6 +728,18 @@ contract MockVerifier is IAttestationVerifier {
     }
 }
 
+contract MockRevertingHook is IComplianceHook {
+    function check(address, address, uint256) external pure {
+        revert("hook-revert");
+    }
+}
+
+contract MockGasBurningHook is IComplianceHook {
+    function check(address, address, uint256) external pure {
+        while (true) {}
+    }
+}
+
 contract MockBlockHook is IComplianceHook {
     address public blocked;
     constructor(address b) { blocked = b; }
@@ -633,11 +757,9 @@ contract WBTXTokenTest is Test {
 
     function setUp() public {
         alice = vm.addr(alicePk);
-        wbtx = new WBTX(admin, 0);
-        vm.startPrank(admin);
-        wbtx.grantRole(wbtx.MINTER_ROLE(), admin);
+        wbtx = new WBTX(admin, 0, admin);
+        vm.prank(admin);
         wbtx.mint(alice, 1000e18);
-        vm.stopPrank();
     }
 
     function _digest(bytes32 structHash) internal view returns (bytes32) {
@@ -667,19 +789,18 @@ contract WBTXTokenTest is Test {
         assertEq(wbtx.balanceOf(bob), 5e18);
     }
 
-    function test_ComplianceHookBlocks() public {
+    function test_ComplianceHookFailOpen() public {
         MockBlockHook hook = new MockBlockHook(bob);
         vm.prank(admin);
         wbtx.setComplianceHook(hook);
         vm.prank(alice);
-        vm.expectRevert(bytes("blocked"));
-        wbtx.transfer(bob, 1e18);
-        // removing the hook restores neutrality
-        vm.prank(admin);
-        wbtx.setComplianceHook(IComplianceHook(address(0)));
-        vm.prank(alice);
         wbtx.transfer(bob, 1e18);
         assertEq(wbtx.balanceOf(bob), 1e18);
+        vm.prank(admin);
+        wbtx.setComplianceHook(IComplianceHook(address(0)));
+        vm.prank(admin);
+        vm.expectRevert(WBTX.BadComplianceHook.selector);
+        wbtx.setComplianceHook(IComplianceHook(address(0xBEEF)));
     }
 
     function test_Permit() public {
@@ -702,11 +823,9 @@ contract HTLCTest is Test {
 
     function setUp() public {
         htlc = new WBTXAtomicSwapHTLC();
-        token = new WBTX(admin, 0);
-        vm.startPrank(admin);
-        token.grantRole(token.MINTER_ROLE(), admin);
+        token = new WBTX(admin, 0, admin);
+        vm.prank(admin);
         token.mint(alice, 1000e18);
-        vm.stopPrank();
     }
 
     function test_HashDomainMatchesBTX() public view {

--- a/contrib/wbtx/test/WBTX.t.sol
+++ b/contrib/wbtx/test/WBTX.t.sol
@@ -18,6 +18,9 @@ contract WBTXTest is Test {
     address pauser = address(0x9A05E);
     // three federation signers (sorted ascending by address for the proof)
     uint256 pk1 = 0xA11; uint256 pk2 = 0xB22; uint256 pk3 = 0xC33;
+    bytes32 constant DEFAULT_BTX_BLOCK_HASH = keccak256("btx-block");
+    uint64 constant DEFAULT_BTX_BLOCK_HEIGHT = 1_000_000;
+    uint64 constant DEFAULT_ATTESTED_HEIGHT = DEFAULT_BTX_BLOCK_HEIGHT + 150;
 
     function setUp() public {
         address[] memory signers = new address[](3);
@@ -40,8 +43,31 @@ contract WBTXTest is Test {
 
     // --- helpers ---
 
-    function _attest(bytes32 txid, uint32 vout, address to, uint64 amtSat) internal view returns (bytes memory) {
-        bytes32 digest = bridge.mintDigest(txid, vout, to, amtSat);
+    function _futureDeadline() internal view returns (uint64) {
+        return uint64(block.timestamp + 1 days);
+    }
+
+    function _attest(
+        bytes32 txid,
+        uint32 vout,
+        bytes32 btxBlockHash,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        address to,
+        uint64 amtSat,
+        uint64 deadline
+    ) internal view returns (bytes memory) {
+        bytes32 digest = bridge.mintDigest(
+            bridge.bridgeId(),
+            txid,
+            vout,
+            btxBlockHash,
+            btxBlockHeight,
+            attestedHeight,
+            to,
+            amtSat,
+            deadline
+        );
         // sign with pk1 and pk2, then order by recovered address ascending
         (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(pk1, digest);
         (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(pk2, digest);
@@ -57,35 +83,126 @@ contract WBTXTest is Test {
 
     function test_MintHappyPath() public {
         bytes32 txid = keccak256("dep1");
-        bytes memory proof = _attest(txid, 0, address(0xBEEF), 100_000_000); // 1 BTX
-        bridge.mint(txid, 0, address(0xBEEF), 100_000_000, proof);
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 100_000_000, deadline
+        ); // 1 BTX
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 100_000_000, deadline, proof
+        );
         assertEq(wbtx.balanceOf(address(0xBEEF)), 100_000_000 * 1e10);
         assertEq(wbtx.totalSupply(), 1e18);
     }
 
+    function test_Mint_RevertsWhenTooShallow() public {
+        bytes32 txid = keccak256("dep1-shallow");
+        uint64 deadline = _futureDeadline();
+        uint64 shallowAttestedHeight = DEFAULT_BTX_BLOCK_HEIGHT + 99;
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, shallowAttestedHeight, address(0xBEEF), 1_000, deadline
+        );
+        vm.expectRevert(WBTXBridge.TooShallow.selector);
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, shallowAttestedHeight, address(0xBEEF), 1_000, deadline, proof
+        );
+    }
+
+    function test_Mint_RevertsWhenExpired() public {
+        bytes32 txid = keccak256("dep1-expired");
+        uint64 expiredDeadline = uint64(block.timestamp - 1);
+        bytes memory proof = _attest(
+            txid,
+            0,
+            DEFAULT_BTX_BLOCK_HASH,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            address(0xBEEF),
+            1_000,
+            expiredDeadline
+        );
+        vm.expectRevert(WBTXBridge.AttestationExpired.selector);
+        bridge.mint(
+            txid,
+            0,
+            DEFAULT_BTX_BLOCK_HASH,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            address(0xBEEF),
+            1_000,
+            expiredDeadline,
+            proof
+        );
+    }
+
+    function test_Mint_RevertsWhenNotAttested() public {
+        bytes32 txid = keccak256("dep1-not-attested");
+        uint64 deadline = _futureDeadline();
+        uint64 unattestedHeight = DEFAULT_BTX_BLOCK_HEIGHT - 1;
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, unattestedHeight, address(0xBEEF), 1_000, deadline
+        );
+        vm.expectRevert(WBTXBridge.NotAttested.selector);
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, unattestedHeight, address(0xBEEF), 1_000, deadline, proof
+        );
+    }
+
     function test_OutpointReplayRejected() public {
         bytes32 txid = keccak256("dep2");
-        bytes memory proof = _attest(txid, 0, address(0xBEEF), 1_000);
-        bridge.mint(txid, 0, address(0xBEEF), 1_000, proof);
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline, proof
+        );
         vm.expectRevert(WBTXBridge.AlreadyMinted.selector);
-        bridge.mint(txid, 0, address(0xBEEF), 1_000, proof);
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline, proof
+        );
     }
 
     function test_EIP712Replay_WrongRecipientRejected() public {
         bytes32 txid = keccak256("dep3");
-        bytes memory proof = _attest(txid, 0, address(0xBEEF), 1_000); // signed for 0xBEEF
-        vm.expectRevert(WBTXBridge.BadAttestation.selector);
-        bridge.mint(txid, 0, address(0xDEAD), 1_000, proof);           // try to redirect
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline
+        ); // signed for 0xBEEF
+        vm.expectRevert();
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xDEAD), 1_000, deadline, proof
+        ); // try to redirect
     }
 
     function test_BelowThresholdRejected() public {
         bytes32 txid = keccak256("dep4");
-        bytes32 digest = bridge.mintDigest(txid, 0, address(0xBEEF), 1_000);
+        uint64 deadline = _futureDeadline();
+        bytes32 digest = bridge.mintDigest(
+            bridge.bridgeId(),
+            txid,
+            0,
+            DEFAULT_BTX_BLOCK_HASH,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            address(0xBEEF),
+            1_000,
+            deadline
+        );
         (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(pk1, digest);
         bytes[] memory sigs = new bytes[](1);
         sigs[0] = abi.encodePacked(r1, s1, v1);
         vm.expectRevert(WBTXBridge.BadAttestation.selector);
-        bridge.mint(txid, 0, address(0xBEEF), 1_000, abi.encode(sigs)); // 1-of-3 < threshold 2
+        bridge.mint(
+            txid,
+            0,
+            DEFAULT_BTX_BLOCK_HASH,
+            DEFAULT_BTX_BLOCK_HEIGHT,
+            DEFAULT_ATTESTED_HEIGHT,
+            address(0xBEEF),
+            1_000,
+            deadline,
+            abi.encode(sigs)
+        ); // 1-of-3 < threshold 2
     }
 
     // --- circuit breaker + guardian veto ---
@@ -94,17 +211,27 @@ contract WBTXTest is Test {
         vm.prank(gov);
         bridge.setLimits(0, 50_000, 1 days, 0, 0, 7 days); // window cap 50k sat
         bytes32 txid = keccak256("dep5");
-        bytes memory proof = _attest(txid, 0, address(0xBEEF), 60_000);
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 60_000, deadline
+        );
         vm.expectRevert(WBTXBridge.WindowCapExceeded.selector);
-        bridge.mint(txid, 0, address(0xBEEF), 60_000, proof);
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 60_000, deadline, proof
+        );
     }
 
     function test_GuardianVetoFlow() public {
         vm.prank(gov);
         bridge.setLimits(0, 0, 1 days, 100_000, 1 hours, 7 days); // queue mints > 100k sat
         bytes32 txid = keccak256("dep6");
-        bytes memory proof = _attest(txid, 7, address(0xBEEF), 500_000);
-        bridge.mint(txid, 7, address(0xBEEF), 500_000, proof);      // queued, not minted
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 7, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 500_000, deadline
+        );
+        bridge.mint(
+            txid, 7, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 500_000, deadline, proof
+        ); // queued, not minted
         assertEq(wbtx.balanceOf(address(0xBEEF)), 0);
         // too early
         vm.expectRevert(WBTXBridge.TooEarly.selector);
@@ -122,8 +249,13 @@ contract WBTXTest is Test {
         vm.prank(gov);
         bridge.setLimits(0, 0, 1 days, 100_000, 1 hours, 7 days);
         bytes32 txid = keccak256("dep7");
-        bytes memory proof = _attest(txid, 0, address(0xBEEF), 500_000);
-        bridge.mint(txid, 0, address(0xBEEF), 500_000, proof);
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 500_000, deadline
+        );
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 500_000, deadline, proof
+        );
         vm.warp(block.timestamp + 2 hours);
         bridge.executeQueuedMint(txid, 0);
         assertEq(wbtx.balanceOf(address(0xBEEF)), 500_000 * 1e10);
@@ -133,8 +265,13 @@ contract WBTXTest is Test {
 
     function test_RedeemRoundDownAndRefund() public {
         bytes32 txid = keccak256("dep8");
-        bytes memory proof = _attest(txid, 0, address(this), 200_000_000); // mint 2 BTX
-        bridge.mint(txid, 0, address(this), 200_000_000, proof);
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 200_000_000, deadline
+        ); // mint 2 BTX
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 200_000_000, deadline, proof
+        );
         // redeem 1 BTX + 0.5 sat dust -> releases 100000000 sat (rounded down), burns the full amount
         uint256 amt = 100_000_000 * 1e10 + 5e9;
         uint256 id = bridge.redeem(amt, hex"00aabb");
@@ -160,9 +297,14 @@ contract WBTXTest is Test {
         vm.prank(pauser);
         wbtx.pauseIssuance();
         bytes32 txid = keccak256("dep9");
-        bytes memory proof = _attest(txid, 0, address(0xBEEF), 1_000);
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline
+        );
         vm.expectRevert(WBTX.IssuanceIsPaused.selector);
-        bridge.mint(txid, 0, address(0xBEEF), 1_000, proof);
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), 1_000, deadline, proof
+        );
     }
 
     function test_RescueCannotTouchSelf() public {
@@ -181,12 +323,19 @@ contract WBTXTest is Test {
 
     function test_GranularPause() public {
         bytes32 txid = keccak256("gp");
-        bytes memory proof = _attest(txid, 0, address(this), 1_000);
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 1_000, deadline
+        );
         vm.prank(pauser); bridge.setMintPaused(true);
         vm.expectRevert(WBTXBridge.MintPaused.selector);
-        bridge.mint(txid, 0, address(this), 1_000, proof);          // mint blocked
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 1_000, deadline, proof
+        ); // mint blocked
         vm.prank(pauser); bridge.setMintPaused(false);
-        bridge.mint(txid, 0, address(this), 1_000, proof);          // mint works again
+        bridge.mint(
+            txid, 0, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(this), 1_000, deadline, proof
+        ); // mint works again
         vm.prank(pauser); bridge.setRedeemPaused(true);
         vm.expectRevert(WBTXBridge.RedeemPaused.selector);
         bridge.redeem(1_000 * 1e10, hex"00aa");                     // redeem blocked independently
@@ -196,8 +345,13 @@ contract WBTXTest is Test {
     function testFuzz_BackingRelation(uint64 amountSat) public {
         amountSat = uint64(bound(amountSat, 1, 2_100_000_000_000_000)); // up to 21M BTX in sat
         bytes32 txid = keccak256(abi.encode("fuzz", amountSat));
-        bytes memory proof = _attest(txid, 3, address(0xBEEF), amountSat);
-        bridge.mint(txid, 3, address(0xBEEF), amountSat, proof);
+        uint64 deadline = _futureDeadline();
+        bytes memory proof = _attest(
+            txid, 3, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), amountSat, deadline
+        );
+        bridge.mint(
+            txid, 3, DEFAULT_BTX_BLOCK_HASH, DEFAULT_BTX_BLOCK_HEIGHT, DEFAULT_ATTESTED_HEIGHT, address(0xBEEF), amountSat, deadline, proof
+        );
         assertEq(wbtx.totalSupply(), uint256(amountSat) * 1e10);
         assertEq(wbtx.balanceOf(address(0xBEEF)), wbtx.totalSupply());
     }

--- a/contrib/wbtx/test/WBTXInvariant.t.sol
+++ b/contrib/wbtx/test/WBTXInvariant.t.sol
@@ -1,0 +1,642 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {WBTX} from "../evm/WBTX.sol";
+import {WBTXBridge, ECDSAMultisigVerifier, IAttestationVerifier} from "../evm/WBTXBridge.sol";
+
+contract WBTXInvariantHandler is Test {
+    struct MintRequest {
+        bytes32 txid;
+        uint32 vout;
+        bytes32 dk;
+        uint64 btxBlockHeight;
+        uint64 attestedHeight;
+        uint64 deadline;
+        address to;
+        uint64 amountSat;
+    }
+
+    WBTX public immutable wbtx;
+    WBTXBridge public immutable bridge;
+
+    address public immutable gov;
+    address public immutable guardian;
+    address public immutable federation;
+    address public immutable pauser;
+    address public immutable unpauser;
+
+    uint256 public constant SAT_SCALE = 1e10;
+    bytes32 internal constant DEFAULT_BTX_BLOCK_HASH = keccak256("invariant-btx-block");
+    uint64 internal constant DEFAULT_BTX_BLOCK_HEIGHT = 1_000_000;
+
+    uint256 public ghost_attestedInSat;
+    uint256 public ghost_redeemedWbtx;
+    uint256 public ghost_refundedSat;
+    uint256 public ghost_refundedWbtx;
+
+    uint256 private _depositNonce;
+    uint256 private _redeemCursor;
+
+    uint256 private immutable _pk1;
+    uint256 private immutable _pk2;
+    uint256 private immutable _pk3;
+    address private immutable _signer1;
+    address private immutable _signer2;
+    address private immutable _signer3;
+
+    address[] private _actors;
+    bytes32[] private _knownDepositKeys;
+    uint256[] private _knownRedeemIds;
+
+    mapping(bytes32 => bool) public ghost_seenDepositKey;
+    mapping(bytes32 => uint8) public ghost_mintSuccessCount;
+    mapping(bytes32 => bool) public ghost_vetoedByGuardian;
+    mapping(uint256 => bool) public ghost_knownRedeem;
+    mapping(uint256 => bool) public ghost_refundCounted;
+
+    constructor(
+        WBTX wbtx_,
+        WBTXBridge bridge_,
+        address gov_,
+        address guardian_,
+        address federation_,
+        address pauser_,
+        address unpauser_,
+        uint256 pk1_,
+        uint256 pk2_,
+        uint256 pk3_
+    ) {
+        wbtx = wbtx_;
+        bridge = bridge_;
+        gov = gov_;
+        guardian = guardian_;
+        federation = federation_;
+        pauser = pauser_;
+        unpauser = unpauser_;
+        _pk1 = pk1_;
+        _pk2 = pk2_;
+        _pk3 = pk3_;
+        _signer1 = vm.addr(pk1_);
+        _signer2 = vm.addr(pk2_);
+        _signer3 = vm.addr(pk3_);
+
+        _actors.push(address(0xBEEF));
+        _actors.push(address(0xCAFE));
+        _actors.push(address(0xD00D));
+        _actors.push(address(0xF00D));
+    }
+
+    // ---------------- fuzzer-callable actions ----------------
+
+    function mintValid(uint256 seed, uint64 amountSatRaw) external {
+        if (bridge.mintPaused() || wbtx.issuancePaused()) return;
+
+        uint64 threshold = bridge.optimisticThresholdSat();
+        if (threshold <= 1) return;
+
+        MintRequest memory req = _buildMintRequest(
+            seed,
+            uint64(bound(amountSatRaw, 1, threshold)),
+            "mint",
+            10_000,
+            2_000,
+            1 days
+        );
+        _mintWithValidAttestation(req);
+        _recordMintSuccess(req.dk, req.amountSat);
+    }
+
+    function queueThenCancel(uint256 seed, uint64 amountSatRaw) external {
+        if (bridge.mintPaused() || wbtx.issuancePaused()) return;
+
+        uint64 threshold = bridge.optimisticThresholdSat();
+        uint64 cap = bridge.windowMintCapSat();
+        if (cap <= threshold + 1) return;
+
+        uint64 upper = cap > threshold + 500_000 ? threshold + 500_000 : cap;
+        if (upper <= threshold) return;
+        MintRequest memory req = _buildMintRequest(
+            seed,
+            uint64(bound(amountSatRaw, threshold + 1, upper)),
+            "queue-cancel",
+            20_000,
+            500,
+            2 days
+        );
+        vm.assume(req.amountSat > threshold);
+        _mintWithValidAttestation(req);
+
+        vm.prank(guardian);
+        bridge.cancelQueuedMint(req.txid, req.vout);
+        ghost_vetoedByGuardian[req.dk] = true;
+    }
+
+    function queueThenExecute(uint256 seed, uint64 amountSatRaw, uint32 warpSecondsRaw) external {
+        if (bridge.mintPaused() || wbtx.issuancePaused()) return;
+
+        uint64 threshold = bridge.optimisticThresholdSat();
+        uint64 cap = bridge.windowMintCapSat();
+        if (cap <= threshold + 1) return;
+
+        uint64 upper = cap > threshold + 500_000 ? threshold + 500_000 : cap;
+        if (upper <= threshold) return;
+        MintRequest memory req = _buildMintRequest(
+            seed,
+            uint64(bound(amountSatRaw, threshold + 1, upper)),
+            "queue-exec",
+            20_000,
+            700,
+            2 days
+        );
+        vm.assume(req.amountSat > threshold);
+        _mintWithValidAttestation(req);
+
+        uint64 minWarp = bridge.guardianDelay() + 1;
+        uint64 delta = uint64(bound(warpSecondsRaw, minWarp, minWarp + 2 days));
+        vm.warp(block.timestamp + delta);
+
+        bridge.executeQueuedMint(req.txid, req.vout);
+        _recordMintSuccess(req.dk, req.amountSat);
+    }
+
+    function redeem(uint256 seed, uint256 amountWbtxRaw) external {
+        if (wbtx.issuancePaused() || bridge.redeemPaused()) return;
+
+        address actor = _pickActor(seed);
+        uint256 bal = wbtx.balanceOf(actor);
+        if (bal < SAT_SCALE) return;
+
+        uint256 amount = bound(amountWbtxRaw, SAT_SCALE, bal);
+        bytes memory destination = abi.encodePacked(bytes1(0x01), actor, seed);
+        vm.assume(destination.length <= 128);
+
+        vm.startPrank(actor);
+        wbtx.approve(address(bridge), amount);
+        uint256 redeemId = bridge.redeem(amount, destination);
+        vm.stopPrank();
+
+        ghost_redeemedWbtx += amount;
+        _registerRedeemId(redeemId);
+    }
+
+    function fulfill(uint256 redeemSeed, uint256 txSeed) external {
+        uint256 redeemId = _pickKnownRedeem(redeemSeed);
+        if (redeemId == 0) return;
+
+        (
+            address from,
+            uint64 amountSat,
+            ,
+            ,
+            ,
+            bytes32 destHash,
+            ,
+            bool fulfilled,
+            bool refunded
+        ) = bridge.redeems(redeemId);
+        if (from == address(0) || fulfilled || refunded) return;
+
+        uint64 btxBlockHeight = DEFAULT_BTX_BLOCK_HEIGHT + uint64(txSeed % 10_000);
+        uint64 attestedHeight = btxBlockHeight + bridge.MIN_CONFIRMATIONS() + 120;
+        uint64 deadline = uint64(block.timestamp + 1 days);
+        bytes32 btxTxid = keccak256(abi.encodePacked("fulfill", redeemId, txSeed));
+        bytes memory proof = _attestFulfill(redeemId, btxTxid, destHash, amountSat, btxBlockHeight, attestedHeight, deadline);
+
+        vm.prank(federation);
+        bridge.fulfillRedeem(redeemId, btxTxid, destHash, amountSat, btxBlockHeight, attestedHeight, deadline, proof);
+    }
+
+    function unfulfill(uint256 redeemSeed) external {
+        uint256 redeemId = _pickKnownRedeem(redeemSeed);
+        if (redeemId == 0) return;
+
+        (
+            address from,
+            ,
+            ,
+            ,
+            uint64 fulfilledAt,
+            ,
+            ,
+            bool fulfilled,
+            bool refunded
+        ) = bridge.redeems(redeemId);
+        if (from == address(0) || !fulfilled || refunded) return;
+
+        if (block.timestamp > fulfilledAt + bridge.FULFILL_REVOKE_WINDOW()) return;
+        vm.prank(guardian);
+        bridge.unfulfillRedeem(redeemId);
+    }
+
+    function refund(uint256 redeemSeed, uint32 extraWarpRaw, uint64 asOfSeed) external {
+        uint256 redeemId = _pickKnownRedeem(redeemSeed);
+        if (redeemId == 0) return;
+
+        (
+            address from,
+            uint64 amountSat,
+            uint256 amountWbtx,
+            uint64 requestedAt,
+            ,
+            bytes32 destHash,
+            ,
+            bool fulfilled,
+            bool refunded
+        ) = bridge.redeems(redeemId);
+        if (from == address(0) || fulfilled || refunded) return;
+
+        uint64 timeout = bridge.redeemRefundTimeout();
+        uint64 readyAt = requestedAt + timeout + 1;
+        if (block.timestamp < readyAt) {
+            uint64 extra = uint64(bound(extraWarpRaw, 0, 2 days));
+            vm.warp(readyAt + extra);
+        }
+
+        uint64 asOfBtxHeight = DEFAULT_BTX_BLOCK_HEIGHT + uint64(bound(asOfSeed, 1, 1_000_000));
+        uint64 deadline = uint64(block.timestamp + 1 days);
+        bytes memory proof = _attestNonRelease(redeemId, destHash, amountSat, asOfBtxHeight, deadline);
+
+        vm.prank(gov);
+        bridge.refundRedeem(redeemId, asOfBtxHeight, deadline, proof);
+
+        if (!ghost_refundCounted[redeemId]) {
+            ghost_refundedSat += amountSat;
+            ghost_refundedWbtx += amountWbtx;
+            ghost_refundCounted[redeemId] = true;
+        }
+    }
+
+    function pauseIssuance() external {
+        vm.prank(pauser);
+        wbtx.pauseIssuance();
+    }
+
+    function unpauseIssuance() external {
+        vm.prank(unpauser);
+        wbtx.unpauseIssuance();
+    }
+
+    function setMintPaused(bool paused) external {
+        vm.prank(pauser);
+        bridge.setMintPaused(paused);
+    }
+
+    function setRedeemPaused(bool paused) external {
+        vm.prank(pauser);
+        bridge.setRedeemPaused(paused);
+    }
+
+    function warp(uint32 dtRaw) external {
+        uint64 dt = uint64(bound(dtRaw, 1, 3 days));
+        vm.warp(block.timestamp + dt);
+    }
+
+    // ---------------- invariant introspection ----------------
+
+    function knownDepositKeysLength() external view returns (uint256) {
+        return _knownDepositKeys.length;
+    }
+
+    function knownDepositKeyAt(uint256 index) external view returns (bytes32) {
+        return _knownDepositKeys[index];
+    }
+
+    function knownRedeemIdsLength() external view returns (uint256) {
+        return _knownRedeemIds.length;
+    }
+
+    function knownRedeemIdAt(uint256 index) external view returns (uint256) {
+        return _knownRedeemIds[index];
+    }
+
+    // ---------------- internal helpers ----------------
+
+    function _buildMintRequest(
+        uint256 seed,
+        uint64 amountSat,
+        bytes32 tag,
+        uint64 heightModulus,
+        uint64 depthExtra,
+        uint64 deadlineOffset
+    ) private returns (MintRequest memory req) {
+        (req.txid, req.vout, req.dk) = _freshDeposit(seed, tag);
+        req.amountSat = amountSat;
+        req.btxBlockHeight = DEFAULT_BTX_BLOCK_HEIGHT + uint64(seed % heightModulus);
+        req.attestedHeight = req.btxBlockHeight + bridge.MIN_CONFIRMATIONS() + depthExtra;
+        req.deadline = uint64(block.timestamp + deadlineOffset);
+        req.to = _pickActor(seed);
+    }
+
+    function _mintWithValidAttestation(MintRequest memory req) private {
+        bytes memory proof = _attestMint(
+            req.txid,
+            req.vout,
+            req.btxBlockHeight,
+            req.attestedHeight,
+            req.to,
+            req.amountSat,
+            req.deadline
+        );
+        bridge.mint(
+            req.txid,
+            req.vout,
+            DEFAULT_BTX_BLOCK_HASH,
+            req.btxBlockHeight,
+            req.attestedHeight,
+            req.to,
+            req.amountSat,
+            req.deadline,
+            proof
+        );
+    }
+
+    function _registerDeposit(bytes32 dk) private {
+        if (!ghost_seenDepositKey[dk]) {
+            ghost_seenDepositKey[dk] = true;
+            _knownDepositKeys.push(dk);
+        }
+    }
+
+    function _registerRedeemId(uint256 redeemId) private {
+        if (!ghost_knownRedeem[redeemId]) {
+            ghost_knownRedeem[redeemId] = true;
+            _knownRedeemIds.push(redeemId);
+        }
+    }
+
+    function _recordMintSuccess(bytes32 dk, uint64 amountSat) private {
+        _registerDeposit(dk);
+        ghost_mintSuccessCount[dk] += 1;
+        ghost_attestedInSat += amountSat;
+    }
+
+    function _pickActor(uint256 seed) private view returns (address) {
+        return _actors[seed % _actors.length];
+    }
+
+    function _pickKnownRedeem(uint256 seed) private returns (uint256) {
+        uint256 len = _knownRedeemIds.length;
+        if (len == 0) return 0;
+
+        uint256 start = (_redeemCursor + seed) % len;
+        for (uint256 i = 0; i < len; i++) {
+            uint256 idx = (start + i) % len;
+            uint256 id = _knownRedeemIds[idx];
+            if (id != 0) {
+                _redeemCursor = idx + 1;
+                return id;
+            }
+        }
+        return 0;
+    }
+
+    function _freshDeposit(uint256 seed, bytes32 tag) private returns (bytes32 txid, uint32 vout, bytes32 dk) {
+        _depositNonce++;
+        txid = keccak256(abi.encodePacked(tag, seed, _depositNonce, block.timestamp));
+        vout = uint32(seed);
+        dk = bridge.depositKey(txid, vout);
+        (, , , bool queuedExists) = bridge.queued(dk);
+        vm.assume(!bridge.minted(dk));
+        vm.assume(!queuedExists);
+        vm.assume(!bridge.vetoed(dk));
+        _registerDeposit(dk);
+    }
+
+    function _proofForDigest(bytes32 digest) private view returns (bytes memory) {
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(_pk1, digest);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(_pk2, digest);
+
+        bytes memory sigA = abi.encodePacked(r1, s1, v1);
+        bytes memory sigB = abi.encodePacked(r2, s2, v2);
+        bytes[] memory sigs = new bytes[](2);
+
+        // Deterministic, sorted 2-of-3 proof using two fixed known signers.
+        _storeSortedPair(sigs, _signer1, sigA, _signer2, sigB);
+        return abi.encode(sigs);
+    }
+
+    function _storeSortedPair(
+        bytes[] memory sigs,
+        address signerA,
+        bytes memory sigA,
+        address signerB,
+        bytes memory sigB
+    ) private pure {
+        if (signerA < signerB) {
+            sigs[0] = sigA;
+            sigs[1] = sigB;
+        } else {
+            sigs[0] = sigB;
+            sigs[1] = sigA;
+        }
+    }
+
+    function _attestMint(
+        bytes32 txid,
+        uint32 vout,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        address to,
+        uint64 amountSat,
+        uint64 deadline
+    ) private view returns (bytes memory) {
+        bytes32 digest = bridge.mintDigest(
+            bridge.bridgeId(),
+            txid,
+            vout,
+            DEFAULT_BTX_BLOCK_HASH,
+            btxBlockHeight,
+            attestedHeight,
+            to,
+            amountSat,
+            deadline
+        );
+        return _proofForDigest(digest);
+    }
+
+    function _attestFulfill(
+        uint256 redeemId,
+        bytes32 btxTxid,
+        bytes32 destHash,
+        uint64 amountSat,
+        uint64 btxBlockHeight,
+        uint64 attestedHeight,
+        uint64 deadline
+    ) private view returns (bytes memory) {
+        bytes32 digest = bridge.fulfillDigest(
+            bridge.bridgeId(),
+            redeemId,
+            btxTxid,
+            destHash,
+            amountSat,
+            btxBlockHeight,
+            attestedHeight,
+            deadline
+        );
+        return _proofForDigest(digest);
+    }
+
+    function _attestNonRelease(
+        uint256 redeemId,
+        bytes32 destHash,
+        uint64 amountSat,
+        uint64 asOfBtxHeight,
+        uint64 deadline
+    ) private view returns (bytes memory) {
+        bytes32 digest = bridge.nonReleaseDigest(
+            bridge.bridgeId(),
+            redeemId,
+            destHash,
+            amountSat,
+            asOfBtxHeight,
+            deadline
+        );
+        return _proofForDigest(digest);
+    }
+}
+
+contract WBTXInvariantTest is Test {
+    WBTX internal wbtx;
+    WBTXBridge internal bridge;
+    ECDSAMultisigVerifier internal verifier;
+    WBTXInvariantHandler internal handler;
+
+    address internal constant ADMIN = address(0xA11CE);
+    address internal constant GOV = address(0x60F);
+    address internal constant GUARDIAN = address(0x6A7D);
+    address internal constant FEDERATION = address(0xFED);
+    address internal constant PAUSER = address(0x9A05E);
+
+    uint256 internal constant PK1 = 0xA11;
+    uint256 internal constant PK2 = 0xB22;
+    uint256 internal constant PK3 = 0xC33;
+    uint256 internal constant SAT_SCALE = 1e10;
+
+    uint256 internal constant MAX_SUPPLY_WBTX = 5_000_000_000 * SAT_SCALE;
+    uint64 internal constant WINDOW_MINT_CAP_SAT = 3_000_000;
+    uint64 internal constant WINDOW_DURATION = 1 days;
+    uint64 internal constant OPTIMISTIC_THRESHOLD_SAT = 1_000_000;
+    uint64 internal constant GUARDIAN_DELAY = 6 hours;
+    uint64 internal constant REDEEM_REFUND_TIMEOUT = 7 days;
+
+    /// forge-config: default.invariant.runs = 256
+    /// forge-config: default.invariant.depth = 32
+    /// forge-config: default.invariant.fail-on-revert = false
+    function setUp() public {
+        address[] memory signers = _initialSignersSorted();
+        verifier = new ECDSAMultisigVerifier(ADMIN, 0, signers, 2);
+
+        uint256 deployerNonce = vm.getNonce(address(this));
+        address predictedBridge = vm.computeCreateAddress(address(this), deployerNonce + 1);
+        wbtx = new WBTX(ADMIN, 0, predictedBridge);
+        bridge = new WBTXBridge(wbtx, IAttestationVerifier(address(verifier)), 1, ADMIN, 0);
+
+        vm.startPrank(ADMIN);
+        wbtx.grantRole(wbtx.PAUSER_ROLE(), PAUSER);
+        wbtx.grantRole(wbtx.UNPAUSER_ROLE(), ADMIN);
+        bridge.grantRole(bridge.GOVERNANCE_ROLE(), GOV);
+        bridge.grantRole(bridge.GUARDIAN_ROLE(), GUARDIAN);
+        bridge.grantRole(bridge.PAUSER_ROLE(), PAUSER);
+        bridge.grantRole(bridge.FEDERATION_ROLE(), FEDERATION);
+        verifier.grantRole(verifier.GUARDIAN_ROLE(), GUARDIAN);
+        vm.stopPrank();
+
+        vm.prank(GOV);
+        bridge.setLimits(
+            MAX_SUPPLY_WBTX,
+            WINDOW_MINT_CAP_SAT,
+            WINDOW_DURATION,
+            OPTIMISTIC_THRESHOLD_SAT,
+            GUARDIAN_DELAY,
+            REDEEM_REFUND_TIMEOUT
+        );
+
+        handler = new WBTXInvariantHandler(
+            wbtx,
+            bridge,
+            GOV,
+            GUARDIAN,
+            FEDERATION,
+            PAUSER,
+            ADMIN,
+            PK1,
+            PK2,
+            PK3
+        );
+
+        targetContract(address(handler));
+    }
+
+    function invariant_Solvency() public view {
+        uint256 attestedWbtx = handler.ghost_attestedInSat() * SAT_SCALE;
+        uint256 redeemedWbtx = handler.ghost_redeemedWbtx();
+        uint256 refundedWbtx = handler.ghost_refundedWbtx();
+        assertLe(redeemedWbtx, attestedWbtx + refundedWbtx);
+
+        uint256 netBackingWbtx = attestedWbtx + refundedWbtx - redeemedWbtx;
+        assertLe(wbtx.totalSupply(), netBackingWbtx);
+
+        // Sat view of the same invariant: supply in satoshis cannot exceed net sat backing.
+        uint256 supplySat = wbtx.totalSupply() / SAT_SCALE;
+        uint256 netBackingSat = netBackingWbtx / SAT_SCALE;
+        assertLe(supplySat, netBackingSat);
+    }
+
+    function invariant_SupplyCeiling() public view {
+        assertLe(wbtx.totalSupply(), bridge.maxSupplyWbtx());
+    }
+
+    function invariant_NoDoubleMintPerDeposit() public view {
+        uint256 len = handler.knownDepositKeysLength();
+        for (uint256 i = 0; i < len; i++) {
+            bytes32 dk = handler.knownDepositKeyAt(i);
+            uint8 count = handler.ghost_mintSuccessCount(dk);
+            assertLe(uint256(count), 1);
+            if (count == 1) {
+                assertTrue(bridge.minted(dk));
+            }
+        }
+    }
+
+    function invariant_FulfillRefundMutuallyExclusive() public view {
+        uint256 len = handler.knownRedeemIdsLength();
+        for (uint256 i = 0; i < len; i++) {
+            uint256 redeemId = handler.knownRedeemIdAt(i);
+            (, , , , , , , bool fulfilled, bool refunded) = bridge.redeems(redeemId);
+            assertFalse(fulfilled && refunded);
+        }
+    }
+
+    function invariant_BucketNeverExceedsCap() public view {
+        assertLe(uint256(bridge.availableSat()), uint256(bridge.windowMintCapSat()));
+    }
+
+    function invariant_VetoedNeverMints() public view {
+        uint256 len = handler.knownDepositKeysLength();
+        for (uint256 i = 0; i < len; i++) {
+            bytes32 dk = handler.knownDepositKeyAt(i);
+            if (handler.ghost_vetoedByGuardian(dk)) {
+                assertFalse(bridge.minted(dk));
+            }
+        }
+    }
+
+    function _initialSignersSorted() internal view returns (address[] memory signers) {
+        signers = new address[](3);
+        signers[0] = vm.addr(PK1);
+        signers[1] = vm.addr(PK2);
+        signers[2] = vm.addr(PK3);
+        for (uint256 i = 1; i < signers.length; i++) {
+            address key = signers[i];
+            uint256 j = i;
+            while (j > 0 && signers[j - 1] > key) {
+                signers[j] = signers[j - 1];
+                unchecked {
+                    --j;
+                }
+            }
+            signers[j] = key;
+        }
+    }
+}

--- a/contrib/wbtx/test/WBTXInvariant.t.sol
+++ b/contrib/wbtx/test/WBTXInvariant.t.sol
@@ -278,12 +278,12 @@ contract WBTXInvariantHandler is Test {
     }
 
     function setMintPaused(bool paused) external {
-        vm.prank(pauser);
+        vm.prank(paused ? pauser : gov);
         bridge.setMintPaused(paused);
     }
 
     function setRedeemPaused(bool paused) external {
-        vm.prank(pauser);
+        vm.prank(paused ? pauser : gov);
         bridge.setRedeemPaused(paused);
     }
 
@@ -519,6 +519,7 @@ contract WBTXInvariantTest is Test {
     uint64 internal constant OPTIMISTIC_THRESHOLD_SAT = 1_000_000;
     uint64 internal constant GUARDIAN_DELAY = 6 hours;
     uint64 internal constant REDEEM_REFUND_TIMEOUT = 7 days;
+    uint48 internal constant BRIDGE_ADMIN_DELAY = 1 days;
 
     /// forge-config: default.invariant.runs = 256
     /// forge-config: default.invariant.depth = 32
@@ -530,7 +531,7 @@ contract WBTXInvariantTest is Test {
         uint256 deployerNonce = vm.getNonce(address(this));
         address predictedBridge = vm.computeCreateAddress(address(this), deployerNonce + 1);
         wbtx = new WBTX(ADMIN, 0, predictedBridge);
-        bridge = new WBTXBridge(wbtx, IAttestationVerifier(address(verifier)), 1, ADMIN, 0);
+        bridge = new WBTXBridge(wbtx, IAttestationVerifier(address(verifier)), 1, ADMIN, BRIDGE_ADMIN_DELAY);
 
         vm.startPrank(ADMIN);
         wbtx.grantRole(wbtx.PAUSER_ROLE(), PAUSER);

--- a/doc/btx-otc-escrow-supply-validation.md
+++ b/doc/btx-otc-escrow-supply-validation.md
@@ -232,7 +232,7 @@ orderbook offer), replace the venue co-sign with CTV and get a fully
 trustless hard bond:
 
 ```
-BOND = mr( ctv_multi_pq(<H_tmpl>, 1, S_settle),   # seller can ONLY spend into the
+BOND = mr( ctv_pk(<H_tmpl>, S_settle),            # seller can ONLY spend into the
            { refund(H_expiry, S_refund),            # pre-committed settlement tx
              commit(offer_terms_hash) } )           # unspendable terms binding
 ```
@@ -293,8 +293,8 @@ arbiter — can send funds anywhere):
 
 ```
 ESCROW = mr( multi_pq(2, K_buyer, S),                      # happy path: both co-sign
-             { { ctv_multi_pq(<H_pay_buyer>,   1, K_arb),  # arbiter: release to buyer
-                 ctv_multi_pq(<H_refund_seller>,1, K_arb) },# arbiter: return to seller
+             { { ctv_pk(<H_pay_buyer>, K_arb),      # arbiter: release to buyer
+                 ctv_pk(<H_refund_seller>, K_arb) },# arbiter: return to seller
                refund(H_deadlock, S) } )                    # nuclear fallback
 ```
 
@@ -311,7 +311,7 @@ ESCROW = mr( multi_pq(2, K_buyer, S),                      # happy path: both co
   `H_deadlock`; an arbiter verdict tx confirmed before `H_deadlock`
   settles the matter since the refund leaf is still time-locked.)
 - Split verdicts (e.g. 70/30) can be added as additional
-  `ctv_multi_pq` leaves for pre-agreed partial-fill templates.
+  `ctv_pk` leaves for pre-agreed partial-fill templates.
 
 ### 5.3 Payment-oracle variant: CSFS "DLC-lite"
 
@@ -550,6 +550,6 @@ btx-cli -rpcwallet=desk buildhtlcrefund "$SWAP#..." '{"txid":"...","vout":0}' \
 | Can it vanish mid-quote? | No (tier A/A+) | No unilateral pre-expiry path in the MAST tree |
 | Is it borrowed for show? | Not while bonded | Timelocked refund leaf ≥ offer expiry |
 | Will settlement actually happen? | Atomic for crypto legs | HTLC leaves + `buildhtlcclaim`/`buildhtlcrefund` |
-| Fiat-leg disputes? | Bounded arbiter, cannot steal | CTV verdict templates (`ctv_multi_pq`) / CSFS oracles |
+| Fiat-leg disputes? | Bounded arbiter, cannot steal | CTV verdict templates (`ctv_pk`) / CSFS oracles |
 | Shielded "trust me" claims? | Counted as zero | No per-account proof exists; pool is sunsetting; exit-then-bond |
 | Consensus changes needed? | **None** | All leaves/opcodes/RPCs are live on `main` today |

--- a/docs/wbtx-contracts.md
+++ b/docs/wbtx-contracts.md
@@ -78,7 +78,8 @@ honored, `refundRedeem(redeemId)` (governance, after `redeemRefundTimeout`) re-m
 silently-lost funds.
 
 **Controls.** `GOVERNANCE_ROLE` (a Timelock) sets the verifier, limits, and refunds; `GUARDIAN_ROLE`
-cancels suspicious queued mints; `PAUSER_ROLE` toggles `mintPaused`/`redeemPaused` independently;
+cancels suspicious queued mints; pausing `mintPaused`/`redeemPaused` is `PAUSER_ROLE` (fast, low trust)
+but UNpausing requires `GOVERNANCE_ROLE` (asymmetric trust — a low-trust key cannot lift a breaker);
 `FEDERATION_ROLE` marks redeems fulfilled. All external state-changers are `nonReentrant`.
 
 ### 2.3 The verifier — `ECDSAMultisigVerifier` (v1) and the zk path

--- a/src/script/pqm.cpp
+++ b/src/script/pqm.cpp
@@ -282,6 +282,10 @@ std::vector<unsigned char> BuildP2MRCSVMultisigScript(
 {
     if (sequence < 1 || sequence > std::numeric_limits<int32_t>::max()) return {};
     if ((static_cast<uint32_t>(sequence) & CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0) return {};
+    // BIP68 consensus only interprets TYPE_FLAG | MASK; all other bits are ignored.
+    // Reject extra bits so the encoded relative delay equals the caller's value
+    // (e.g. 100000 would otherwise enforce 100000 & MASK == 34464).
+    if ((static_cast<uint32_t>(sequence) & ~(CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG | CTxIn::SEQUENCE_LOCKTIME_MASK)) != 0) return {};
 
     CScript prefix;
     prefix << sequence << OP_CHECKSEQUENCEVERIFY << OP_DROP;

--- a/src/test/script_htlc_templates_tests.cpp
+++ b/src/test/script_htlc_templates_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <hash.h>
 #include <pqkey.h>
+#include <primitives/transaction.h>
 #include <script/interpreter.h>
 #include <script/pqm.h>
 #include <script/script_error.h>
@@ -11,6 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
 #include <vector>
 
 namespace {
@@ -201,6 +203,29 @@ BOOST_AUTO_TEST_CASE(refund_before_timeout_fails)
     const P2MRTemplateChecker checker{/*locktime_ok=*/false};
     BOOST_CHECK(!EvalP2MRScript(script, stack, checker, execdata, serror));
     BOOST_CHECK_EQUAL(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
+}
+
+BOOST_AUTO_TEST_CASE(csv_multisig_rejects_non_bip68_sequence_bits)
+{
+    // csv_multi_pq requires >=2 pubkeys; threshold-1 of a 2-key set is the
+    // smallest valid BuildP2MRCSVMultisigScript input.
+    const std::vector<unsigned char> pk1(MLDSA44_PUBKEY_SIZE, 0x12);
+    const std::vector<unsigned char> pk2(MLDSA44_PUBKEY_SIZE, 0x13);
+    const std::vector<std::pair<PQAlgorithm, std::vector<unsigned char>>> keys{
+        {PQAlgorithm::ML_DSA_44, pk1},
+        {PQAlgorithm::ML_DSA_44, pk2},
+    };
+    const auto build = [&](int64_t sequence) {
+        return BuildP2MRCSVMultisigScript(sequence, /*threshold=*/1, keys);
+    };
+
+    BOOST_CHECK(!build(144).empty());
+    BOOST_CHECK(!build(144 | CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG).empty());
+    BOOST_CHECK(build(100000).empty());
+    BOOST_CHECK(build(int64_t{1} << 16).empty());
+    BOOST_CHECK(build(static_cast<int64_t>(CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG)).empty());
+    BOOST_CHECK(build(0).empty());
+    BOOST_CHECK(build(static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1).empty());
 }
 
 BOOST_AUTO_TEST_CASE(two_leaf_merkle_htlc)

--- a/test/functional/wallet_otc_offer.py
+++ b/test/functional/wallet_otc_offer.py
@@ -150,6 +150,42 @@ class WalletOtcOfferTest(BitcoinTestFramework):
         assert_equal(report.tier, "B")
         assert_greater_than(report.verified_sats + 1, amount_sats)
 
+        # === 2b. VERIFY tier-A venue-key pinning ===============================
+        self.log.info("tier-A venue-key pinning")
+        venue_pk = self.pq_pubkey(desk)
+        wrong_venue_pk = self.pq_pubkey(desk)
+        amount_a_sats = 1 * COIN_SAT
+        expiry_a = node.getblockcount() + 40
+        terms_a = self.make_terms(seller_address, amount_a_sats, expiry_a,
+                                 nonce="aa" * 16)
+        desc_a = btx_otc.venue_bond_descriptor(settle_pk, venue_pk,
+                                              expiry_a, refund_pk)
+        bundle_a = btx_otc.create_offer(rpc, rpc_desk, terms_a, desc_a)
+        mine_block(self, node, mine_addr)
+        assert_equal(bundle_a["bond"]["tier"], "A")
+
+        self.log.info("reject: tier-A verify without expected_venue_pubkey")
+        self.assert_failed_checks(btx_otc.verify_offer(rpc, bundle_a, min_conf=1),
+                                  {"venue-key"})
+
+        self.log.info("verify: tier-A with matching expected_venue_pubkey")
+        report_a = btx_otc.verify_offer(rpc, bundle_a, min_conf=1,
+                                        expected_venue_pubkey=venue_pk)
+        for c in report_a.checks:
+            self.log.info(f"  [{'ok' if c.ok else 'FAIL'}] {c.name}: {c.detail}")
+        assert_equal(report_a.ok, True)
+        assert_equal(report_a.tier, "A")
+        assert_greater_than(report_a.verified_sats + 1, amount_a_sats)
+        venue_checks = [c for c in report_a.checks if c.name == "venue-key"]
+        assert_equal(len(venue_checks), 1)
+        assert_equal(venue_checks[0].ok, True)
+
+        self.log.info("reject: tier-A with mismatched expected_venue_pubkey")
+        self.assert_failed_checks(
+            btx_otc.verify_offer(rpc, bundle_a, min_conf=1,
+                                 expected_venue_pubkey=wrong_venue_pk),
+            {"venue-key"})
+
         self.log.info("reject: immature coinbase cannot back executable offered supply")
         coinbase_hash = self.generatetoaddress(
             node, 1, report.address, sync_fun=self.no_op,


### PR DESCRIPTION
## 0.34.6 — OTC escrow + wBTX bridge/HTLC hardening

Additional 0.34.6 workstream, sibling to #135. Where #135 is the *neutral consensus/net correctness* line, **this PR is scoped to the off-chain-facing money-movement tooling**: the OTC bonded-escrow SDK, the wBTX bridge/token/HTLC contracts, and their SDK. No consensus rules change here.

> The wBTX EVM contracts are **UNAUDITED reference implementations**; the OTC/wBTX SDKs are tooling. An external audit + invariant-fuzz campaign remains mandatory before real value flows. This PR closes the specific defects found by internal adversarial review + a community pre-ship review, each fix test-gated and independently audited.

### Provenance
- **wBTX bridge:** a community pre-ship security review (2026-08-22, Jpp-Matata) of `WBTXBridge.sol` / `WBTX.sol` / `WBTXAtomicSwapHTLC.sol` / `btx_wbtx.py`. We re-verified every finding against current source (14 REAL, 1 partial, 4 EIP-3009 items confirmed non-issues) before fixing.
- **OTC escrow:** four rounds of internal deepseek-v4-flash adversarial review of `contrib/otc/btx_otc.py`.

### wBTX bridge — community review F1–F15 (7 clusters)
- **F1 (CRITICAL):** mint attestation now binds `btxBlockHash/btxBlockHeight/attestedHeight/deadline` + `bridgeId`; `mint()` enforces attested-frontier depth (`MIN_CONFIRMATIONS=100`) + expiry.
- **F2/F9/F11:** durable guardian veto (`vetoed` + timelocked `clearVeto`); fail-closed breakers (`limitsConfigured`, all-non-zero); continuous token-bucket window (no 2× boundary burst), budget consumed at execution.
- **F4:** in-contract timelocks on `setVerifier`/`rotateSigners` (7d) + `clearVeto` (48h) with guardian cancel; `guardianDelay` floor (6h).
- **F8/F13:** issuance bound to an immutable `bridge` (no MINTER/BURNER roles), allowance-gated `burn`/`burnFrom` (no confiscation); compliance hook excludes issuance + gas-capped try/catch + immediate `clearComplianceHook`; pause-independent `mintRefund`.
- **F3/F10/F12:** attested + reversible redeem fulfillment (M-of-N + depth, `unfulfillRedeem`); refund gated on an affirmative non-release attestation, routed through the supply cap, pause-independent.
- **F5/F6/F7:** HTLC `claim()` gated on the timeout (disjoint claim/refund), `open()` enforces `received==amount`, corrected Model-B preimage flow + `check_timeout_ordering`, `MIN_TIMEOUT` 30m→6h.
- **F14/F15:** SDK `to_sat` Decimal parse (sci-notation/dust DoS), `find_deposits` minconf floor (100), ripemd160 fallback (vendored pure-Python).

Foundry: **45 tests pass** (24 → 45 across the clusters). Python SDK self-checks pass.

### OTC escrow — internal rounds 1–4
Timestamp-domain locktime rejection; tier-A venue-key pinning (fail-closed) + fixed the round-4 tier-downgrade gap; BIP68 sequence-bit hardening; tier-A+ CTV template verification; cross-leg HTLC timeout-asymmetry helper (+ flow-requirement docs); tier-A+ made buildable (`ctv_pk`); 0-conf/RBF, duplicate-key terms, and sub-floor-bond guards. `btx_otc.py selftest`: OK.

### Process
Each fix: cursor-authored → `forge test`/selftest re-run independently → deepseek-v4-flash adversarial audit → reviewed + committed. Author≠reviewer throughout.

### Not in this PR
Consensus-level script findings (ML-DSA signature non-canonicality/malleability, CSFS signature replay across contracts sharing a hashlock+key) are being verified and tracked on a **separate** track — they touch `interpreter.cpp`/`pqm.cpp` and are a different risk class from this tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
